### PR TITLE
Convert some test cases and adapt code for Cygwin

### DIFF
--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -467,8 +467,11 @@ int ctrlchannel_process_fd(int fd,
             PTM_CAP_GET_STATEBLOB |
             PTM_CAP_SET_STATEBLOB |
             PTM_CAP_STOP |
-            PTM_CAP_GET_CONFIG |
-            PTM_CAP_SET_DATAFD);
+            PTM_CAP_GET_CONFIG
+#ifndef __CYGWIN__
+            | PTM_CAP_SET_DATAFD
+#endif
+            );
 
         out_len = sizeof(*ptm_caps);
         break;
@@ -693,6 +696,10 @@ int ctrlchannel_process_fd(int fd,
         break;
 
     case CMD_SET_DATAFD:
+#ifdef __CYGWIN__
+        if (1)
+            goto err_running;
+#endif
         if (mlp->fd != -1)
             goto err_io;
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,6 +16,7 @@ TESTS += \
 endif
 
 TESTS += \
+	test_ctrlchannel3 \
 	test_encrypted_state \
 	test_getcap \
 	test_hashing \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -11,11 +11,12 @@ TESTS = \
 
 if WITH_CHARDEV
 TESTS += \
-	test_ctrlchannel \
-	test_ctrlchannel2
+	test_ctrlchannel2 \
+	test_ctrlchannel4
 endif
 
 TESTS += \
+	test_ctrlchannel \
 	test_ctrlchannel3 \
 	test_encrypted_state \
 	test_getcap \

--- a/tests/common
+++ b/tests/common
@@ -222,6 +222,36 @@ function swtpm_cmd_tx()
 	esac
 }
 
+# Transmit a control command on fd 101
+#
+# @param1: type of interface
+function swtpm_ctrl_tx()
+{
+	local iface=$1
+	local ctrl_path resp_path
+
+	case "${iface}" in
+	socket+socket|unix+socket)
+		$ECHO -en "$2" >&101
+		cat <&101 | od -t x1 -A n -w128
+		;;
+	socket+unix|unix+unix)
+		ctrl_path=$(mktemp)
+		echo -en "$2" > ${ctrl_path}
+		socat -x -t20 \
+			FILE:${ctrl_path},rdonly \
+			UNIX-CLIENT:${SWTPM_CTRL_UNIX_PATH} 2>&1 | \
+		  sed -n '/^ /p' | \
+		  tail -n1
+		rm -f ${ctrl_path}
+		;;
+	*)
+		echo "swtpm_opendev: unsupported interface $iface"
+		exit 1
+	esac
+}
+
+
 # Run swtpm_bios
 #
 # @param1: type of interface

--- a/tests/test_ctrlchannel
+++ b/tests/test_ctrlchannel
@@ -4,12 +4,10 @@
 
 DIR=$(dirname "$0")
 ROOT=${DIR}/..
-SWTPM=swtpm
-SWTPM_EXE=${SWTPM_EXEC:-$ROOT/src/swtpm/$SWTPM}
 TPMDIR=`mktemp -d`
-PID_FILE=$TPMDIR/${SWTPM}.pid
-LOG_FILE=$TPMDIR/${SWTPM}.log
-SOCK_PATH=$TPMDIR/sock
+SWTPM_CTRL_UNIX_PATH=$TPMDIR/sock
+PID_FILE=$TPMDIR/swtpm.pid
+LOG_FILE=$TPMDIR/swtpm.log
 CMD_PATH=$TPMDIR/cmd
 RESP_PATH=$TPMDIR/resp
 
@@ -25,15 +23,10 @@ function cleanup()
 	fi
 }
 
-function unix_tx()
-{
-	rm -f $CMD_PATH $RESP_PATH
-	echo -en "$1" > $CMD_PATH
-	socat -x -t20 FILE:$CMD_PATH,rdonly UNIX-CLIENT:$SOCK_PATH 2>&1 | \
-		sed -n '/^ /p' | \
-		tail -n1 > $RESP_PATH
-	cat $RESP_PATH
-}
+SWTPM_INTERFACE=socket+unix
+SWTPM_SERVER_PORT=65430
+SWTPM_SERVER_NAME=localhost
+source ${DIR}/common
 
 # Test 1: test the control channel on the chardev tpm
 
@@ -43,8 +36,10 @@ $SWTPM_EXE chardev \
 	--fd 100 \
 	--tpmstate dir=$TPMDIR \
 	--pid file=$PID_FILE \
