### PR TITLE
swtpm_setup: Leave swtpm_setup.sh ownership to root

### DIFF
--- a/dist/swtpm.spec
+++ b/dist/swtpm.spec
@@ -141,7 +141,7 @@ fi
 %{_bindir}/swtpm_cert
 %endif
 %{_bindir}/swtpm_setup
-%attr( 755, tss , tss)  %{_bindir}/swtpm_setup.sh
+%{_bindir}/swtpm_setup.sh
 %{_bindir}/swtpm_ioctl
 %{_mandir}/man8/swtpm_bios.8*
 %{_mandir}/man8/swtpm_cert.8*

--- a/dist/swtpm.spec.in
+++ b/dist/swtpm.spec.in
@@ -141,7 +141,7 @@ fi
 %{_bindir}/swtpm_cert
 %endif
 %{_bindir}/swtpm_setup
-%attr( 755, @TSS_USER@ , @TSS_GROUP@)  %{_bindir}/swtpm_setup.sh
+%{_bindir}/swtpm_setup.sh
 %{_bindir}/swtpm_ioctl
 %{_mandir}/man8/swtpm_bios.8*
 %{_mandir}/man8/swtpm_cert.8*

--- a/src/swtpm_setup/Makefile.am
+++ b/src/swtpm_setup/Makefile.am
@@ -14,11 +14,6 @@ swtpm_setup_SOURCES = swtpm_setup.c
 
 dist_bin_SCRIPTS = swtpm_setup.sh
 
-install-exec-hook:
-	if test -z $(DESTDIR); then \
-		chown @TSS_USER@:@TSS_GROUP@ $(DESTDIR)$(bindir)/swtpm_setup.sh || true; \
-	fi
-
 EXTRA_DIST = \
 	README
 


### PR DESCRIPTION
swtpm_setup.sh does not need to be owned by tss:tss and in the
Fedora package it's not even allowed. So remove the install hook
that was changing the ownership.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>