### PR TITLE
Integration with Coverall.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
 - cd ..
 - sudo apt-get -y install libfuse-dev libglib2.0-dev libgmp-dev expect libtasn1-dev
   socat findutils tpm-tools gnutls-dev gnutls-bin
+- sudo pip install cpp-coveralls
 addons:
   coverity_scan:
     project:
@@ -28,4 +29,8 @@ addons:
     branch_pattern: coverity_scan
 script: "./autogen.sh --with-openssl --prefix=/usr
   && SWTPM_TEST_EXPENSIVE=1 make -j4 distcheck
-  && sudo make -j4 distcheck"
+  && ./configure --with-openssl --prefix=/usr --enable-test-coverage
+  && sudo make clean
+  && sudo make -j4 check"
+after_success:
+- sudo coveralls --gcov-options '\-lp'

--- a/configure.ac
+++ b/configure.ac
@@ -359,6 +359,14 @@ if test "x$enable_hardening" != "xno"; then
 	AC_SUBST([HARDENING_CFLAGS])
 fi
 
+AC_ARG_ENABLE([test-coverage],
+  AS_HELP_STRING([--enable-test-coverage], [Enable test coverage flags]))
+
+if test "x$enable_test_coverage" = "xyes"; then
+	COVERAGE_CFLAGS="-fprofile-arcs -ftest-coverage"
+	COVERAGE_LDFLAGS="-fprofile-arcs"
+fi
+
 AC_ARG_WITH([tss-user],
             AC_HELP_STRING([--with-tss-user=TSS_USER],
                            [The tss user to use]),
@@ -378,7 +386,9 @@ AC_SUBST([TSS_GROUP])
 CFLAGS="$CFLAGS -Wreturn-type -Wsign-compare -Wswitch-enum"
 CFLAGS="$CFLAGS -Wmissing-prototypes -Wall -Werror"
 CFLAGS="$CFLAGS -Wformat -Wformat-security"
-CFLAGS="$CFLAGS $GNUTLS_CFLAGS"
+CFLAGS="$CFLAGS $GNUTLS_CFLAGS $COVERAGE_CFLAGS"
+
+LDFLAGS="$LDFLAGS $COVERAGE_LDFLAGS"
 
 dnl Simulate the following for systems with pkg-config < 0.28:
 dnl PKG_CHECK_VAR([libtpms_cryptolib], [libtpms], [cryptolib],

--- a/src/swtpm/Makefile.am
+++ b/src/swtpm/Makefile.am
@@ -118,3 +118,5 @@ swtpm_cuse_LDADD = \
 
 AM_CPPFLAGS   = 
 LDADD         = -ltpms
+
+CLEANFILES = *.gcno *.gcda *.gcov

--- a/src/swtpm_bios/Makefile.am
+++ b/src/swtpm_bios/Makefile.am
@@ -18,3 +18,5 @@ swtpm_bios_SOURCES = tpm_bios.c
 
 EXTRA_DIST = \
 	README
+
+CLEANFILES = *.gcno *.gcda *.gcov

--- a/src/swtpm_cert/Makefile.am
+++ b/src/swtpm_cert/Makefile.am
@@ -33,3 +33,5 @@ EXTRA_DIST = \
 	tpm.asn \
 	tpm_asn1.h \
 	README
+
+CLEANFILES = *.gcno *.gcda *.gcov

--- a/src/swtpm_ioctl/Makefile.am
+++ b/src/swtpm_ioctl/Makefile.am
@@ -17,3 +17,5 @@ swtpm_ioctl_CFLAGS = \
 
 EXTRA_DIST = \
 	README
+
+CLEANFILES = *.gcno *.gcda *.gcov

--- a/src/swtpm_setup/Makefile.am
+++ b/src/swtpm_setup/Makefile.am
@@ -21,3 +21,5 @@ install-exec-hook:
 
 EXTRA_DIST = \
 	README
+
+CLEANFILES = *.gcno *.gcda *.gcov


### PR DESCRIPTION
This series of patches enables test coverage with gcc by using the configure option --enable-test-coverage. The test results are uploaded to Coverall.io at the end of a successful Travis run. 