### PR TITLE
Enable and test pkcs11 keys to be used for signing TPM certificates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ addons:
         - gnutls-dev
         - gnutls-bin
         - libasan2
+        - softhsm2
   coverity_scan:
     project:
       name: swtpm

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,8 @@ Build-Depends: automake,
 	       gnutls-dev,
 	       libssl-dev,
 	       net-tools,
-	       gawk
+	       gawk,
+	       softhsm2
 # linux-image-extra
 
 Package: swtpm

--- a/dist/swtpm.spec
+++ b/dist/swtpm.spec
@@ -29,6 +29,7 @@ BuildRequires:  openssl-devel
 BuildRequires:  socat
 BuildRequires:  python3
 BuildRequires:  python3-twisted
+BuildRequires:  softhsm2
 BuildRequires:  trousers >= 0.3.9
 BuildRequires:  tpm-tools >= 1.3.8-6
 %if %{with gnutls}

--- a/dist/swtpm.spec.in
+++ b/dist/swtpm.spec.in
@@ -29,6 +29,7 @@ BuildRequires:  openssl-devel
 BuildRequires:  socat
 BuildRequires:  python3
 BuildRequires:  python3-twisted
+BuildRequires:  softhsm2
 BuildRequires:  trousers >= 0.3.9
 BuildRequires:  tpm-tools >= 1.3.8-6
 %if %{with gnutls}