-	--ctrl type=unixio,path=$SOCK_PATH \
+	--ctrl type=unixio,path=$SWTPM_CTRL_UNIX_PATH \
 	--log file=$LOG_FILE,level=20 &
+
+exec 100>&-
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: Chardev TPM did not write pidfile."
@@ -53,9 +48,8 @@ fi
 
 PID="$(cat $PID_FILE)"
 
-
 # Get the capability bits: CMD_GET_CAPABILITY = 0x00 00 00 01
-res="$(unix_tx '\x00\x00\x00\x01')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x01')"
 exp=" 00 00 00 00 00 00 1f ff"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Unexpected response from CMD_GET_CAPABILITY:"
@@ -65,7 +59,7 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # Send TPM_Init to the TPM: CMD_INIT = 0x00 00 00 02 + flags
-res="$(unix_tx '\x00\x00\x00\x02\x00\x00\x00\x00')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x02\x00\x00\x00\x00')"
 exp=" 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Unexpected response from CMD_INIT:"
@@ -75,7 +69,7 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # Send unknown command to the TPM
-res="$(unix_tx '\x00\x00\xff\xff')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\xff\xff')"
 exp=" 00 00 00 0a"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Unexpected response from sending unsupported command:"
@@ -85,7 +79,7 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # Save the volatile state: CMD_STORE_VOLATILE = 0x00 00 00 0a
-res="$(unix_tx '\x00\x00\x00\x0a')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x0a')"
 exp=" 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Unexpected response from CMD_STORE_VOLATILE:"
@@ -100,7 +94,7 @@ if [ ! -r $TPMDIR/tpm-00.volatilestate ]; then
 fi
 
 # Send stop command to the TPM: CMD_STOP = 00 00 00 0e
-res="$(unix_tx '\x00\x00\x00\x0e')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x0e')"
 exp=" 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from CMD_STOP:"
@@ -109,9 +103,8 @@ if [ "$res" != "$exp" ]; then
 	exit 1
 fi
 
-
 # Send get config command to the TPM: CMD_GET_CONFIG = 00 00 00 0f
-res="$(unix_tx '\x00\x00\x00\x0f')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x0f')"
 exp=" 00 00 00 00 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from CMD_GET_CONFIG:"
@@ -120,9 +113,8 @@ if [ "$res" != "$exp" ]; then
 	exit 1
 fi
 
-
 # Send shutdown command to the TPM: CMD_SHUTDOWN = 00 00 00 03
-res="$(unix_tx '\x00\x00\x00\x03')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x03')"
 exp=" 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Unexpected response from CMD_SHUTDOWN:"
@@ -148,30 +140,28 @@ rm -f $LOG_FILE
 
 echo "OK"
 
-
 # Test 2: test the control channel on the socket tpm
 
 # There are a few more tests here that require sending commands to the TPM
 
 # use a pseudo terminal
-$SWTPM_EXE socket \
-	--server port=65430,disconnect=true \
+run_swtpm ${SWTPM_INTERFACE} \
 	--tpmstate dir=$TPMDIR \
 	--pid file=$PID_FILE \
-	--ctrl type=unixio,path=$SOCK_PATH \
-	--log file=$LOG_FILE &
+	--log file=$LOG_FILE
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: Socket TPM did not write pidfile."
+	cat $LOG_FILE
 	exit 1
 fi
 
 PID="$(cat $PID_FILE)"
 
-exec 100<>/dev/tcp/localhost/65430
+swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 
 # Get the capability bits: CMD_GET_CAPABILITY = 0x00 00 00 01
-res="$(unix_tx '\x00\x00\x00\x01')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x01')"
 exp=" 00 00 00 00 00 00 1f ff"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from CMD_GET_CAPABILITY:"
@@ -181,7 +171,7 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # Send TPM_Init to the TPM: CMD_INIT = 0x00 00 00 02 + flags
-res="$(unix_tx '\x00\x00\x00\x02\x00\x00\x00\x00')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x02\x00\x00\x00\x00')"
 exp=" 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from CMD_INIT:"
@@ -191,7 +181,7 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # Send unknown command to the TPM
-res="$(unix_tx '\x00\x00\xff\xff')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\xff\xff')"
 exp=" 00 00 00 0a"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from sending unsupported command:"
