### PR TITLE
Add options for locality handling and SetLocality command

### DIFF
--- a/man/man8/swtpm.8
+++ b/man/man8/swtpm.8
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "swtpm 8"
-.TH swtpm 8 "2017-03-31" "swtpm" ""
+.TH swtpm 8 "2017-05-11" "swtpm" ""
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -287,6 +287,10 @@ The level parameter allows to choose the level of logging. Starting at log
 level 5, libtpms debug logging is activated.
 .Sp
 All logged lines will be prefixed with prefix. By default no prefix is prepended.
+.IP "\fB\-\-locality reject\-locality\-4\fR" 4
+.IX Item "--locality reject-locality-4"
+The \fIreject\-locality\-4\fR parameter will cause \s-1TPM\s0 error messages to be
+returned for requests to set the \s-1TPM\s0 into locality 4.
 .IP "\fB\-\-key file=<keyfile>[,format=<hex|binary>][,mode=aes\-cbc],[remove[=true|false]]\fR" 4
 .IX Item "--key file=<keyfile>[,format=<hex|binary>][,mode=aes-cbc],[remove[=true|false]]"
 Enable encryption of the state files of the \s-1TPM.\s0 The keyfile must contain

--- a/man/man8/swtpm.pod
+++ b/man/man8/swtpm.pod
@@ -194,6 +194,11 @@ level 5, libtpms debug logging is activated.
 
 All logged lines will be prefixed with prefix. By default no prefix is prepended.
 
+=item B<--locality reject-locality-4>
+
+The I<reject-locality-4> parameter will cause TPM error messages to be
+returned for requests to set the TPM into locality 4.
+
 =item B<--key file=E<lt>keyfileE<gt>[,format=E<lt>hex|binaryE<gt>][,mode=aes-cbc],[remove[=true|false]]>
 
 Enable encryption of the state files of the TPM. The keyfile must contain

--- a/man/man8/swtpm_cuse.8
+++ b/man/man8/swtpm_cuse.8
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "swtpm_cuse 8"
-.TH swtpm_cuse 8 "2017-03-31" "swtpm" ""
+.TH swtpm_cuse 8 "2017-05-11" "swtpm" ""
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -185,6 +185,10 @@ The level parameter allows to choose the level of logging. Starting at log
 level 5, libtpms debug logging is activated.
 .Sp
 All logged lines will be prefixed with prefix. By default no prefix is prepended.
+.IP "\fB\-\-locality [reject\-locality\-4]\fR" 4
+.IX Item "--locality [reject-locality-4]"
+The \fIreject\-locality\-4\fR parameter will cause \s-1TPM\s0 error messages to be
+returned for requests to set the \s-1TPM\s0 into locality 4.
 .IP "\fB\-\-key file=<keyfile>[,format=<hex|binary>][,mode=aes\-cbc],[remove[=true|false]]\fR" 4
 .IX Item "--key file=<keyfile>[,format=<hex|binary>][,mode=aes-cbc],[remove[=true|false]]"
 Enable encryption of the state files of the \s-1TPM.\s0 The keyfile must contain

--- a/man/man8/swtpm_cuse.pod
+++ b/man/man8/swtpm_cuse.pod
@@ -58,6 +58,11 @@ level 5, libtpms debug logging is activated.
 
 All logged lines will be prefixed with prefix. By default no prefix is prepended.
 
+=item B<--locality [reject-locality-4]>
+
+The I<reject-locality-4> parameter will cause TPM error messages to be
+returned for requests to set the TPM into locality 4.
+
 =item B<--key file=E<lt>keyfileE<gt>[,format=E<lt>hex|binaryE<gt>][,mode=aes-cbc],[remove[=true|false]]>
 
 Enable encryption of the state files of the TPM. The keyfile must contain

--- a/src/swtpm/Makefile.am
+++ b/src/swtpm/Makefile.am
@@ -8,6 +8,7 @@ noinst_HEADERS = \
 	common.h \
 	ctrlchannel.h \
 	key.h \
+	locality.h \
 	logging.h \
 	main.h \
 	mainloop.h \

--- a/src/swtpm/common.h
+++ b/src/swtpm/common.h
@@ -46,6 +46,7 @@ struct ctrlchannel;
 int handle_ctrlchannel_options(char *options, struct ctrlchannel **cc);
 struct server;
 int handle_server_options(char *options, struct server **s);
+int handle_locality_options(char *options, uint32_t *flags);
 
 #endif /* _SWTPM_COMMON_H_ */
 