--- a/samples/swtpm-localca.in
+++ b/samples/swtpm-localca.in
@@ -559,7 +559,18 @@ main() {
 	esac
 
 	# TPM keys are GNUTLS URLs...
-	if ! [[ "$SIGNKEY" =~ ^tpmkey:(uuid|file)= ]]; then
+	if [[ "$SIGNKEY" =~ ^tpmkey:(uuid|file)= ]]; then
+		export TSS_TCSD_HOSTNAME=$(get_config_value "$LOCALCA_CONFIG" \
+			"TSS_TCSD_HOSTNAME" "localhost")
+		export TSS_TCSD_PORT=$(get_config_value "$LOCALCA_CONFIG" \
+			"TSS_TCSD_PORT" "30003")
+		logit "CA uses a GnuTLS TPM key; using TSS_TCSD_HOSTNAME=${TSS_TCSD_HOSTNAME}" \
+			"TSS_TCSD_PORT=${TSS_TCSD_PORT}"
+	elif [[ "$SIGNKEY" =~ ^pkcs11: ]]; then
+		export SWTPM_PKCS11_PIN=$(get_config_value "$LOCALCA_CONFIG" \
+			"SWTPM_PKCS11_PIN" "swtpm-tpmca")
+		logit "CA uses a PKCS#11 key; using SWTPM_PKCS11_PIN"
+	else
 		if [ ! -r "$SIGNKEY" ]; then
 			if [ -f "$SIGNKEY" ]; then
 				logerr "Signing key $SIGNKEY exists but cannot access" \
@@ -579,13 +590,6 @@ main() {
 			logerr "Cannot access signing key ${SIGNKEY}."
 			exit 1
 		fi
-	else
-		export TSS_TCSD_HOSTNAME=$(get_config_value "$LOCALCA_CONFIG" \
-			"TSS_TCSD_HOSTNAME" "localhost")
-		export TSS_TCSD_PORT=$(get_config_value "$LOCALCA_CONFIG" \
-			"TSS_TCSD_PORT" "30003")
-		logit "CA uses a GnuTLS TPM key; using TSS_TCSD_HOSTNAME=${TSS_TCSD_HOSTNAME}" \
-			"TSS_TCSD_PORT=${TSS_TCSD_PORT}"
 	fi
 
 	if [ ! -r "$ISSUERCERT" ]; then

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -75,6 +75,7 @@ TESTS += \
 	test_swtpm_cert \
 	test_tpm2_parameters \
 	test_tpm2_samples_swtpm_localca \
+	test_tpm2_samples_swtpm_localca_pkcs11 \
 	test_tpm2_swtpm_cert \
 	test_tpm2_swtpm_cert_ecc \
 	test_tpm2_swtpm_setup_create_cert
@@ -131,6 +132,7 @@ EXTRA_DIST=$(TESTS) \
 	data/tpm2state3b/tpm2-00.volatilestate \
 	data/tpm2state3b/tpm2-00.permall \
 	load_vtpm_proxy \
+	softhsm_setup \
 	test_clientfds.py \
 	test_common \
 	test_cuse \

--- a/tests/softhsm_setup
+++ b/tests/softhsm_setup
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+
+# For the license, see the LICENSE file in the root directory.
+
+# This script does not work with softhsm2 2.0.0 but with >= 2.3.0
+
+if [ -z "$(type -P p11tool)" ]; then
+	echo "Need p11tool from gnutls"
+	exit 77
+fi
+
+if [ -z "$(type -P softhsm2-util)" ]; then
+	echo "Need softhsm2-util from softhsm2 package"
+	exit 77
+fi
+
+MYKEY="
+-----BEGIN PRIVATE KEY-----
+MIIG/gIBADANBgkqhkiG9w0BAQEFAASCBugwggbkAgEAAoIBgQDGjc47VG+btr7L
+2JSAV48n+ciZBYehMqUXhfouMm+b1GIV8WLgv3ndiAqO1tYzvS8fH0EtCbVQIJdN
+1bhqYFPnKoVdVPqdcU0Z7cQbx5bj6lL8IHujM5e1oQsg6SG0uIJ8pbIauYBC+FiD
+HBkvcBmVTi3K3AZtSU0XjBn6WY+pTfnSNS/3OpSZZykaNaW01u11CA4GR771R5Ls
+rDWpULavYTqR7+E4tOqcko9mtfg/7jIamfCKda7MAa9Xy2IE/S+y+JGtwccFYeY4
+i/n4XFJMGVLf0Q3IWMa4ieMJa3yWafs/m13LomENby8+/lKrXFMv2gJ1u28F0TpR
+Rc9/j0M5rYRBVe/7rmQNJrPZn1A7iK/JMTxF3BAQ3OIbdshyeSdfYmKF7zfT3cEW
+3ryvhkVCD9JRrXibQ75EsFDVGRGCGYHDrUFvtkgecuQPBLNOGxaMuUMROTOiUmDp
+DtynkggCCNxL7KupIO5DtsmieqQ+bsIk4pjNPKfwgkd3njcNIgMCAwEAAQKCAYAM
+aNB65MwU71b9ZovheZd46COhbLcNXBz1W2pHeN+A3cVDmdKUOWNkdRwz0TmSAkDv
+sQRhzDmIyICsXK8p9ttHl2C+dJE1Rd+Lv1CCa/cCR6LoHx+bE55nu6j2ZZu1r9J3
+9+MpyG47wUnG5/qq/Fac/kXeZ+H+8pXe4uK8wtw3uKfke26EBSVEcS4gdTnmE4jD
+x70Yp2NH8TE9mYXBD0pbq7f9ZwCsiqIfJwnPYZAibsCy6OwfuzsxhOlwk0WNCkXU
+mmPUuA1d6xbqKIfcFZRz4VymRcyGRtKMxrpEjO8XUbaZC2SReEDXBPiMZ54mnLwr
+wzGC03fsGiPeMkLfqDSJP+Sjro4B/SnsMkNyV9sf2l4jHkseeZiITlU1r+bYCN9q
+R+Lp5p4NM1wb2HR3+qp6WQNKUad1IoOh0CMPBMw6FginvMsUkJv/Fr7WBJLNN90a
+jIhmriOy683Mj9JYP48k1KhtoYiPcjTmiiE4l4+N2kjB5DzjJSWLuRxKhi66gAEC
+gcEA9/1+gujpN0UKUG84nIEZFq4rYkZ21tLRtsrlr33qxBJXNcKvW8EJvXPOsYm/
+1U1u6qgg4xCWvFPyKirF2a/jtqNAzisDTixW++rf4SU175PhMbYvPsWfyPVRXfbQ
+bDBhcpHA5JkLIq73taIhd/hj3hIxLfObpyHvb1d+W2ubzd8vIW/Jagj+SwYwvqbB
+4SmHqIznHbxiZB4CEQB2p7xXosdteBq6piXqN0e6RXLxYOeQV/meC5tqWCMC55bq
+t1J3AoHBAMz3jDkavG6VjpQloRIEMJ4OHwNjajBQZ8gqjKV6V45KxV241KIUMlue
+Z3dx6fJgt708DTJbLFBcSKG4+IcuHGvDZTn30aTPTnt42a7FQtCc7r+0KTrLACl5
+uH0uL4dNTrpbzoS9rXQYNG3zljCbuhPFxu5qwIeCQpAchIcvwcYWJsXmSu/yQNhA
+1IQnZFBG6b2SLMAUKy08U1I0d363OhkEmq8yjfNOvoB+kzF7MIbpyAoZDkuAsop0
+xFXfuErj1QKBwHa+rhZXGlz5tR+gshXWh0Hh8iojnYHt/rctXl/yxjhOo+29JCSm
+QVizHDTMxcuIQWUhTmYLqnHRLHLeelBrNXldoIlX9UQ4XQpRhBQVskbeo4UfPG4t
+SP574RNCPLihTfgDLL8JPVjFOR2C3c3JZWCPi3b6X/zedfz1gy6ZT0h75uB225Xn
+aoRYGX0g8lMzhJ7DoWMOsnpIGCs18psMx1XNcnCBNACcxRLlSJ86k7QYDXjisLfU
+Gk7LrPdhv1A6rwKBwQC1osXbsQq9QMG6HWKQka/30PHA0e+/YvGlW7eJyVIf4bjn
+ZizgeN9re4ObQRKd3QHWq4nSTyOFD1K6Ji3vtXgwM1bYOPnKgH+/QYg+rcaZEgkt
+T12eIVlCaACKxkwOLf8PfN4VmfVFRVHpAgzdhJMwhHrWuzlknJWaGfuDxVmFzgmM
+JJnR6y91tHXfqvzlewIWIZyQlw7wJl58IcynOX49v2vIyBctP2HogsKz/cQyOqgv
+8qZNWH5f3jxDEV/C1gUCgcEA7m9imZn3RIM5J3mqz2JKdbpobh7N9ulCGIOkGDHo
+1oumVO+D1eSObUDE684keyiSyERlnpQuGZjkbF5585cF+gEXWsxxOHKKZC3CiRFK
+fCgMJtm7S4E5V2B+fTnCFwMK4IBFrTagpVVe9/bTABvaqu3TDlAslGyXBS8ilmz6
+1eRfFRe1aXiqpfm8pB0mH5sALS0EjHu87saAyf2vq7BEZA0NJO/QVhZZI/0tFR8B
+ifNpEJG5p2K2AKnYFw6Dt49S
+-----END PRIVATE KEY-----"
+
+NAME=swtpm-test
+PIN=${PIN:-1234}
+SO_PIN=${SO_PIN:-1234}
+
+teardown_softhsm() {
+	local configdir=~/.config/softhsm2
+	local configfile=${configdir}/softhsm2.conf
+	local bakconfigfile=${configfile}.bak
+	local tokendir=${configdir}/tokens
+
+	if [ -f "$bakconfigfile" ]; then
+		mv "$bakconfigfile" "$configfile"
+	else
+		rm -f "$configfile"
+	fi
+	if [ -d "$tokendir" ]; then
+		rm -rf "${tokendir}"
+	fi
+	return 0
+}
+
+setup_softhsm() {
+	local msg tokenuri keyuri
+	local configdir=~/.config/softhsm2
+	local configfile=${configdir}/softhsm2.conf
+	local bakconfigfile=${configfile}.bak
+	local tokendir=${configdir}/tokens
+	local rc
+
+	if ! [ -d $configdir ]; then
+		mkdir -p $configdir
+	fi
+	mkdir -p ${tokendir}
+
+	if [ -f $configfile ]; then
+		mv "$configfile" "$bakconfigfile"
+	fi
+
+	if ! [ -f $configfile ]; then
+		cat <<_EOF_ > $configfile
+directories.tokendir = ${tokendir}
+objectstore.backend = file
+log.level = DEBUG
+slots.removable = false
+_EOF_
+	fi
+
+	msg=$(p11tool --list-tokens 2>&1 | grep "token=${NAME}" | tail -n1)
+	if [ $? -ne 0 ]; then
+		echo "Could not list existing tokens"
+		echo "$msg"
+	fi
+	tokenuri=$(echo "$msg" | sed -n 's/.*URL: \([[:print:]*]\)/\1/p')
+
+	if [ -z "$tokenuri" ]; then
+		msg=$(softhsm2-util \
+			--init-token --pin ${PIN} --so-pin ${SO_PIN} \
+			--free --label ${NAME} 2>&1)
+		if [ $? -ne 0 ]; then
+			echo "Could not initialize token"
+			echo "$msg"
+			return 1
+		fi
+
+		slot=$(echo "$msg" | \
+		       sed -n 's/.* reassigned to slot \([0-9]*\)$/\1/p')
+		if [ -z "$slot" ]; then
+			echo "Could not parse slot number from output."
+			echo "$msg"
+			return 1
+		fi
+
+		msg=$(softhsm2-util \
+			--slot "$slot" --label mykey --id 01 \
+			--import <(echo "${MYKEY}") --pin ${PIN} 2>&1)
+		if [ $? -ne 0 ]; then
+			echo "Could not import key"
+			echo "$msg"
+			return 1
+		fi
+
+	fi
+
+	getkeyuri_softhsm
+	rc=$?
+
+	if [ $rc -ne 0 ]; then
+		teardown_softhsm
+	fi
+
+	return $rc
+}
+
+getkeyuri_softhsm() {
+	local msg tokenuri keyuri
+
+	msg=$(p11tool --list-tokens 2>&1 | grep "token=${NAME}")
+	if [ $? -ne 0 ]; then
+		echo "Could not list existing tokens"
+		echo "$msg"
+		return 1
+	fi
+	tokenuri=$(echo "$msg" | sed -n 's/.*URL: \([[:print:]*]\)/\1/p')
+	if [ -z "$tokenuri" ]; then
+		echo "Could not get token URL"
+		echo "$msg"
+		return 1
+	fi
+	msg=$(p11tool --list-all ${tokenuri} 2>&1)
+	if [ $? -ne 0 ]; then
+		echo "Could not list object under token $tokenuri"
+		echo "$msg"
+		return 1
+	fi
+
+	keyuri=$(echo "$msg" | sed -n 's/.*URL: \([[:print:]*]\)/\1/p')
+	if [ -z "$keyuri" ]; then
+		echo "Could not get key URL"
+		echo "$msg"
+		return 1
+	fi
+	echo "keyuri: $keyuri"
+	return 0
+}
+
+usage() {
+	cat <<_EOF_
+Usage: $0 [command]
+
+Supported commands are:
+
+setup      : Setup the user's account for softhsm and create a
+             token and key with a test configuration
+
+getkeyuri  : Get the key's URL; must be called after setup
+
+teardown   : Remove the temporary softhsm test configuration
+
+_EOF_
+}
+
+main() {
+	local ret
+
+	if [ $# -lt 1 ]; then
+		usage $0
+		echo -e "Missing command.\n\n"
+		return 1
+	fi
+	case "$1" in
+	setup)
+		setup_softhsm
+		ret=$?
+		;;
+	getkeyuri)
+		getkeyuri_softhsm
+		ret=$?
+		;;
+	teardown)
+		teardown_softhsm
+		ret=$?
+		;;
+	*)
+		echo -e "Unsupported command: $1\n\n"
+		usage $0
+		ret=1
+	esac
+	return $ret
+}
+
+main "$@"
+exit $?

