### PR TITLE
swtpm: fix segfault introduced in aa3999

### DIFF
--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -114,8 +114,12 @@ int ctrlchannel_get_client_fd(struct ctrlchannel *cc)
 
 int ctrlchannel_set_client_fd(struct ctrlchannel *cc, int fd)
 {
-    int clientfd = cc->clientfd;
+    int clientfd;
 
+    if (!cc)
+        return -1;
+
+    clientfd = cc->clientfd;
     cc->clientfd = fd;
 
     return clientfd;


### PR DESCRIPTION
Changeset aa3999 introduced a segfault when calling
ctrlchannel_set_client_fd() with a NULL pointer. Like all the other
functions, we return with -1 in this case.

Signed-off-by: Stefan Berger <stefanb@linux.vnet.ibm.com>