### PR TITLE
Cleanups and avoid race in test case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
 - pep8 $(find . -type f | grep -E "\.py$")
 - sudo apt-get -y install automake autoconf libtool libssl-dev sed make gawk sed bash
   dh-exec
+- sudo pip install twisted
 - git clone https://github.com/stefanberger/libtpms
 - cd libtpms
 - git checkout origin/tpm2-preview.rev146 -b tpm2-preview.rev146

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ sudo: required
 language: c
 dist: trusty
 before_install:
+- sudo apt-get -y install pep8
+- pep8 $(find . -type f | grep -E "\.py$")
 - sudo apt-get -y install automake autoconf libtool libssl-dev sed make gawk sed bash
   dh-exec
 - git clone https://github.com/stefanberger/libtpms

--- a/debian/control
+++ b/debian/control
@@ -16,6 +16,7 @@ Build-Depends: automake,
 	       socat,
 	       findutils,
 	       tpm-tools (>= 1.3.8),
+	       python-twisted
 # linux-image-extra
 
 Package: swtpm

--- a/dist/swtpm.spec
+++ b/dist/swtpm.spec
@@ -27,7 +27,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildRequires:  automake autoconf bash coreutils libtool sed
 BuildRequires:  libtpms-devel fuse-devel glib2-devel gmp-devel
-BuildRequires:  expect bash net-tools nss-devel socat
+BuildRequires:  expect bash net-tools nss-devel socat python-twisted
 %if %{with_gnutls}
 BuildRequires:  gnutls >= 3.1.0 gnutls-devel gnutls-utils
 BuildRequires:  libtasn1-devel libtasn1

--- a/dist/swtpm.spec.in
+++ b/dist/swtpm.spec.in
@@ -27,7 +27,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildRequires:  automake autoconf bash coreutils libtool sed
 BuildRequires:  libtpms-devel fuse-devel glib2-devel gmp-devel
-BuildRequires:  expect bash net-tools nss-devel socat
+BuildRequires:  expect bash net-tools nss-devel socat python-twisted
 %if %{with_gnutls}
 BuildRequires:  gnutls >= 3.1.0 gnutls-devel gnutls-utils
 BuildRequires:  libtasn1-devel libtasn1

--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -391,7 +391,7 @@ wait_chunk:
  * @tpm_running: indicates whether the TPM is running; may be changed by
  *               this function in case TPM is stopped or started
  * @mlp: mainloop parameters used; may be altered by this function incase of
- *       CMD_SET_DATAFD 
+ *       CMD_SET_DATAFD
  *
  * This function returns the passed file descriptor or -1 in case the
  * file descriptor was closed.

--- a/tests/test_clientfds.py
+++ b/tests/test_clientfds.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
-import os, sys
+import os
+import sys
 import socket
 import subprocess
 import time
@@ -10,6 +11,7 @@ child = None
 fd = -1
 ctrlfd = -1
 
+
 def wait_for_pidfile(pidfile, timeout):
     while timeout != 0:
         if os.path.exists(pidfile):
@@ -17,6 +19,7 @@ def wait_for_pidfile(pidfile, timeout):
         time.sleep(1)
         timeout -= 1
     return False
+
 
 def spawn_swtpm():
     global child, fd, ctrlfd
@@ -28,9 +31,10 @@ def spawn_swtpm():
     tpmpath = os.getenv('TPMDIR')
     pidfile = os.getenv('PID_FILE')
 
-    if swtpm_exe == None or tpmpath == None or pidfile == None:
-        print("Missing test environment \n swtpm_exe=%s,\n tpmpath=%s\n pidfile=%s" %
-                (swtpm_exe, tpmpath, pidfile));
+    if not swtpm_exe or not tpmpath or not pidfile:
+        print("Missing test environment \n swtpm_exe=%s,\n"
+              " tpmpath=%s\n pidfile=%s" %
+              (swtpm_exe, tpmpath, pidfile))
         return False
 
     cmd = swtpm_exe + " socket --fd=" + str(_fd.fileno())
@@ -45,21 +49,22 @@ def spawn_swtpm():
 
     print("Child PID: %d" % child.pid)
 
-    if wait_for_pidfile(pidfile, 3) == False:
-        print("waitpid timeout");
+    if not wait_for_pidfile(pidfile, 3):
+        print("waitpid timeout")
         child.kill()
         child = None
         return False
 
     return True
 
+
 def test_get_caps():
     global ctrlfd
 
     # test get capabilities
     # CMD_GET_CAPABILITY = 0x00 00 00 01
-    cmd_get_caps = bytearray([0x00,0x00,0x00,0x01])
-    expected_caps = bytearray([0x00,0x00,0x00,0x00,0x00,0x00,0x1f,0xff])
+    cmd_get_caps = bytearray([0x00, 0x00, 0x00, 0x01])
+    expected_caps = bytearray([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1f, 0xff])
 
     def toString(arr):
         return ' '.join('{:02x}'.format(x) for x in arr)
@@ -74,8 +79,9 @@ def test_get_caps():
         if caps == expected_caps:
             return True
         else:
