### PR TITLE
swtpm: Move debugging output into own function

### DIFF
--- a/src/swtpm/swtpm.c
+++ b/src/swtpm/swtpm.c
@@ -399,27 +399,7 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
 
     TPM_DEBUG("main: Initializing TPM at %s", ctime(&start_time));
 
-    TPM_DEBUG("Main: Compiled for %u auth, %u transport, and %u DAA session slots\n",
-           tpmlib_get_tpm_property(TPMPROP_TPM_MIN_AUTH_SESSIONS),
-           tpmlib_get_tpm_property(TPMPROP_TPM_MIN_TRANS_SESSIONS),
-           tpmlib_get_tpm_property(TPMPROP_TPM_MIN_DAA_SESSIONS));
-    TPM_DEBUG("Main: Compiled for %u key slots, %u owner evict slots\n",
-           tpmlib_get_tpm_property(TPMPROP_TPM_KEY_HANDLES),
-           tpmlib_get_tpm_property(TPMPROP_TPM_OWNER_EVICT_KEY_HANDLES));
-    TPM_DEBUG("Main: Compiled for %u counters, %u saved sessions\n",
-           tpmlib_get_tpm_property(TPMPROP_TPM_MIN_COUNTERS),
-           tpmlib_get_tpm_property(TPMPROP_TPM_MIN_SESSION_LIST));
-    TPM_DEBUG("Main: Compiled for %u family, %u delegate table entries\n",
-           tpmlib_get_tpm_property(TPMPROP_TPM_NUM_FAMILY_TABLE_ENTRY_MIN),
-           tpmlib_get_tpm_property(TPMPROP_TPM_NUM_DELEGATE_TABLE_ENTRY_MIN));
-    TPM_DEBUG("Main: Compiled for %u total NV, %u savestate, %u volatile space\n",
-           tpmlib_get_tpm_property(TPMPROP_TPM_MAX_NV_SPACE),
-           tpmlib_get_tpm_property(TPMPROP_TPM_MAX_SAVESTATE_SPACE),
-           tpmlib_get_tpm_property(TPMPROP_TPM_MAX_VOLATILESTATE_SPACE));
-#if 0
-    TPM_DEBUG("Main: Compiled for %u NV defined space\n",
-           tpmlib_get_tpm_property(TPMPROP_TPM_MAX_NV_DEFINED_SIZE));
-#endif
+    tpmlib_debug_libtpms_parameters(TPMLIB_TPM_VERSION_1_2);
 
     if (!need_init_cmd) {
         if ((rc = tpmlib_start(&callbacks, 0)))

--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -430,27 +430,7 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
 
     TPM_DEBUG("main: Initializing TPM at %s", ctime(&start_time));
 
-    TPM_DEBUG("Main: Compiled for %u auth, %u transport, and %u DAA session slots\n",
-           tpmlib_get_tpm_property(TPMPROP_TPM_MIN_AUTH_SESSIONS),
-           tpmlib_get_tpm_property(TPMPROP_TPM_MIN_TRANS_SESSIONS),
-           tpmlib_get_tpm_property(TPMPROP_TPM_MIN_DAA_SESSIONS));
-    TPM_DEBUG("Main: Compiled for %u key slots, %u owner evict slots\n",
-           tpmlib_get_tpm_property(TPMPROP_TPM_KEY_HANDLES),
-           tpmlib_get_tpm_property(TPMPROP_TPM_OWNER_EVICT_KEY_HANDLES));
-    TPM_DEBUG("Main: Compiled for %u counters, %u saved sessions\n",
-           tpmlib_get_tpm_property(TPMPROP_TPM_MIN_COUNTERS),
-           tpmlib_get_tpm_property(TPMPROP_TPM_MIN_SESSION_LIST));
-    TPM_DEBUG("Main: Compiled for %u family, %u delegate table entries\n",
-           tpmlib_get_tpm_property(TPMPROP_TPM_NUM_FAMILY_TABLE_ENTRY_MIN),
-           tpmlib_get_tpm_property(TPMPROP_TPM_NUM_DELEGATE_TABLE_ENTRY_MIN));
-    TPM_DEBUG("Main: Compiled for %u total NV, %u savestate, %u volatile space\n",
-           tpmlib_get_tpm_property(TPMPROP_TPM_MAX_NV_SPACE),
-           tpmlib_get_tpm_property(TPMPROP_TPM_MAX_SAVESTATE_SPACE),
-           tpmlib_get_tpm_property(TPMPROP_TPM_MAX_VOLATILESTATE_SPACE));
-#if 0
-    TPM_DEBUG("Main: Compiled for %u NV defined space\n",
-           tpmlib_get_tpm_property(TPMPROP_TPM_MAX_NV_DEFINED_SIZE));
-#endif
+    tpmlib_debug_libtpms_parameters(TPMLIB_TPM_VERSION_1_2);
 
 #ifdef WITH_VTPM_PROXY
     if (use_vtpm_proxy)

--- a/src/swtpm/utils.c
+++ b/src/swtpm/utils.c
@@ -44,6 +44,8 @@
 
 #include "utils.h"
 #include "logging.h"
+#include "tpmlib.h"
+#include "swtpm_debug.h"
 
 int install_sighandlers(int pipefd[2], sighandler_t handler)
 {
@@ -104,4 +106,39 @@ change_process_owner(const char *user)
         return -12;
     }
     return 0;
+}
+
+void tpmlib_debug_libtpms_parameters(TPMLIB_TPMVersion tpmversion)
+{
+    switch (tpmversion) {
+    case TPMLIB_TPM_VERSION_1_2:
+        TPM_DEBUG("TPM 1.2: Compiled for %u auth, %u transport, "
+                  "and %u DAA session slots\n",
+            tpmlib_get_tpm_property(TPMPROP_TPM_MIN_AUTH_SESSIONS),
+            tpmlib_get_tpm_property(TPMPROP_TPM_MIN_TRANS_SESSIONS),
+            tpmlib_get_tpm_property(TPMPROP_TPM_MIN_DAA_SESSIONS));
+        TPM_DEBUG("TPM 1.2: Compiled for %u key slots, %u owner evict slots\n",
+            tpmlib_get_tpm_property(TPMPROP_TPM_KEY_HANDLES),
+            tpmlib_get_tpm_property(TPMPROP_TPM_OWNER_EVICT_KEY_HANDLES));
+        TPM_DEBUG("TPM 1.2: Compiled for %u counters, %u saved sessions\n",
+           tpmlib_get_tpm_property(TPMPROP_TPM_MIN_COUNTERS),
+           tpmlib_get_tpm_property(TPMPROP_TPM_MIN_SESSION_LIST));
+        TPM_DEBUG("TPM 1.2: Compiled for %u family, "
+                  "%u delegate table entries\n",
+           tpmlib_get_tpm_property(TPMPROP_TPM_NUM_FAMILY_TABLE_ENTRY_MIN),
+           tpmlib_get_tpm_property(TPMPROP_TPM_NUM_DELEGATE_TABLE_ENTRY_MIN));
+        TPM_DEBUG("TPM 1.2: Compiled for %u total NV, %u savestate, "
+                  "%u volatile space\n",
+           tpmlib_get_tpm_property(TPMPROP_TPM_MAX_NV_SPACE),
+           tpmlib_get_tpm_property(TPMPROP_TPM_MAX_SAVESTATE_SPACE),
+           tpmlib_get_tpm_property(TPMPROP_TPM_MAX_VOLATILESTATE_SPACE));
+#if 0
+        TPM_DEBUG("TPM1.2: Compiled for %u NV defined space\n",
+           tpmlib_get_tpm_property(TPMPROP_TPM_MAX_NV_DEFINED_SIZE));
+#endif
+        break;
+    case TPMLIB_TPM_VERSION_2:
+        break;
+    }
+
 }

--- a/src/swtpm/utils.h
+++ b/src/swtpm/utils.h
@@ -39,9 +39,14 @@
 #define _SWTPM_UTILS_H_
 
 #include <signal.h>
+
+#include <libtpms/tpm_library.h>
+
 typedef void (*sighandler_t)(int);
 
 int install_sighandlers(int pipefd[2], sighandler_t handler);
 int change_process_owner(const char *owner);
+
+void tpmlib_debug_libtpms_parameters(TPMLIB_TPMVersion tpmversion);
 
 #endif /* _SWTPM_UTILS_H_ */


### PR DESCRIPTION
Move some of the debugging output into its own function and
differentiate output by TPM Version number.

Signed-off-by: Stefan Berger <stefanb@linux.vnet.ibm.com>