### PR TITLE
swtpm: implement uninstall_sighandlers

### DIFF
--- a/src/swtpm/swtpm.c
+++ b/src/swtpm/swtpm.c
@@ -4,7 +4,7 @@
 /*                 Written by Ken Goldman, Stefan Berger                        */
 /*                     IBM Thomas J. Watson Research Center                     */
 /*                                                                              */
-/* (c) Copyright IBM Corporation 2006, 2010, 2016.				*/
+/* (c) Copyright IBM Corporation 2006, 2010, 2016, 2019.			*/
 /*										*/
 /* All rights reserved.								*/
 /* 										*/
@@ -470,7 +470,7 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
 
     rc = mainLoop(&mlp, notify_fd[0]);
 
-    install_sighandlers(notify_fd, NULL);
+    uninstall_sighandlers();
 
 error_no_sighandlers:
     TPMLIB_Terminate();

--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -4,7 +4,7 @@
 /*                 Written by Ken Goldman, Stefan Berger                        */
 /*                     IBM Thomas J. Watson Research Center                     */
 /*                                                                              */
-/* (c) Copyright IBM Corporation 2006, 2010, 2015, 2016.			*/
+/* (c) Copyright IBM Corporation 2006, 2010, 2015, 2016, 2019			*/
 /*										*/
 /* All rights reserved.								*/
 /* 										*/
@@ -504,7 +504,7 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
 
     rc = mainLoop(&mlp, notify_fd[0]);
 
-    install_sighandlers(notify_fd, NULL);
+    uninstall_sighandlers();
 
 error_no_sighandlers:
     TPMLIB_Terminate();

--- a/src/swtpm/utils.c
+++ b/src/swtpm/utils.c
@@ -1,7 +1,7 @@
 /*
  * utils.s -- utilities
  *
- * (c) Copyright IBM Corporation 2014, 2015.
+ * (c) Copyright IBM Corporation 2014, 2015, 2019.
  *
  * Author: Stefan Berger <stefanb@us.ibm.com>
  *
@@ -51,6 +51,15 @@
 #include "tpmlib.h"
 #include "swtpm_debug.h"
 
+void uninstall_sighandlers()
+{
+    if (signal(SIGTERM, SIG_DFL) == SIG_ERR)
+        logprintf(STDERR_FILENO, "Could not uninstall signal handler for SIGTERM.\n");
+
+    if (signal(SIGPIPE, SIG_DFL) == SIG_ERR)
+        logprintf(STDERR_FILENO, "Could not uninstall signal handler for SIGPIPE.\n");
+}
+
 int install_sighandlers(int pipefd[2], sighandler_t handler)
 {
     if (pipe(pipefd) < 0) {
@@ -58,7 +67,7 @@ int install_sighandlers(int pipefd[2], sighandler_t handler)
         goto err_exit;
     }
 
-    if (signal(SIGTERM, (handler != NULL) ? handler : SIG_DFL) == SIG_ERR) {
+    if (signal(SIGTERM, handler) == SIG_ERR) {
         logprintf(STDERR_FILENO, "Could not install signal handler for SIGTERM.\n");
         goto err_close_pipe;
     }

--- a/src/swtpm/utils.h
+++ b/src/swtpm/utils.h
@@ -47,6 +47,7 @@
 typedef void (*sighandler_t)(int);
 
 int install_sighandlers(int pipefd[2], sighandler_t handler);
+void uninstall_sighandlers(void);
 int change_process_owner(const char *owner);
 
 void tpmlib_debug_libtpms_parameters(TPMLIB_TPMVersion);


### PR DESCRIPTION
Implement uninstall sighandlers to uninstall the signal handlers
and not to create another pipe.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>