@@ -200,20 +190,18 @@ if [ "$res" != "$exp" ]; then
 	exit 1
 fi
 
-
 # Startup the TPM
-/bin/echo -en '\x00\xC1\x00\x00\x00\x0C\x00\x00\x00\x99\x00\x01' >&100
-RES=$(cat <&100 | od -t x1 -A n)
+res="$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0C\x00\x00\x00\x99\x00\x01')"
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
-if [ "$RES" != "$exp" ]; then
+if [ "$res" != "$exp" ]; then
 	echo "Error: Did not get expected result from TPM_Startup(ST_Clear)"
 	echo "expected: $exp"
-	echo "received: $RES"
+	echo "received: $res"
 	exit 1
 fi
 
 # Save the volatile state: CMD_STORE_VOLATILE = 0x00 00 00 0a
-res="$(unix_tx '\x00\x00\x00\x0a')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x0a')"
 exp=" 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from CMD_STORE_VOLATILE:"
@@ -228,7 +216,7 @@ if [ ! -r $TPMDIR/tpm-00.volatilestate ]; then
 fi
 
 # 1. Send command to get TPM established flag: CMD_GET_TPMESTABLISHED = 00 00 00 04
-res="$(unix_tx '\x00\x00\x00\x04')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x04')"
 exp=" 00 00 00 00 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from sending CMD_GET_TPMESTABLISHED command:"
@@ -238,7 +226,7 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # 2. Send command to start HASH : CMD_HASH_START = 00 00 00 06
-res="$(unix_tx '\x00\x00\x00\x06')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x06')"
 exp=" 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from sending CMD_HASH_START command:"
@@ -251,7 +239,7 @@ fi
 # We send 0x100 null bytes
 echo -en '\x00\x00\x00\x07\x00\x00\x20\x00' > $CMD_PATH
 dd if=/dev/zero count=$((0x2000)) bs=1 >> $CMD_PATH 2>/dev/null
-socat -x -t10 FILE:$CMD_PATH,rdonly UNIX-CONNECT:$SOCK_PATH 2>&1 | \
+socat -x -t10 FILE:$CMD_PATH,rdonly UNIX-CONNECT:$SWTPM_CTRL_UNIX_PATH 2>&1 | \
 	sed -n '/^ /p' | \
 	tail -n1 > $RESP_PATH
 res="$(cat $RESP_PATH)"
@@ -264,7 +252,7 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # 3. Send command to end HASH : CMD_HASH_END = 00 00 00 08
-res="$(unix_tx '\x00\x00\x00\x08')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x08')"
 exp=" 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from sending CMD_HASH_END command:"
@@ -274,7 +262,7 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # 4. Send command to get TPM established flag: CMD_GET_TPMESTABLISHED = 00 00 00 04
-res="$(unix_tx '\x00\x00\x00\x04')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x04')"
 exp=" 00 00 00 00 01 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from sending CMD_GET_TPMESTABLISHED command:"
@@ -284,7 +272,7 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # 5. Send command to reset TPM established flag: CMD_RESET_TPMESTABLISHED = 00 00 00 0b 03
-res="$(unix_tx '\x00\x00\x00\x0b\x03')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x0b\x03')"
 exp=" 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from sending CMD_GET_TPMESTABLISHED command:"
@@ -294,7 +282,7 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # 6. Send command to get TPM established flag: CMD_GET_TPMESTABLISHED = 00 00 00 04
-res="$(unix_tx '\x00\x00\x00\x04')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x04')"
 exp=" 00 00 00 00 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from sending CMD_GET_TPMESTABLISHED command:"
@@ -304,21 +292,19 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # Read PCR 17
-exec 100<>/dev/tcp/localhost/65430
-echo -en '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11' >&100
-RES=$(cat <&100 | od -t x1 -A n | tr -d "\n")
+swtpm_open_cmddev ${SWTPM_INTERFACE} 100
+res="$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')"
 exp=' 00 c4 00 00 00 1e 00 00 00 00 c4 e1 e1 c9 81 c0 cd b1 e0 43 df 97 20 72 f9 5d a9 ff 06 ff'
-if [ "$RES" != "$exp" ]; then
+if [ "$res" != "$exp" ]; then
 	echo "Error: (1) Did not get expected result from TPM_PCRRead(17)"
 	echo "expected: $exp"
-	echo "received: $RES"
+	echo "received: $res"
 	exit 1
 fi
 
