### PR TITLE
tests: Add test case running TPM 1.2 test suite

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -39,6 +39,7 @@ TESTS += \
 	test_volatilestate \
 	test_swtpm_bios \
 	test_tpm_probe \
+	test_tpm12 \
 	test_wrongorder
 
 TESTS += \
@@ -132,6 +133,7 @@ EXTRA_DIST=$(TESTS) \
 	data/tpm2state3b/tpm2-00.volatilestate \
 	data/tpm2state3b/tpm2-00.permall \
 	load_vtpm_proxy \
+	patches/lib.patch \
 	softhsm_setup \
 	test_clientfds.py \
 	test_common \

--- a/tests/patches/lib.patch
+++ b/tests/patches/lib.patch
@@ -1,0 +1,88 @@
+Patch for TPM 1.2 test suite to support recent OpenSSL versions.
+--- hmac.c.old	2017-07-28 15:44:50.000000000 -0400
++++ hmac.c	2019-03-28 15:48:46.564254873 -0400
+@@ -3,7 +3,7 @@
+ /*			     	TPM HMAC routines				*/
+ /*			     Written by J. Kravitz				*/
+ /*		       IBM Thomas J. Watson Research Center			*/
+-/*	      $Id: hmac.c 4726 2014-09-03 22:02:10Z kgoldman $			*/
++/*	      $Id: hmac.c 4771 2017-08-31 21:12:33Z kgoldman $			*/
+ /*										*/
+ /* (c) Copyright IBM Corporation 2006, 2010.					*/
+ /*										*/
+@@ -381,16 +381,29 @@
+ /****************************************************************************/
+ uint32_t TSS_rawhmac(unsigned char *digest, const unsigned char *key, unsigned int keylen, ...)
+    {
+-   HMAC_CTX hmac;
++#if OPENSSL_VERSION_NUMBER < 0x10100000
++   HMAC_CTX 	hmac;
++#else
++   HMAC_CTX 	*hmac;
++#endif
+    unsigned int dlen;
+    unsigned char *data;
+    va_list argp;
+    
+-#ifdef HAVE_HMAC_CTX_CLEANUP
++#if OPENSSL_VERSION_NUMBER < 0x10100000
+    HMAC_CTX_init(&hmac);
++#else
++   hmac = HMAC_CTX_new();
+ #endif
+-   HMAC_Init(&hmac,key,keylen,EVP_sha1());
+ 
++#if OPENSSL_VERSION_NUMBER < 0x10100000
++   HMAC_Init(&hmac,key,keylen,EVP_sha1());
++#else
++   HMAC_Init_ex(hmac,
++		key, keylen,		/* HMAC key */
++		EVP_sha1(),		/* message digest method */
++		NULL);
++#endif
+    va_start(argp,keylen);
+    for (;;)
+       {
+@@ -398,14 +411,23 @@
+       if (dlen == 0) break;
+       data = (unsigned char *)va_arg(argp,unsigned char *);
+       if (data == NULL) return ERR_NULL_ARG;
+-      HMAC_Update(&hmac,data,dlen);
++
++#if OPENSSL_VERSION_NUMBER < 0x10100000
++      HMAC_Update(&hmac, data, dlen);
++#else
++      HMAC_Update(hmac, data, dlen);
++#endif
+       }
+-   HMAC_Final(&hmac,digest,&dlen);
++#if OPENSSL_VERSION_NUMBER < 0x10100000
++   HMAC_Final(&hmac, digest, &dlen);
++#else
++   HMAC_Final(hmac, digest, &dlen);
++#endif
+ 
+-#ifdef HAVE_HMAC_CTX_CLEANUP
++#if OPENSSL_VERSION_NUMBER < 0x10100000
+    HMAC_CTX_cleanup(&hmac);
+ #else
+-   HMAC_cleanup(&hmac);
++   HMAC_CTX_free(hmac);
+ #endif
+    va_end(argp);
+    return 0;
+--- keys.c.old	2019-03-28 15:47:22.627805826 -0400
++++ keys.c	2019-03-28 15:48:42.665280466 -0400
+@@ -1316,8 +1316,12 @@
+                 exp);
+    }
+    /* set up the RSA public key structure */
++#if OPENSSL_VERSION_NUMBER < 0x10100000
+    rsa->n = mod;
+    rsa->e = exp;
++#else
++   RSA_set0_key(rsa, mod, exp, NULL);
++#endif
+    return rsa;
+    }
+ 