--- a/tests/softhsm_setup
+++ b/tests/softhsm_setup
@@ -60,11 +60,33 @@ NAME=swtpm-test
 PIN=${PIN:-1234}
 SO_PIN=${SO_PIN:-1234}
 
+UNAME_S="$(uname -s)"
+
+case "${UNAME_S}" in
+Darwin)
+	msg=$(sudo -v -n)
+	if [ $? -ne 0 ]; then
+		echo "Need password-less sudo rights on OS X to change /etc/gnutls/pkcs11.conf"
+		exit 1
+	fi
+	;;
+esac
+
 teardown_softhsm() {
 	local configdir=~/.config/softhsm2
 	local configfile=${configdir}/softhsm2.conf
 	local bakconfigfile=${configfile}.bak
 	local tokendir=${configdir}/tokens
+
+	case "${UNAME_S}" in
+	Darwin*)
+		if [ -f /etc/gnutls/pkcs11.conf.bak ]; then
+			sudo rm -f /etc/gnutls/pkcs11.conf
+			sudo mv /etc/gnutls/pkcs11.conf.bak \
+			   /etc/gnutls/pkcs11.conf &>/dev/null
+		fi
+		;;
+	esac
 
 	if [ -f "$bakconfigfile" ]; then
 		mv "$bakconfigfile" "$configfile"
