### PR TITLE
Explicitly set python test scripts to use python2

### DIFF
--- a/tests/test_clientfds.py
+++ b/tests/test_clientfds.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import os
 import sys

--- a/tests/test_setdatafd.py
+++ b/tests/test_setdatafd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import os
 import sys


### PR DESCRIPTION
On Linux distributions where python3 is the default python interpreter, the scripts fail to run because they have been written for python2.