--- a/src/swtpm/locality.h
+++ b/src/swtpm/locality.h
@@ -1,7 +1,7 @@
 /*
- * ctrlchannel.h -- control channel implementation
+ * locality.h -- locality parameters
  *
- * (c) Copyright IBM Corporation 2015.
+ * (c) Copyright IBM Corporation 2017.
  *
  * Author: Stefan Berger <stefanb@us.ibm.com>
  *
@@ -35,22 +35,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _SWTPM_CTRLCHANNEL_H_
-#define _SWTPM_CTRLCHANNEL_H_
+#ifndef _SWTPM_LOCALITY_H_
+#define _SWTPM_LOCALITY_H_
 
-#include <stdbool.h>
+#define LOCALITY_FLAG_REJECT_LOCALITY_4   (1 << 0)
+#define LOCALITY_FLAG_ALLOW_SETLOCALITY   (1 << 1)
 
-struct ctrlchannel;
-struct libtpms_callbacks;
-
-struct ctrlchannel *ctrlchannel_new(int fd, bool isclient);
-int ctrlchannel_get_fd(struct ctrlchannel *cc);
-int ctrlchannel_get_client_fd(struct ctrlchannel *cc);
-int ctrlchannel_process_fd(int fd,
-                           struct libtpms_callbacks *cbs,
-                           bool *terminate,
-                           TPM_MODIFIER_INDICATOR *locality,
-                           bool *tpm_running,
-                           uint32_t locality_flags);
-
-#endif /* _SWTPM_CTRLCHANNEL_H_ */
+#endif /* _SWTPM_LOCALITY_H_ */

--- a/src/swtpm/mainloop.h
+++ b/src/swtpm/mainloop.h
@@ -57,6 +57,7 @@ struct mainLoopParams {
 
     int fd;
     struct ctrlchannel *cc;
+    uint32_t locality_flags;
 };
 
 int mainLoop(struct mainLoopParams *mlp,

--- a/src/swtpm/swtpm.c
+++ b/src/swtpm/swtpm.c
@@ -125,6 +125,8 @@ static void usage(FILE *file, const char *prgname, const char *iface)
     "--key pwdfile=<path>[,mode=aes-cbc][,remove=[true|false]]\n"
     "                 : provide a passphrase in a file; the AES key will be\n"
     "                   derived from this passphrase\n"
+    "--locality reject-locality-4\n"
+    "                 : reject-locality-4: reject any command in locality 4\n"
     "--pid file=<path>\n"
     "                 : write the process ID into the given file\n"
     "--tpmstate dir=<dir>\n"
@@ -157,6 +159,7 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
         .cc = NULL,
         .flags = 0,
         .fd = -1,
+        .locality_flags = 0,
     };
     struct server *server = NULL;
     unsigned long val;
@@ -165,6 +168,7 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
     char *keydata = NULL;
     char *logdata = NULL;
     char *piddata = NULL;
+    char *localitydata = NULL;
     char *tpmstatedata = NULL;
     char *ctrlchdata = NULL;
     char *serverdata = NULL;
@@ -182,6 +186,7 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
         {"server"    , required_argument, 0, 'c'},
         {"runas"     , required_argument, 0, 'r'},
         {"terminate" ,       no_argument, 0, 't'},
+        {"locality"  , required_argument, 0, 'L'},
         {"log"       , required_argument, 0, 'l'},
         {"key"       , required_argument, 0, 'k'},
         {"pid"       , required_argument, 0, 'P'},
@@ -287,6 +292,10 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
             ctrlchdata = optarg;
             break;
 
+        case 'L':
+            localitydata = optarg;
+            break;
+
         case 'h':
             usage(stdout, prgname, iface);
             exit(EXIT_SUCCESS);