-            print("Unexpected reply for CMD_GET_CAPABILITY: \n  actual: %s\n  expected: %s"
-                   % (toString(caps), toString(expected_caps)))
+            print("Unexpected reply for CMD_GET_CAPABILITY: \n"
+                  "  actual: %s\n  expected: %s"
+                  % (toString(caps), toString(expected_caps)))
             return False
     else:
         print("Null reply from swtpm")
@@ -83,7 +89,7 @@ def test_get_caps():
 
 if __name__ == "__main__":
     try:
-        if spawn_swtpm() == False or test_get_caps() == False:
+        if not spawn_swtpm() or not test_get_caps():
             res = 1
         else:
             res = 0
@@ -91,6 +97,7 @@ if __name__ == "__main__":
         print "__Exception: ", sys.exc_info()
         res = -1
 
-    if child: child.terminate()
+    if child:
+        child.terminate()
 
     sys.exit(res)

--- a/tests/test_setdatafd.py
+++ b/tests/test_setdatafd.py
@@ -6,9 +6,10 @@ import socket
 import subprocess
 import time
 import struct
+
 from array import array
 if sys.version_info[0] < 3:
-    import _multiprocessing
+    import twisted.python.sendmsg as sendmsg
 
 
 def toString(arr):
@@ -56,8 +57,10 @@ def test_SetDatafd():
         ctrlfd.connect(sock_path)
         print("Sending data fd over ctrl fd...")
         if sys.version_info[0] < 3:
-            ctrlfd.send(cmd_set_data_fd)
-            _multiprocessing.sendfd(ctrlfd.fileno(), _fd.fileno())
+            sendmsg.sendmsg(ctrlfd, str(cmd_set_data_fd),
+                            [(socket.SOL_SOCKET,
+                              sendmsg.SCM_RIGHTS,
+                              struct.pack("i", _fd.fileno()))])
         else:
             ctrlfd.sendmsg([cmd_set_data_fd],
                            [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds)])

--- a/tests/test_setdatafd.py
+++ b/tests/test_setdatafd.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
-import os, sys
+import os
+import sys
 import socket
 import subprocess
 import time
@@ -9,15 +10,18 @@ from array import array
 if sys.version_info[0] < 3:
     import _multiprocessing
 
+
 def toString(arr):
     return ' '.join('{:02x}'.format(x) for x in arr)
 
+
 def test_ReadPCR10(fd):
     send_data = bytearray(b"\x00\xC1\x00\x00\x00\x0C\x00\x00\x00\x99\x00\x01")
-    exp_data = bytearray([0x00, 0xC4, 0x00, 0x00, 0x00, 0x0A, 0x00, 0x00, 0x00, 0x26])
+    exp_data = bytearray([0x00, 0xC4, 0x00, 0x00, 0x00, 0x0A,
+                          0x00, 0x00, 0x00, 0x26])
 
     try:
-        print("Sending data over ....");
+        print("Sending data over ....")
         n = fd.send(send_data)
         print("Written %d bytes " % n)
     except socket.error as e:
@@ -32,17 +36,18 @@ def test_ReadPCR10(fd):
             return True
         else:
             print("Unexpected reply:\n  actual: %s\n  expected: %s"
-                   % (toString(buf), toString(exp_data)))
+                  % (toString(buf), toString(exp_data)))
             return False
     else:
         print("Null reply from swtpm")
         return False
 
+
 def test_SetDatafd():
     fd, _fd = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM)
     sock_path = os.getenv('SOCK_PATH')
-    cmd_set_data_fd = bytearray([0x00,0x00,0x00,0x10])
-    expected_res = bytearray([0x00,0x00,0x00,0x00])
+    cmd_set_data_fd = bytearray([0x00, 0x00, 0x00, 0x10])
+    expected_res = bytearray([0x00, 0x00, 0x00, 0x00])
     try:
         fds = array("i")
         fds.append(_fd.fileno())
@@ -55,7 +60,7 @@ def test_SetDatafd():
             _multiprocessing.sendfd(ctrlfd.fileno(), _fd.fileno())
         else:
             ctrlfd.sendmsg([cmd_set_data_fd],
-                       [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds)])
+                           [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds)])
     except socket.error as e:
         print("SocketError: " + str(e))
         ctrlfd.close()
@@ -67,8 +72,9 @@ def test_SetDatafd():
         if caps == expected_res:
             return test_ReadPCR10(fd)
         else:
-            print("Unexpected reply for CMD_SET_DATA_FD: \n  actual: %s\n  expected: %s"
-                   % (toString(caps), toString(expected_res)))
+            print("Unexpected reply for CMD_SET_DATA_FD: \n"
+                  "  actual: %s\n  expected: %s"
+                  % (toString(caps), toString(expected_res)))
             return False
     else:
         print("Null reply from swtpm")
@@ -76,7 +82,7 @@ def test_SetDatafd():
 
 if __name__ == "__main__":
     try:
-        if test_SetDatafd() == False:
+        if not test_SetDatafd():
             res = 1
         else:
             res = 0


### PR DESCRIPTION
This patch series cleans up all python code to pass pep8 without complaints. It also removes a white space error in ctrchannel.c.

Switch the python test case that's sending the control and data message in two API calls to use the python twisted package to send it in one API call and avoid hacks on the server side.