@@ -84,6 +106,19 @@ setup_softhsm() {
 	local bakconfigfile=${configfile}.bak
 	local tokendir=${configdir}/tokens
 	local rc
+
+	case "${UNAME_S}" in
+	Darwin*)
+		if [ -f /etc/gnutls/pkcs11.conf.bak ]; then
+			echo "/etc/gnutls/pkcs11.conf.bak already exists; need to 'teardown' first"
+			return 1
+		fi
+		sudo mv /etc/gnutls/pkcs11.conf \
+			/etc/gnutls/pkcs11.conf.bak &>/dev/null
+		SONAME="$(brew ls --verbose softhsm | grep -E "\.so$")"
+		sudo bash -c "echo "load=${SONAME}" > /etc/gnutls/pkcs11.conf"
+		;;
+	esac
 
 	if ! [ -d $configdir ]; then
 		mkdir -p $configdir

--- a/tests/test_tpm2_samples_swtpm_localca_pkcs11
+++ b/tests/test_tpm2_samples_swtpm_localca_pkcs11
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+
+# For the license, see the LICENSE file in the root directory.
+#set -x
+
+TOPBUILD=${abs_top_builddir:-$(dirname "$0")/..}
+TOPSRC=${abs_top_srcdir:-$(dirname "$0")/..}
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+
+SWTPM_LOCALCA=${TOPSRC}/samples/swtpm-localca
+
+workdir=$(mktemp -d)
+
+ek=""
+for ((i = 0; i < 256; i++)); do
+  ek="${ek}$(printf "%02x" $i)"
+done
+
+SIGNINGKEY=${workdir}/signingkey.pem
+ISSUERCERT=${workdir}/issuercert.pem
+CERTSERIAL=${workdir}/certserial
+
+PATH=${TOPBUILD}/src/swtpm_cert:$PATH
+
+trap "cleanup" SIGTERM EXIT
+
+function cleanup()
+{
+	rm -rf ${workdir}
+	${TESTDIR}/softhsm_setup teardown
+}
+
+case "$(uname -s)" in
+Darwin)
+	CERTTOOL=gnutls-certtool;;
+*)
+	CERTTOOL=certtool;;
+esac
+
+unset GNUTLS_PIN
+export PIN="abcdef"
+
+# Generate the PKCS11 token and key; it uses env. variable 'PIN'
+msg=$(${TESTDIR}/softhsm_setup setup 2>&1)
+if [ $? -ne 0 ]; then
+	echo -e "Could not setup softhsm:\n${msg}"
+	echo "softhsm needs to be v2.3.0 or greater and pkcs11 correctly configured"
+	exit 77
+fi
+pkcs11uri=$(echo ${msg} | sed -n 's|^keyuri: \(.*\)|\1|p')
+
+# Now we need to create the root CA ...
+template=${workdir}/template
+
+cakey=${workdir}/swtpm-localca-rootca-privkey.pem
+cacert=${workdir}/swtpm-localca-rootca-cert.pem
+
+# first the private key
+msg=$(${CERTTOOL} \
+	--generate-privkey \
+	--outfile ${cakey} \
+	${passparam} \
+	2>&1)
+if [ $? -ne 0 ]; then
+	echo "Could not create root-CA key ${cakey}."
+	echo "${msg}"
+	exit 1
+fi
+chmod 640 ${cakey}
+
+# now the self-signed certificate
+cat <<_EOF_ >${template}
+cn=swtpm-localca-rootca
+ca
+cert_signing_key
+expiration_days = 3650
+_EOF_
+
+msg=$(${CERTTOOL} \
+	--generate-self-signed \
+	--template ${template} \
+	--outfile ${cacert} \
+	--load-privkey ${cakey} \
+	2>&1)
+if [ $? -ne 0 ]; then
+	echo "Could not create root CA."
+	echo "${msg}"
+	exit 1
+fi
+
+# And now create the intermediate CA with the pkcs11 URI key
+
+pubkey=${workdir}/swtpm-localca-interm-pubkey.pem
+
+msg=$(GNUTLS_PIN=${PIN} ${CERTTOOL} \
+	--load-privkey ${pkcs11uri} \
+	--pubkey-info \
+	--outfile ${pubkey})
+if [ $? -ne 0 ]; then
+	echo "Could not get public key for pkcs11 uri key ($pkcs11uri}."
+	echo "${msg}"
+	exit 1
+fi
+
+cat <<_EOF_ > ${template}
+cn=swtpm-localca
+ca
+cert_signing_key
+expiration_days = 3650
+_EOF_
+
+msg=$(GNUTLS_PIN=${PIN} ${CERTTOOL} \
+	--generate-certificate \
+	--template ${template} \
+	--outfile ${ISSUERCERT} \
+	--load-ca-privkey ${cakey} \
+	--load-ca-certificate ${cacert} \
+	--load-privkey ${pkcs11uri} \
+	--load-pubkey ${pubkey} \
+	2>&1)
+if [ $? -ne 0 ]; then
+	echo "Could not create intermediate CA"
+	echo "${msg}"
+	exit 1
+fi
+
+echo -n 1 > ${CERTSERIAL}
+
+# Now we can create the config files
+cat <<_EOF_ > ${workdir}/swtpm-localca.conf
+statedir = ${workdir}
+signingkey = $(echo ${pkcs11uri} | sed 's|;|\\;|g')
+issuercert = ${ISSUERCERT}
+certserial = ${CERTSERIAL}
+SWTPM_PKCS11_PIN = ${PIN}
+_EOF_
+
+cat <<_EOF_ > ${workdir}/swtpm-localca.options
+--tpm-manufacturer IBM
+--tpm-model swtpm-libtpms
+--tpm-version 2
+--platform-manufacturer Fedora
+--platform-version 2.1
+--platform-model QEMU
+_EOF_
+
+# the following contains the test parameters and
+# expected key usage
+for testparams in \
+	"--allow-signing|Digital signature" \
+	"--allow-signing --decryption|Digital signature,Key encipherment" \
+	"--decryption|Key encipherment" \
+	"|Key encipherment";
+do
+  params=$(echo ${testparams} | cut -d"|" -f1)
+  usage=$(echo ${testparams} | cut -d"|" -f2)
+
+  ${SWTPM_LOCALCA} \
+    --type ek \
+    --ek ${ek} \
+    --dir ${workdir} \
+    --vmid test \
+    --tpm2 \
+    --configfile ${workdir}/swtpm-localca.conf \
+    --optsfile ${workdir}/swtpm-localca.options \
+    --tpm-spec-family 2.0 --tpm-spec-revision 146 --tpm-spec-level 0 \
+    ${params}
+  if [ $? -ne 0 ]; then
+    echo "Error: Test with parameters '$params' failed."
+    exit 1
+  fi
+
+  if [ ! -r ${workdir}/ek.cert ]; then
+    echo "Error: ${workdir}/ek.cert was not created."
+    exit 1
+  fi
+
+  OIFS="$IFS"
+  IFS=","
+
+  for u in $usage; do
+    if [ -z "$(${CERTTOOL} -i \
+                 --inder --infile ${workdir}/ek.cert | \
+                grep "Key Usage" -A2 | \
+                grep "$u")" ]; then
+      echo "Error: Could not find key usage $u in key created " \
+           "with $params."
+    else
+      echo "Found '$u'"
+    fi
+  done
+
+  IFS="$OIFS"
+
+  ${CERTTOOL} \
+    -i \
+    --inder --infile ${workdir}/ek.cert \
+    --outfile ${workdir}/ek.pem
+
+  GNUTLS_PIN=${PIN} ${CERTTOOL} \
+    --verify \
+    --load-ca-certificate ${ISSUERCERT} \
+    --infile ${workdir}/ek.pem
+  if [ $? -ne 0 ]; then
+    echo "Error: Could not verify certificate chain."
+    exit 1
+  fi
+done
+
+exit 0


### PR DESCRIPTION
This series of patches enable the signing of the TPM 1.2 or TPM 2.0 certificates with a key described by its pkcs11 URI.