-
 # Get the volatile state of the TPM: CMD_GET_STATEBLOB = 00 00 00 0c
-#                    cmd  |     flags     |     type      |    offset     |
-res="$(unix_tx '\x00\x00\x00\x0c\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00')"
+#                                                  cmd  |     flags     |     type      |    offset     |
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x0c\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00')"
 #      result    |   flags   | totlength |   length  |
 exp=" 00 00 00 00 00 00 00 00 00 00 04 d9 00 00 04 d9"
 if [ "${res:0:48}" != "$exp" ]; then
@@ -328,9 +314,8 @@ if [ "${res:0:48}" != "$exp" ]; then
 	exit 1
 fi
 
-
 # Send stop command to the TPM: CMD_STOP = 00 00 00 0e
-res="$(unix_tx '\x00\x00\x00\x0e')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x0e')"
 exp=" 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from CMD_STOP:"
@@ -340,20 +325,18 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # Read PCR 17 -- should fail now
-exec 100<>/dev/tcp/localhost/65430
-echo -en '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11' >&100
-RES=$(cat <&100 | od -t x1 -A n | tr -d "\n")
+swtpm_open_cmddev ${SWTPM_INTERFACE} 100
+res="$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')"
 exp=' 00 c4 00 00 00 0a 00 00 00 09'
-if [ "$RES" != "$exp" ]; then
+if [ "$res" != "$exp" ]; then
 	echo "Error: (1) Did not get expected result from TPM_PCRRead(17)"
 	echo "expected: $exp"
-	echo "received: $RES"
+	echo "received: $res"
 	exit 1
 fi
 
-
 # Send get config command to the TPM: CMD_GET_CONFIG = 00 00 00 0f
-res="$(unix_tx '\x00\x00\x00\x0f')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x0f')"
 exp=" 00 00 00 00 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from CMD_GET_CONFIG:"
@@ -362,9 +345,8 @@ if [ "$res" != "$exp" ]; then
 	exit 1
 fi
 
-
 # Send shutdown command to the TPM: CMD_SHUTDOWN = 00 00 00 03
-res="$(unix_tx '\x00\x00\x00\x03')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x03')"
 exp=" 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from CMD_SHUTDOWN:"
@@ -391,20 +373,17 @@ rm -f $LOG_FILE
 
 echo "OK"
 
