### PR TITLE
build-sys: Avoid prefix=NONE if no prefix is passed to configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -123,6 +123,9 @@ fi
 if test "$prefix" = "/usr" && test "$localstatedir" = '${prefix}/var'; then
 	localstatedir="/var"
 fi
+if test "x$prefix" = "xNONE"; then
+	prefix="/usr/local"
+fi
 SYSCONFDIR=`eval echo $sysconfdir`
 DATAROOTDIR=`eval echo $datarootdir`
 LOCALSTATEDIR=`eval echo $localstatedir`


### PR DESCRIPTION
If no prefix is passed to the configure line we get prefix=NONE
in evaluations of variables that depend on prefix at this point.
If the user provides no --prefix we assume /usr/local as the
default and override the 'NONE' value we have at this point.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>