### PR TITLE
Make softhsm/pkcs11 test case work on Travis on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,7 @@ matrix:
            CHECK="check"
            LD_LIBRARY_PATH=${PREFIX}/lib:${PREFIX}/lib/swtpm
            RUN_TEST="1"
+           SUDO="sudo"
       os: osx
       compiler: clang
       before_script:
@@ -117,3 +118,5 @@ matrix:
       - brew tap discoteq/discoteq
       - brew install flock
       - brew install socat
+      # To run the pkcs11 test with softhsm we need SUDO (above)
+      - brew install softhsm

--- a/tests/softhsm_setup
+++ b/tests/softhsm_setup
@@ -115,7 +115,14 @@ setup_softhsm() {
 		fi
 		sudo mv /etc/gnutls/pkcs11.conf \
 			/etc/gnutls/pkcs11.conf.bak &>/dev/null
-		SONAME="$(brew ls --verbose softhsm | grep -E "\.so$")"
+		if [ $(id -u) -eq 0 ]; then
+			SONAME="$(sudo -u nobody brew ls --verbose softhsm | \
+				  grep -E "\.so$")"
+		else
+			SONAME="$(brew ls --verbose softhsm | \
+				  grep -E "\.so$")"
+		fi
+		sudo mkdir -p /etc/gnutls &>/dev/null
 		sudo bash -c "echo "load=${SONAME}" > /etc/gnutls/pkcs11.conf"
 		;;
 	esac


### PR DESCRIPTION
We need to run the softhsm/pkcs11 test case as root (sudo) under OS X
so that we can write the file /etc/gnutls/pkcs11.conf. However, once
we run the tests as root we cannot run the 'brew ls' command anymore
since it refuses to run with high privileges. So, if we run as root we
need to use sudo to switch to the nobody user to run the 'brew ls'
command that gives us the name of the softhsm pkcs11 module.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>