--- a/tests/test_tpm12
+++ b/tests/test_tpm12
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+if [ ${SWTPM_TEST_EXPENSIVE:-0} -eq 0 ]; then
+	exit 77
+fi
+
+ROOT=${abs_top_builddir:-$(pwd)/..}
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+
+function cleanup() {
+	if [ -n "${SWTPM_PID}" ]; then
+		kill -9 ${SWTPM_PID}
+	fi
+	if [ -n "${SWTPM1_PID}" ]; then
+		kill -9 ${SWTPM1_PID}
+	fi
+	if [ -n ${WORKDIR} ]; then
+		rm -rf ${WORKDIR}
+	fi
+}
+
+trap "cleanup" EXIT
+
+source ${TESTDIR}/common
+
+WORKDIR=$(mktemp -d)
+TESTLOG=${WORKDIR}/test.log
+
+# variables used by the TPM 1.2 test suite
+TPM_SERVER_PORT=65440
+TPM_SERVER_NAME=localhost
+SLAVE_TPM_PORT=65442
+SLAVE_TPM_SERVER=localhost
+
+SWTPM_INTERFACE=socket+socket
+
+# Start main TPM 1.2
+SWTPM_SERVER_PORT=${TPM_SERVER_PORT}
+SWTPM_SERVER_NAME=${TPM_SERVER_NAME}
+SWTPM_CTRL_PORT=65441
+
+mkdir -p ${WORKDIR}/tpm12.1
+SWTPM_SERVER_NO_DISCONNECT="1" run_swtpm ${SWTPM_INTERFACE} \
+	--tpmstate dir=${WORKDIR}/tpm12.1 \
+	--flags not-need-init
+SWTPM1_PID=${SWTPM_PID}
+
+# Start 2nd TPM 1.2
+SWTPM_SERVER_PORT=${SLAVE_TPM_PORT}
+SWTPM_SERVER_NAME=${SLAVE_TPM_SERVER}
+SWTPM_CTRL_PORT=65443
+
+mkdir -p ${WORKDIR}/tpm12.2
+SWTPM_SERVER_NO_DISCONNECT="1" run_swtpm ${SWTPM_INTERFACE} \
+	--tpmstate dir=${WORKDIR}/tpm12.2 \
+	--flags not-need-init
+
+pushd ${WORKDIR} &>/dev/null
+
+curl -sJOL https://sourceforge.net/projects/ibmswtpm/files/tpm4769tar.gz/download
+tar -xzf tpm4769tar.gz
+
+pushd libtpm &>/dev/null
+
+pushd lib &>/dev/null
+patch -p0 < ${TESTDIR}/patches/lib.patch
+popd &>/dev/null
+
+./autogen
+LIBS="" CFLAGS="-g -O2" ./configure
+make -j$(nproc)
+
+pushd utils &>/dev/null
+
+ln -s makeidentity identity
+
+for tst in 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 20 23; do
+    echo "Running test ${tst}"
+    PATH=$PWD:$PATH \
+       TPM_SERVER_PORT=${TPM_SERVER_PORT} TPM_SERVER_NAME=${TPM_SERVER_NAME} \
+       SLAVE_TPM_PORT=${SLAVE_TPM_PORT} SLAVE_TPM_SERVER=${SLAVE_TPM_SERVER} \
+       ./test_console.sh \
+           --non-interactive \
+           ${tst} >> ${TESTLOG}
+    if [ -n "$(grep "ERROR" ${TESTLOG})" ]; then
+        echo "Error occurred!"
+        cat ${TESTLOG}
+        exit 1
+    fi
+done
+
+popd &>/dev/null
+popd &>/dev/null
+
+echo "OK"
+exit 0


### PR DESCRIPTION
Add a test case that downloads the TPM 1.2 package from sourceforge,
patches a few files for OpenSSL compatibility, and runs a few test
cases of that test suite. Look for ERROR output in the test suite.
This test suite also provides better code coverage for libtpms.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>