-
 # Test 3: test the control channel on the socket tpm: resume encrypted state
 
 # copy all the state files
 cp ${PWD}/${DIR}/data/tpmstate2/* ${TPMDIR}
 
-$SWTPM_EXE socket \
-	--server port=65430,disconnect=true \
+run_swtpm ${SWTPM_INTERFACE} \
 	--tpmstate dir=$TPMDIR \
 	--pid file=$PID_FILE \
-	--ctrl type=unixio,path=$SOCK_PATH \
 	--key pwdfile=${PWD}/${DIR}/data/tpmstate2/pwdfile.txt \
 	--log file=$LOG_FILE,level=20 \
-	--flags not-need-init &
+	--flags not-need-init
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: Socket TPM did not write pidfile."
@@ -413,22 +392,20 @@ fi
 
 PID="$(cat $PID_FILE)"
 
-
 # Read PCR 10
-exec 100<>/dev/tcp/localhost/65430
-echo -en '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x0a' >&100
-RES=$(cat <&100 | od -t x1 -A n -w128)
+swtpm_open_cmddev ${SWTPM_INTERFACE} 100
+res="$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x0a')"
 exp=' 00 c4 00 00 00 1e 00 00 00 00 c7 8a 6e 94 c7 3c 4d 7f c3 05 c8 a6 6b bf 15 45 f4 ed b7 a5'
-if [ "$RES" != "$exp" ]; then
+if [ "$res" != "$exp" ]; then
 	echo "Error: (1) Did not get expected result from TPM_PCRRead(10)"
 	echo "expected: $exp"
-	echo "received: $RES"
+	echo "received: $res"
 	exit 1
 fi
 
 # Get the volatile state of the TPM: CMD_GET_STATEBLOB = 00 00 00 0c
-#                    cmd  |     flags     |     type      |    offset     |
-vstate="$(unix_tx '\x00\x00\x00\x0c\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00')"
+#                                                      cmd  |     flags     |     type      |    offset     |
+vstate="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x0c\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00')"
 #      result    |   flags   | totlength |   length  |
 exp=" 00 00 00 00 00 00 00 02 00 00 04 fa 00 00 04 fa"
 if [ "${vstate:0:48}" != "$exp" ]; then
@@ -439,7 +416,7 @@ if [ "${vstate:0:48}" != "$exp" ]; then
 fi
 
 # Send shutdown command to the TPM: CMD_SHUTDOWN = 00 00 00 03
-res="$(unix_tx '\x00\x00\x00\x03')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x03')"
 exp=" 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from CMD_SHUTDOWN:"
@@ -468,14 +445,12 @@ echo "OK"
 # remove volatile state
 rm -f $TPMDIR/*.volatilestate
 
-$SWTPM_EXE socket \
-	--server port=65430,disconnect=true \
+run_swtpm ${SWTPM_INTERFACE} \
 	--tpmstate dir=$TPMDIR \
 	--pid file=$PID_FILE \
-	--ctrl type=unixio,path=$SOCK_PATH \
 	--key pwdfile=${PWD}/${DIR}/data/tpmstate2/pwdfile.txt \
 	--log file=$LOG_FILE \
-	--flags not-need-init &
+	--flags not-need-init
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: Socket TPM did not write pidfile."
@@ -484,22 +459,19 @@ fi
 
 PID="$(cat $PID_FILE)"
 
-
 # Read PCR 10 -- this should fail now
-exec 100<>/dev/tcp/localhost/65430
-echo -en '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x0a' >&100
-RES=$(cat <&100 | od -t x1 -A n -w128)
+swtpm_open_cmddev ${SWTPM_INTERFACE} 100
+res="$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x0a')"
 exp=' 00 c4 00 00 00 0a 00 00 00 26'
-if [ "$RES" != "$exp" ]; then
+if [ "$res" != "$exp" ]; then
 	echo "Error: (1) Did not get expected result from TPM_PCRRead(10)"
 	echo "expected: $exp"
-	echo "received: $RES"
+	echo "received: $res"
 	exit 1
 fi
 
-
 # Send stop command to the TPM: CMD_STOP = 00 00 00 0e
-res="$(unix_tx '\x00\x00\x00\x0e')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x0e')"
 exp=" 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from CMD_STOP:"
@@ -514,7 +486,7 @@ vstate=${vstate:48}
 size=$((${#vstate} / 3))
 size=$(printf "%08x" $size | sed 's/\([0-9a-f]\{2\}\)/\\x\1/g')
 vstate=$(echo "${vstate}" | sed 's/ /\\x/g')
-res="$(unix_tx "\x00\x00\x00\x0d\x00\x00\x00\x02\x00\x00\x00\x02${size}${vstate}")"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} "\x00\x00\x00\x0d\x00\x00\x00\x02\x00\x00\x00\x02${size}${vstate}")"
 exp=" 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from CMD_SET_STATEBLOB:"
@@ -524,7 +496,7 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # Send init command to the TPM: CMD_INIT = 00 00 00 02
-res="$(unix_tx '\x00\x00\x00\x02\x00\x00\x00\x00')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x02\x00\x00\x00\x00')"
 exp=" 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from CMD_INIT:"
@@ -533,35 +505,31 @@ if [ "$res" != "$exp" ]; then
 	exit 1
 fi
 
-
 # Read PCR 10 -- has to return same result as before
-exec 100<>/dev/tcp/localhost/65430
-echo -en '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x0a' >&100
-RES=$(cat <&100 | od -t x1 -A n -w128)
+swtpm_open_cmddev ${SWTPM_INTERFACE} 100
+res="$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x0a')"
 exp=' 00 c4 00 00 00 1e 00 00 00 00 c7 8a 6e 94 c7 3c 4d 7f c3 05 c8 a6 6b bf 15 45 f4 ed b7 a5'
-if [ "$RES" != "$exp" ]; then
+if [ "$res" != "$exp" ]; then
 	echo "Error: (1) Did not get expected result from TPM_PCRRead(10)"
 	echo "expected: $exp"
-	echo "received: $RES"
+	echo "received: $res"
 	exit 1
 fi
 
-
 # Reset PCR 20 while in locality 0 -- should not work
-exec 100<>/dev/tcp/localhost/65430
-echo -en '\x00\xC1\x00\x00\x00\x0F\x00\x00\x00\xC8\x00\x03\x00\x00\x10' >&100
-RES=$(cat <&100 | od -t x1 -A n)
+swtpm_open_cmddev ${SWTPM_INTERFACE} 100
+res="$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0F\x00\x00\x00\xC8\x00\x03\x00\x00\x10')"
 exp=' 00 c4 00 00 00 0a 00 00 00 33'
-if [ "$RES" != "$exp" ]; then
+if [ "$res" != "$exp" ]; then
 	echo "Error: Trying to reset PCR 20 in locality 0 returned unexpected result"
 	echo "expected: $exp"
-	echo "received: $RES"
+	echo "received: $res"
 	exit 1
 fi
 
 # In locality 2 we can reset PCR 20
 # Set the localoty on the TPM: CMD_SET_LOCALITY = 00 00 00 05 <locality>
-res="$(unix_tx '\x00\x00\x00\x05\x02')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x05\x02')"
 exp=" 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from CMD_SET_LOCALITY:"
@@ -571,20 +539,18 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # Reset PCR 20 while in locality 2 -- has to work
-exec 100<>/dev/tcp/localhost/65430
-echo -en '\x00\xC1\x00\x00\x00\x0F\x00\x00\x00\xC8\x00\x03\x00\x00\x10' >&100
-RES=$(cat <&100 | od -t x1 -A n)
+swtpm_open_cmddev ${SWTPM_INTERFACE} 100
+res="$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0F\x00\x00\x00\xC8\x00\x03\x00\x00\x10')"
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
-if [ "$RES" != "$exp" ]; then
+if [ "$res" != "$exp" ]; then
 	echo "Error: Could not reset PCR 20 in locality 2"
 	echo "expected: $exp"
-	echo "received: $RES"
+	echo "received: $res"
 	exit 1
 fi
 
-
 # Send shutdown command to the TPM: CMD_SHUTDOWN = 00 00 00 03
-res="$(unix_tx '\x00\x00\x00\x03')"
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x03')"
 exp=" 00 00 00 00"
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from CMD_SHUTDOWN:"
@@ -614,7 +580,7 @@ echo "OK"
 # Test CMD_SET_DATAFD
 cp ${PWD}/${DIR}/data/tpmstate1/* ${TPMDIR}
 $SWTPM_EXE socket --flags not-need-init \
-           --ctrl type=unixio,path=$SOCK_PATH \
+           --ctrl type=unixio,path=$SWTPM_CTRL_UNIX_PATH \
            --tpmstate dir=$TPMDIR -t --pid file=$PID_FILE \
            --log file=$LOG_FILE,level=20 &
 PID=$!
@@ -624,7 +590,7 @@ if wait_for_file $PID_FILE 3; then
 	exit 1
 fi
 
-LOG=$(SOCK_PATH=$SOCK_PATH exec python $DIR/test_setdatafd.py)
+LOG=$(SOCK_PATH=$SWTPM_CTRL_UNIX_PATH exec python $DIR/test_setdatafd.py)
 RES=$?
 
 if [ $RES -ne 0 ]; then

--- a/tests/test_ctrlchannel
+++ b/tests/test_ctrlchannel
@@ -577,27 +577,4 @@ rm -f $LOG_FILE
 
 echo "OK"
 
-# Test CMD_SET_DATAFD
-cp ${PWD}/${DIR}/data/tpmstate1/* ${TPMDIR}
-$SWTPM_EXE socket --flags not-need-init \
-           --ctrl type=unixio,path=$SWTPM_CTRL_UNIX_PATH \
-           --tpmstate dir=$TPMDIR -t --pid file=$PID_FILE \
-           --log file=$LOG_FILE,level=20 &
-PID=$!
-
-if wait_for_file $PID_FILE 3; then
-	echo "Error: Socket TPM did not write pidfile."
-	exit 1
-fi
-
-LOG=$(SOCK_PATH=$SWTPM_CTRL_UNIX_PATH exec python $DIR/test_setdatafd.py)
-RES=$?
-
-if [ $RES -ne 0 ]; then
-    echo "Error: CMD_SET_DATAFD failed: $LOG"
-    exit 1
-fi
-
-echo "OK"
-
 exit 0

--- a/tests/test_ctrlchannel
+++ b/tests/test_ctrlchannel
@@ -50,7 +50,11 @@ PID="$(cat $PID_FILE)"
 
 # Get the capability bits: CMD_GET_CAPABILITY = 0x00 00 00 01
 res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x01')"
-exp=" 00 00 00 00 00 00 1f ff"
+if [[ "$(uname -o)" =~ Linux ]]; then
+	exp=" 00 00 00 00 00 00 1f ff"
+else
+	exp=" 00 00 00 00 00 00 0f ff"
+fi
 if [ "$res" != "$exp" ]; then
 	echo "Error: Unexpected response from CMD_GET_CAPABILITY:"
 	echo "       actual  : $res"
@@ -162,7 +166,11 @@ swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 
 # Get the capability bits: CMD_GET_CAPABILITY = 0x00 00 00 01
 res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x01')"
-exp=" 00 00 00 00 00 00 1f ff"
+if [[ "$(uname -o)" =~ Linux ]]; then
+	exp=" 00 00 00 00 00 00 1f ff"
+else
+	exp=" 00 00 00 00 00 00 0f ff"
+fi
 if [ "$res" != "$exp" ]; then
 	echo "Error: Socket TPM: Unexpected response from CMD_GET_CAPABILITY:"
 	echo "       actual  : $res"

--- a/tests/test_ctrlchannel
+++ b/tests/test_ctrlchannel
@@ -28,11 +28,11 @@ SWTPM_SERVER_PORT=65430
 SWTPM_SERVER_NAME=localhost
 source ${DIR}/common
 
-# Test 1: test the control channel on the chardev tpm
+# Test 1: test the control channel on the socket tpm
 
 # use a pseudo terminal
 exec 100<>/dev/ptmx
-$SWTPM_EXE chardev \
+$SWTPM_EXE socket \
 	--fd 100 \
 	--tpmstate dir=$TPMDIR \
 	--pid file=$PID_FILE \
@@ -42,7 +42,7 @@ $SWTPM_EXE chardev \
 exec 100>&-
 
 if wait_for_file $PID_FILE 3; then
-	echo "Error: Chardev TPM did not write pidfile."
+	echo "Error: Socket TPM did not write pidfile."
 	exit 1
 fi
 

--- a/tests/test_ctrlchannel3
+++ b/tests/test_ctrlchannel3
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# For the license, see the LICENSE file in the root directory.
+
+DIR=$(dirname "$0")
+ROOT=${DIR}/..
+TPMDIR=`mktemp -d`
+SWTPM_CTRL_UNIX_PATH=$TPMDIR/sock
+PID_FILE=$TPMDIR/swtpm.pid
+LOG_FILE=$TPMDIR/swtpm.log
+
+source ${DIR}/test_common
+
+trap "cleanup" SIGTERM EXIT
+
+function cleanup()
+{
+	rm -rf $TPMDIR
+	if [ -n "$PID" ]; then
+		kill -SIGTERM $PID 2>/dev/null
+	fi
+}
+
+source ${DIR}/common
+
+if ! [[ "$(uname -o)" =~ Linux ]]; then
+	echo "Need Linux to run UnixIO test for CMD_SET_DATAFD."
+	exit 77
+fi
+
+# Test CMD_SET_DATAFD
+cp ${PWD}/${DIR}/data/tpmstate1/* ${TPMDIR}
+$SWTPM_EXE socket \
+	--flags not-need-init \
+	--ctrl type=unixio,path=$SWTPM_CTRL_UNIX_PATH \
+	--tpmstate dir=$TPMDIR \
+	-t \
+	--pid file=$PID_FILE \
+	--log file=$LOG_FILE,level=20 &
+PID=$!
+
+if wait_for_file $PID_FILE 3; then
+	echo "Error: Socket TPM did not write pidfile."
+	exit 1
+fi
+
+LOG=$(SOCK_PATH=$SWTPM_CTRL_UNIX_PATH exec python $DIR/test_setdatafd.py)
+res=$?
+
+if [ $res -ne 0 ]; then
+	echo "Error: CMD_SET_DATAFD failed: $LOG"
+	exit 1
+fi
+
+echo "OK"
+
+exit 0

--- a/tests/test_ctrlchannel4
+++ b/tests/test_ctrlchannel4
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+# For the license, see the LICENSE file in the root directory.
+
+DIR=$(dirname "$0")
+ROOT=${DIR}/..
+TPMDIR=`mktemp -d`
+SWTPM_CTRL_UNIX_PATH=$TPMDIR/sock
+PID_FILE=$TPMDIR/swtpm.pid
+LOG_FILE=$TPMDIR/swtpm.log
+
+source ${DIR}/test_common
+
+trap "cleanup" SIGTERM EXIT
+
+function cleanup()
+{
+	rm -rf $TPMDIR
+	if [ -n "$PID" ]; then
+		kill -SIGTERM $PID 2>/dev/null
+	fi
+}
+
+SWTPM_INTERFACE=socket+unix
+source ${DIR}/common
+
+# Test 1: test the control channel on the chardev tpm
+
+exec 100<>/dev/ptmx
+$SWTPM_EXE chardev \
+	--fd 100 \
+	--tpmstate dir=$TPMDIR \
+	--pid file=$PID_FILE \
+	--ctrl type=unixio,path=$SWTPM_CTRL_UNIX_PATH \
+	--log file=$LOG_FILE,level=20 &
+
+exec 100>&-
+
+if wait_for_file $PID_FILE 3; then
+	echo "Error: Chardev TPM did not write pidfile."
+	exit 1
+fi
+
+PID="$(cat $PID_FILE)"
+
+# Get the capability bits: CMD_GET_CAPABILITY = 0x00 00 00 01
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x01')"
+exp=" 00 00 00 00 00 00 1f ff"
+if [ "$res" != "$exp" ]; then
+	echo "Error: Unexpected response from CMD_GET_CAPABILITY:"
+	echo "       actual  : $res"
+	echo "       expected: $exp"
+	exit 1
+fi
+
+# Send TPM_Init to the TPM: CMD_INIT = 0x00 00 00 02 + flags
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x02\x00\x00\x00\x00')"
+exp=" 00 00 00 00"
+if [ "$res" != "$exp" ]; then
+	echo "Error: Unexpected response from CMD_INIT:"
+	echo "       actual  : $res"
+	echo "       expected: $exp"
+	exit 1
+fi
+
+# Send unknown command to the TPM
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\xff\xff')"
+exp=" 00 00 00 0a"
+if [ "$res" != "$exp" ]; then
+	echo "Error: Unexpected response from sending unsupported command:"
+	echo "       actual  : $res"
+	echo "       expected: $exp"
+	exit 1
+fi
+
+# Save the volatile state: CMD_STORE_VOLATILE = 0x00 00 00 0a
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x0a')"
+exp=" 00 00 00 00"
+if [ "$res" != "$exp" ]; then
+	echo "Error: Unexpected response from CMD_STORE_VOLATILE:"
+	echo "       actual  : $res"
+	echo "       expected: $exp"
+	exit 1
+fi
+
+if [ ! -r $TPMDIR/tpm-00.volatilestate ]; then
+	echo "Error: Socket TPM: Did not write volatile state file"
+	exit 1
+fi
+
+# Send stop command to the TPM: CMD_STOP = 00 00 00 0e
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x0e')"
+exp=" 00 00 00 00"
+if [ "$res" != "$exp" ]; then
+	echo "Error: Socket TPM: Unexpected response from CMD_STOP:"
+	echo "       actual  : $res"
+	echo "       expected: $exp"
+	exit 1
+fi
+
+# Send get config command to the TPM: CMD_GET_CONFIG = 00 00 00 0f
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x0f')"
+exp=" 00 00 00 00 00 00 00 00"
+if [ "$res" != "$exp" ]; then
+	echo "Error: Socket TPM: Unexpected response from CMD_GET_CONFIG:"
+	echo "       actual  : $res"
+	echo "       expected: $exp"
+	exit 1
+fi
+
+# Send shutdown command to the TPM: CMD_SHUTDOWN = 00 00 00 03
+res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x03')"
+exp=" 00 00 00 00"
+if [ "$res" != "$exp" ]; then
+	echo "Error: Unexpected response from CMD_SHUTDOWN:"
+	echo "       actual  : $res"
+	echo "       expected: $exp"
+	exit 1
+fi
+
+sleep 0.2
+kill -0 $PID 2>/dev/null
+if [ $? -eq 0 ]; then
+	echo "Error: TPM should not be running anymore."
+	exit 1
+fi
+
+if [ -f $PID_FILE ]; then
+	echo "Error: TPM should have removed the PID file."
+	exit 1
+fi
+
+check_logfile_patterns_level_20 $LOG_FILE
+rm -f $LOG_FILE
+
+echo "OK"


### PR DESCRIPTION
Convert and split some ctrlchannel related test cases so more tests can run on Cygwin as well.
Adapt the code related to CMD_SET_DATAFD in case of Cygwin.