### PR TITLE
Make swtpm compileable on older system (one step)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,6 +157,9 @@ AC_CHECK_LIB(tpms,
 )
 AC_SUBST([LIBTPMS_LIBS])
 
+AC_CHECK_LIB(c, clock_gettime, LIBRT_LIBS="", LIBRT_LIBS="-lrt")
+AC_SUBST([LIBRT_LIBS])
+
 AC_PATH_PROG([TPM_NVDEFINE], tpm_nvdefine)
 case $host_os in
 linux-*)

--- a/configure.ac
+++ b/configure.ac
@@ -329,7 +329,7 @@ if test "x$PYTHON" = "x"; then
 	AC_MSG_ERROR([python3 is required])
 fi
 
-TMP="$($CC -fstack-protector-strong 2>&1)"
+TMP="$($CC -fstack-protector-strong $srcdir/include/swtpm/tpm_ioctl.h 2>&1)"
 if echo $TMP | $GREP 'unrecognized command line option' >/dev/null; then
   HARDENING_CFLAGS="-fstack-protector -Wstack-protector "
 else

--- a/src/swtpm/Makefile.am
+++ b/src/swtpm/Makefile.am
@@ -62,7 +62,8 @@ libswtpm_libtpms_la_CFLAGS = \
 
 libswtpm_libtpms_la_LIBADD = \
 	$(LIBTPMS_LIBS) \
-	$(GLIB_LIBS)
+	$(GLIB_LIBS) \
+	$(LIBRT_LIBS)
 
 bin_PROGRAMS = swtpm
 if WITH_CUSE


### PR DESCRIPTION
This series of patches allows swtpm to be compiled on older systems.