@@ -310,6 +319,7 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
     if (handle_log_options(logdata) < 0 ||
         handle_key_options(keydata) < 0 ||
         handle_pid_options(piddata) < 0 ||
+        handle_locality_options(localitydata, &mlp.locality_flags) < 0 ||
         handle_tpmstate_options(tpmstatedata) < 0 ||
         handle_ctrlchannel_options(ctrlchdata, &mlp.cc) < 0 ||
         handle_server_options(serverdata, &server) < 0) {

--- a/src/swtpm/tpmlib.h
+++ b/src/swtpm/tpmlib.h
@@ -52,6 +52,18 @@ TPM_RESULT tpmlib_TpmEstablished_Reset(TPM_MODIFIER_INDICATOR *g_locty,
 void tpmlib_write_fatal_error_response(unsigned char **rbuffer,
                                        uint32_t *rlength,
                                        uint32_t *rTotal);
+void tpmlib_write_locality_error_response(unsigned char **rbuffer,
+                                          uint32_t *rlength,
+                                          uint32_t *rTotal);
+void tpmlib_write_success_response(unsigned char **rbuffer,
+                                   uint32_t *rlength,
+                                   uint32_t *rTotal);
+TPM_RESULT tpmlib_process(unsigned char **rbuffer, uint32_t *rlength,
+                          uint32_t *rTotal,
+                          unsigned char *command,
+                          uint32_t command_length,
+                          uint32_t locality_flags,
+                          TPM_MODIFIER_INDICATOR *locality);
 
 struct tpm_req_header {
     uint16_t tag;
@@ -68,5 +80,8 @@ struct tpm_resp_header {
 /* TPM 1.2 ordinals */
 #define TPMLIB_TPM_ORD_TakeOwnership   0x0000000d
 #define TPMLIB_TPM_ORD_CreateWrapKey   0x0000001f
+
+/* TPM 2 error codes */
+#define TPM_RC_LOCALITY     0x107
 
 #endif /* _SWTPM_TPMLIB_H_ */

--- a/src/swtpm/vtpm_proxy.h
+++ b/src/swtpm/vtpm_proxy.h
@@ -49,6 +49,10 @@ struct vtpm_proxy_new_dev {
 
 #define VTPM_PROXY_FLAG_TPM2   1
 
+/* vendor specific commands to set locality */
+#define TPM2_CC_SET_LOCALITY 0x20001000
+#define TPM_CC_SET_LOCALITY  0x20001000
+
 #define VTPM_PROXY_IOC_NEW_DEV _IOWR(0xa1, 0x00, struct vtpm_proxy_new_dev)
 
 #endif /* _SWTPM_VTPM_PROXY_H_ */

--- a/tests/test_locality
+++ b/tests/test_locality
@@ -131,4 +131,66 @@ fi
 
 echo "OK"
 
+
+$SWTPM_EXE --locality reject-locality-4 -n $VTPM_NAME
+sleep 0.5
+PID=$(ps aux | grep $SWTPM | grep -E "$VTPM_NAME\$" | gawk '{print $2}')
+
+ps aux | grep $SWTPM | grep -v grep
+
+kill -0 $PID
+if [ $? -ne 0 ]; then
+	echo "Error: CUSE TPM did not start."
+	exit 1
+fi
+
+# Init the TPM
+$CUSE_TPM_IOCTL -i /dev/$VTPM_NAME
+if [ $? -ne 0 ]; then
+	echo "Error: Could not initialize the CUSE TPM."
+	exit 1
+fi
+
+kill -0 $PID 2>/dev/null
+if [ $? -ne 0 ]; then
+	echo "Error: CUSE TPM not running anymore after INIT."
+	exit 1
+fi
+
+# Set locality 4 on the TPM -- this must fail now
+$CUSE_TPM_IOCTL -l 4 /dev/$VTPM_NAME
+if [ $? -eq 0 ]; then
+	echo "Error: CUSE TPM MUST NOT accept locality 4."
+	exit 1
+fi
+
+# Set illegal locality 5 on the TPM
+$CUSE_TPM_IOCTL -l 5 /dev/$VTPM_NAME
+if [ $? -eq 0 ]; then
+	echo "Error: CUSE TPM accepted locality 5."
+	exit 1
+fi
+
+# Shut down TPM
+$CUSE_TPM_IOCTL -s /dev/$VTPM_NAME
+if [ $? -ne 0 ]; then
+	echo "Error: Could not shut down the CUSE TPM."
+	exit 1
+fi
+sleep 0.5
+
+kill -0 $PID 2>/dev/null
+if [ $? -eq 0 ]; then
+	echo "Error: CUSE TPM should not be running anymore."
+	exit 1
+fi
+
+if [ ! -e $STATE_FILE ]; then
+	echo "Error: TPM state file $STATE_FILE does not exist."
+	exit 1
+fi
+
+echo "OK"
+
+
 exit 0


### PR DESCRIPTION
Add options for locality handling so that commands in locality
4 for example are rejected per command line parameter. This is
useful when the vTPM is used with containers.

Also implement the custom TPM/TPM2_SetLocality command to allow
the Linux vTPM proxy driver to set the locality in which subsequent
TPM commands will be executed.
