### PR TITLE
swtpm-setup: fallback on $HOME/.config

### DIFF
--- a/samples/swtpm-localca.in
+++ b/samples/swtpm-localca.in
@@ -43,8 +43,23 @@ SETUP_TPM2_F=1
 ALLOW_SIGNING_F=2
 DECRYPTION_F=4
 
-LOCALCA_OPTIONS=${XDG_CONFIG_HOME:-@SYSCONFDIR@}/swtpm-localca.options
-LOCALCA_CONFIG=${XDG_CONFIG_HOME:-@SYSCONFDIR@}/swtpm-localca.conf
+LOCALCA_OPTIONS="swtpm-localca.options"
+if [ -n "$XDG_CONFIG_HOME" ] && [ -r "$XDG_CONFIG_HOME/$LOCALCA_OPTIONS" ]; then
+    LOCALCA_OPTIONS="$XDG_CONFIG_HOME/$LOCALCA_OPTIONS"
+elif [ -n "$HOME" ] && [ -r "$HOME/.config/$LOCALCA_OPTIONS" ]; then
+    LOCALCA_OPTIONS="$HOME/.config/$LOCALCA_OPTIONS"
+else
+    LOCALCA_OPTIONS="@SYSCONFDIR@/$LOCALCA_OPTIONS"
+fi
+
+LOCALCA_CONFIG="swtpm-localca.conf"
+if [ -n "$XDG_CONFIG_HOME" ] && [ -r "$XDG_CONFIG_HOME/$LOCALCA_CONFIG" ]; then
+    LOCALCA_CONFIG="$XDG_CONFIG_HOME/$LOCALCA_CONFIG"
+elif [ -n "$HOME" ] && [ -r "$HOME/.config/$LOCALCA_CONFIG" ]; then
+    LOCALCA_CONFIG="$HOME/.config/$LOCALCA_CONFIG"
+else
+    LOCALCA_CONFIG="@SYSCONFDIR@/$LOCALCA_CONFIG"
+fi
 
 # Default logging goes to stderr
 LOGFILE=""

--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -79,7 +79,15 @@ DEFAULT_OWNER_PASSWORD=ooo
 DEFAULT_SRK_PASSWORD=sss
 
 # default configuration file
-DEFAULT_CONFIG_FILE="${XDG_CONFIG_HOME:-@SYSCONFDIR@}/swtpm_setup.conf"
+SWTPM_SETUP_CONF="swtpm_setup.conf"
+
+if [ -n "$XDG_CONFIG_HOME" ] && [ -r "$XDG_CONFIG_HOME/$SWTPM_SETUP_CONF" ] ; then
+    DEFAULT_CONFIG_FILE="$XDG_CONFIG_HOME/$SWTPM_SETUP_CONF"
+elif [ -n "$HOME" ] && [ -r "$HOME/.config/$SWTPM_SETUP_CONF" ] ; then
+    DEFAULT_CONFIG_FILE="$HOME/.config/$SWTPM_SETUP_CONF"
+else
+    DEFAULT_CONFIG_FILE="@SYSCONFDIR@/$SWTPM_SETUP_CONF"
+fi
 
 #default PCR banks to activate for TPM 2
 DEFAULT_PCR_BANKS="sha1,sha256"


### PR DESCRIPTION
According to the XDG spec,
https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html:
"If $XDG_CONFIG_HOME is either not set or empty, a default equal to
$HOME/.config should be used."

This fixes setting up a TPM with libvirt running in a user session.

When libvirt is running as a system instance, $HOME isn't set, so it
will fall back on @SYSCONFDIR@ (/etc usually)

Signed-off-by: Marc-André Lureau <marcandre.lureau@redhat.com>