### PR TITLE
tests: Add yet more tests for TPM 1.2 and enable auditing

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -133,7 +133,7 @@ EXTRA_DIST=$(TESTS) \
 	data/tpm2state3b/tpm2-00.volatilestate \
 	data/tpm2state3b/tpm2-00.permall \
 	load_vtpm_proxy \
-	patches/lib.patch \
+	patches/libtpm.patch \
 	softhsm_setup \
 	test_clientfds.py \
 	test_common \

--- a/tests/patches/libtpm.patch
+++ b/tests/patches/libtpm.patch
@@ -1,6 +1,6 @@
 Patch for TPM 1.2 test suite to support recent OpenSSL versions.
---- hmac.c.old	2017-07-28 15:44:50.000000000 -0400
-+++ hmac.c	2019-03-28 15:48:46.564254873 -0400
+--- lib/hmac.c.old	2017-07-28 15:44:50.000000000 -0400
++++ lib/hmac.c	2019-03-28 15:48:46.564254873 -0400
 @@ -3,7 +3,7 @@
  /*			     	TPM HMAC routines				*/
  /*			     Written by J. Kravitz				*/
@@ -71,8 +71,8 @@ Patch for TPM 1.2 test suite to support recent OpenSSL versions.
  #endif
     va_end(argp);
     return 0;
---- keys.c.old	2019-03-28 15:47:22.627805826 -0400
-+++ keys.c	2019-03-28 15:48:42.665280466 -0400
+--- lib/keys.c.old	2019-03-28 15:47:22.627805826 -0400
++++ lib/keys.c	2019-03-28 15:48:42.665280466 -0400
 @@ -1316,8 +1316,12 @@
                  exp);
     }
@@ -85,4 +85,24 @@ Patch for TPM 1.2 test suite to support recent OpenSSL versions.
 +#endif
     return rsa;
     }
- 
+
+--- utils/test_console.sh.old	2019-03-29 16:34:47.014890971 -0400
++++ utils/test_console.sh	2019-03-29 16:35:16.181691631 -0400
+@@ -61,7 +61,7 @@
+ USE_HWTPM="0"
+ export TPM_SERVER_NAME
+ export TPM_SERVER_PORT
+-export TPM_TRANSPORT="0"
++export TPM_TRANSPORT=${TPM_TRANSPORT:-0}
+ export TPM_TRANSPORT_EK
+ export TPM_TRANSPORT_EKP
+ export TPM_TRANSPORT_SK
+@@ -71,7 +71,7 @@
+ export TPM_TRANSPORT_ENONCE
+ export TPM_TRANSPORT_ENC
+ export LOADKEY_VERSION=""
+-export TPM_AUDITING="0"
++export TPM_AUDITING=${TPM_AUDITING:-0}
+ export TPM_IS_FIPS="0"
+ export TPM_ET_ENCRYPT_AES="0"
+ export NO_SRK_PASSWORD=0

--- a/tests/test_tpm12
+++ b/tests/test_tpm12
@@ -18,7 +18,7 @@ function cleanup() {
 		rm -rf ${WORKDIR}
 	fi
 	# clean up after (interrupted) test suite
-	rm -f /tmp/.key-*-0 /tmp/.delegation-0
+	rm -f /tmp/.key-*-0 /tmp/.delegation-0 /tmp/.transdigest-*-0
 }
 
 trap "cleanup" EXIT
@@ -64,13 +64,11 @@ tar -xzf tpm4769tar.gz
 
 pushd libtpm &>/dev/null
 
-pushd lib &>/dev/null
-patch -p0 < ${TESTDIR}/patches/lib.patch
+patch -p0 < ${TESTDIR}/patches/libtpm.patch
 if [ $? -ne 0 ]; then
 	echo "Error: Patching failed."
 	exit 1
 fi
-popd &>/dev/null
 
 ./autogen
 LIBS="" CFLAGS="-g -O2" ./configure
@@ -78,23 +76,45 @@ make -j$(nproc)
 
 pushd utils &>/dev/null
 
+# variables used by TPM 1.2 tools and test suite
+export TPM_SERVER_PORT=${TPM_SERVER_PORT} \
+    TPM_SERVER_NAME=${TPM_SERVER_NAME} \
+    SLAVE_TPM_PORT=${SLAVE_TPM_PORT} \
+    SLAVE_TPM_SERVER=${SLAVE_TPM_SERVER} \
+    PATH=$PWD:$PATH
+
+if wait_for_serversocket ${TPM_SERVER_PORT} 127.0.0.1 2; then
+	echo "Error: swtpm 1 did not open port ${TPM_SERVER_PORT}"
+	exit 1
+fi
+
+if wait_for_serversocket ${SLAVE_TPM_PORT} 127.0.0.1 2; then
+	echo "Error: swtpm 2 did not open port ${SLAVE_TPM_PORT}"
+	exit 1
+fi
+
+tpmbios
+
 ln -s makeidentity identity
 
 # keep test 1 last due to ERRORs it creates since we do not
 # restart the TPM
-for tst in 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 20 23 2 1; do
+for tst in 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 20 23 25 26 1; do
+
+    TPM_AUDITING=0
+    TPM_TRANSPORT=0
 
     echo "Running test ${tst}"
-    if [[ "${tst}" =~ ^(1|2)$ ]]; then
+    if [[ "${tst}" =~ ^(1)$ ]]; then
         $SWTPM_IOCTL --tcp :65441 -i
+        tpmbios
+    elif [[ "${tst}" = ^25$ ]]; then
+        TPM_AUDITING=1
+        TPM_TRANSPORT=1
     fi
 
-    PATH=$PWD:$PATH \
-       TPM_SERVER_PORT=${TPM_SERVER_PORT} TPM_SERVER_NAME=${TPM_SERVER_NAME} \
-       SLAVE_TPM_PORT=${SLAVE_TPM_PORT} SLAVE_TPM_SERVER=${SLAVE_TPM_SERVER} \
-       ./test_console.sh \
-           --non-interactive \
-           ${tst} >> ${TESTLOG}
+    timeout 40 ./test_console.sh \
+        --non-interactive ${tst} >> ${TESTLOG} </dev/null
     # Ignore all errors that occurred in test 1
     if [ $tst != "1" ] && [ -n "$(grep "ERROR" ${TESTLOG})" ]; then
         echo "Error occurred!"
@@ -103,8 +123,15 @@ for tst in 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 20 23 2 1; do
     fi
 done
 
+$SWTPM_IOCTL --tcp :65441 -s
+wait_process_gone ${SWTPM1_PID} 4
+
+$SWTPM_IOCTL --tcp :65443 -s
+wait_process_gone ${SWTPM_PID} 4
+
 popd &>/dev/null
 popd &>/dev/null
 
 echo "OK"
+
 exit 0


### PR DESCRIPTION
Add test cases 25 and 26 and run test 25 with auditing enabled.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>