### PR TITLE
Travis: Get Travis to submit to Coverity again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,11 @@ addons:
       name: swtpm
       description: Build submitted via Travis CI
     notification_email: stefanb@linux.vnet.ibm.com
-    build_command_prepend: "./autogen.sh --with-openssl; make clean"
-    build_command: make -j4
+    build_command_prepend: "git clone https://github.com/stefanberger/libtpms && cd libtpms && ./autogen.sh --with-openssl --prefix=/usr --with-tpm2 && make -j$(${NPROC:-nproc}) && sudo make install && cd .. && ./autogen.sh --with-openssl"
+    build_command: make -j$(${NPROC:-nproc})
     branch_pattern: coverity_scan
+before_install:
+  - test $TRAVIS_BRANCH != coverity_scan -o ${TRAVIS_JOB_NUMBER##*.} = 1 || exit 0
 script:
   - git clone https://github.com/stefanberger/libtpms
   - cd libtpms

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@
 #       This file is derived from tpm-tool's configure.in.
 #
 
-AC_INIT(swtpm, 0.1.0)
+AC_INIT(swtpm, 0.2.0)
 AC_PREREQ(2.12)
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_HEADER(config.h)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+swtpm (0.2.0~dev1) UNRELEASED; urgency=medium
+
+  -- Stefan Berger <stefanb@linux.ibm.com>  Mon, 04 Feb 2019 14:30:08 -0500
+
 swtpm (0.1.0-1) RELEASED; urgency medium
 
   * Initial public release

--- a/dist/swtpm.spec
+++ b/dist/swtpm.spec
@@ -11,7 +11,7 @@
 
 Summary: TPM Emulator
 Name:           swtpm
-Version:        0.1.0
+Version:        0.2.0
 Release:        0.%{gitdate}git%{gitshortcommit}%{?dist}
 License:        BSD
 Url:            http://github.com/stefanberger/swtpm

--- a/dist/swtpm.spec
+++ b/dist/swtpm.spec
@@ -1,7 +1,7 @@
 %bcond_without gnutls
 
-%global gitdate     20180918
-%global gitcommit   da71c2a1ebec56d81a2b2a09b3e42fa372a791a9
+%global gitdate     20190201
+%global gitcommit   2c25d137f7bbc50b1f6cde191073f465ad7878c3
 %global gitshortcommit  %(c=%{gitcommit}; echo ${c:0:7})
 
 # Macros needed by SELinux
@@ -29,7 +29,7 @@ BuildRequires:  openssl-devel
 BuildRequires:  socat
 BuildRequires:  python3
 BuildRequires:  python3-twisted
-BuildRequires:  softhsm2
+BuildRequires:  softhsm
 BuildRequires:  trousers >= 0.3.9
 BuildRequires:  tpm-tools >= 1.3.8-6
 %if %{with gnutls}
@@ -94,6 +94,8 @@ make %{?_smp_mflags} check
 
 %make_install
 rm -f $RPM_BUILD_ROOT%{_libdir}/%{name}/*.{a,la,so}
+rm -f $RPM_BUILD_ROOT%{_mandir}/man8/swtpm-create-tpmca.8*
+rm -f $RPM_BUILD_ROOT%{_datadir}/%{name}/swtpm-create-tpmca
 
 %post
 for pp in /usr/share/selinux/packages/swtpm.pp \
@@ -161,6 +163,9 @@ fi
 %attr( 755, tss, tss) %{_localstatedir}/lib/swtpm-localca
 
 %changelog
+* Mon Feb 4 2019 Stefan Berger <stefanb@linux.vnet.ibm.com> - 0.1.0.0.20190204git2c25d13
+- v0.1.0 release
+
 * Mon Sep 17 2018 Stefan Berger <stefanb@linux.vnet.ibm.com> - 0.1.0-0.20180918git67d7ea3
 - Created initial version of rpm spec files
 - Version is now 0.1.0

--- a/dist/swtpm.spec.in
+++ b/dist/swtpm.spec.in
@@ -1,7 +1,7 @@
 %bcond_without gnutls
 
-%global gitdate     20180918
-%global gitcommit   da71c2a1ebec56d81a2b2a09b3e42fa372a791a9
+%global gitdate     20190201
+%global gitcommit   2c25d137f7bbc50b1f6cde191073f465ad7878c3
 %global gitshortcommit  %(c=%{gitcommit}; echo ${c:0:7})
 
 # Macros needed by SELinux
@@ -29,7 +29,7 @@ BuildRequires:  openssl-devel
 BuildRequires:  socat
 BuildRequires:  python3
 BuildRequires:  python3-twisted
-BuildRequires:  softhsm2
+BuildRequires:  softhsm
 BuildRequires:  trousers >= 0.3.9
 BuildRequires:  tpm-tools >= 1.3.8-6
 %if %{with gnutls}
@@ -94,6 +94,8 @@ make %{?_smp_mflags} check
 
 %make_install
 rm -f $RPM_BUILD_ROOT%{_libdir}/%{name}/*.{a,la,so}
+rm -f $RPM_BUILD_ROOT%{_mandir}/man8/swtpm-create-tpmca.8*
+rm -f $RPM_BUILD_ROOT%{_datadir}/%{name}/swtpm-create-tpmca
 
 %post
 for pp in /usr/share/selinux/packages/swtpm.pp \
@@ -161,6 +163,9 @@ fi
 %attr( 755, @TSS_USER@, @TSS_GROUP@) %{_localstatedir}/lib/swtpm-localca
 
 %changelog
+* Mon Feb 4 2019 Stefan Berger <stefanb@linux.vnet.ibm.com> - 0.1.0.0.20190204git2c25d13
+- v0.1.0 release
+
 * Mon Sep 17 2018 Stefan Berger <stefanb@linux.vnet.ibm.com> - 0.1.0-0.20180918git67d7ea3
 - Created initial version of rpm spec files
 - Version is now 0.1.0


### PR DESCRIPTION
The extension of the travis.yml with the matrix broke the Coverity
submission. This patch fixes this. We have to build libtpms in
build_command_prepend since before_script now does something different.

We only build in task .1 and exit early on all the other ones if
we are using the coverity_scan git branch.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>