### PR TITLE
tests: Some work on the tests

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+unset SWTPM
+
+# FIXME:
+# Due to some bug in glib2 for i686 we don't seem to be able to run a
+# 32bit swtpm with cuse interface correctly. The g_cond_wait_until()
+# doesn't behave as it does with 64bit. test_hashing2 gets stuck.
+
+
+CFLAGS='-m64' ./configure --with-openssl --with-gnutls --prefix=/usr --libdir=/lib64 && \
+ make clean && \
+ make -j8 &&
+ sudo make -j8 install &&
+ cp /usr/bin/swtpm /tmp/swtpm64 &&
+ make -j8 check &&
+ sudo make -j8 check ||
+ exit 1
+
+CFLAGS='-m32' ./configure --with-openssl --with-gnutls --prefix=/usr --libdir=/lib && \
+ make clean && \
+ make -j8 &&
+ sudo make -j8 install &&
+ cp /usr/bin/swtpm /tmp/swtpm32 &&
+ make -j8 check &&
+ SWTPM_EXE=/tmp/swtpm64 make -j8 check &&
+ sudo SWTPM_EXE=/tmp/swtpm64 make -j8 check ||
+ exit 1
+
+CFLAGS='-m64' ./configure --with-openssl --with-gnutls --prefix=/usr --libdir=/lib64 && \
+ make clean && \
+ make -j8 &&
+ SWTPM_EXE=/tmp/swtpm32 make -j8 check &&
+ exit 1

--- a/src/swtpm_cert/ek-cert.c
+++ b/src/swtpm_cert/ek-cert.c
@@ -524,7 +524,7 @@ main(int argc, char *argv[])
                 fprintf(stderr, "Exponent is wrong and cannot be 0.\n");
                 goto cleanup;
             }
-            if (exponent > UINT_MAX) {
+            if ((unsigned long int)exponent > UINT_MAX) {
                 fprintf(stderr, "Exponent must fit into 32bits.\n");
                 goto cleanup;
             }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -64,3 +64,16 @@ EXTRA_DIST=$(TESTS) \
 	test_common \
 	test_cuse \
 	test_swtpm_cert
+
+check-display:
+	@if test -n "$$SWTPM_EXE"; then \
+		echo "*** Using SWTPM_EXE=$$SWTPM_EXE"; \
+	fi
+	@if test -n "$$SWTPM_BIOS"; then \
+		echo "*** Using SWTPM_BIOS=$$SWTPM_BIOS"; \
+	fi
+	@if test -n "$$SWTPM_IOCTL"; then \
+		echo "*** Using SWTPM_IOCTL=$$SWTPM_IOCTL"; \
+	fi
+
+check: check-am check-display

--- a/tests/common
+++ b/tests/common
@@ -3,9 +3,9 @@ DIR=$(dirname "$0")
 ROOT=${DIR}/..
 
 SWTPM=swtpm
-SWTPM_EXE=${ROOT}/src/swtpm/${SWTPM}
-SWTPM_IOCTL=${ROOT}/src/swtpm_ioctl/swtpm_ioctl
-SWTPM_BIOS=${ROOT}/src/swtpm_bios/swtpm_bios
+SWTPM_EXE=${SWTPM_EXE:-${ROOT}/src/swtpm/${SWTPM}}
+SWTPM_IOCTL=${SWTPM_IOCTL:-${ROOT}/src/swtpm_ioctl/swtpm_ioctl}
+SWTPM_BIOS=${SWTPM_BIOS:-${ROOT}/src/swtpm_bios/swtpm_bios}
 ECHO=$(type -P echo)
 
 # Run the swtpm_ioctl command

--- a/tests/test_ctrlchannel
+++ b/tests/test_ctrlchannel
@@ -5,7 +5,7 @@
 DIR=$(dirname "$0")
 ROOT=${DIR}/..
 SWTPM=swtpm
-SWTPM_EXE=$ROOT/src/swtpm/$SWTPM
+SWTPM_EXE=${SWTPM_EXEC:-$ROOT/src/swtpm/$SWTPM}
 TPMDIR=`mktemp -d`
 PID_FILE=$TPMDIR/${SWTPM}.pid
 LOG_FILE=$TPMDIR/${SWTPM}.log

--- a/tests/test_ctrlchannel2
+++ b/tests/test_ctrlchannel2
@@ -5,8 +5,8 @@
 DIR=$(dirname "$0")
 ROOT=${DIR}/..
 SWTPM=swtpm
-SWTPM_EXE=$ROOT/src/swtpm/$SWTPM
-SWTPM_IOCTL=$ROOT/src/swtpm_ioctl/swtpm_ioctl
+SWTPM_EXE=${SWTPM_EXEC:-$ROOT/src/swtpm/$SWTPM}
+SWTPM_IOCTL=${SWTPM_IOCTL:-$ROOT/src/swtpm_ioctl/swtpm_ioctl}
 TPMDIR=`mktemp -d`
 PID_FILE=$TPMDIR/${SWTPM}.pid
 SOCK_PATH=$TPMDIR/sock

--- a/tests/test_parameters
+++ b/tests/test_parameters
@@ -53,7 +53,7 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 SWTPM=swtpm
-SWTPM_EXE=$ROOT/src/swtpm/$SWTPM
+SWTPM_EXE=${SWTPM_EXE:-$ROOT/src/swtpm/$SWTPM}
 TCSD=`type -P tcsd`
 TPMDIR=`mktemp -d`
 SWTPM_SETUP_CONF=$ROOT/etc/swtpm_setup.conf

--- a/tests/test_vtpm_proxy
+++ b/tests/test_vtpm_proxy
@@ -11,7 +11,7 @@ fi
 DIR=$(dirname "$0")
 ROOT=${DIR}/..
 SWTPM=swtpm
-SWTPM_EXE=$ROOT/src/swtpm/$SWTPM
+SWTPM_EXE=${SWTPM_EXE:-$ROOT/src/swtpm/$SWTPM}
 TPM_PATH=$(mktemp -d)
 STATE_FILE=$TPM_PATH/tpm-00.permall
 VOLATILE_STATE_FILE=$TPM_PATH/tpm-00.volatilestate


### PR DESCRIPTION
Enable testing of 32 bit and 64 bit executables with the test suite by allowing the path to the executable for swtpm, swtpm_ioctl, and swtpm_bios to be provided via variables. Add a test script that makes use of that.

