### PR TITLE
swtpm: Fix return code of change_process_owner

### DIFF
--- a/src/swtpm/utils.c
+++ b/src/swtpm/utils.c
@@ -95,7 +95,7 @@ change_process_owner(const char *user)
             logprintf(STDERR_FILENO,
                       "Error: User '%s' does not exist.\n",
                       user);
-            return 14;
+            return -14;
         }
 
         if (initgroups(passwd->pw_name, passwd->pw_gid) < 0) {

--- a/tests/test_commandline
+++ b/tests/test_commandline
@@ -140,13 +140,13 @@ if [ $RES -ne 0 ]; then
 	exit 1
 fi
 
-exec 200<>/dev/tcp/localhost/$PORT
+exec 100<>/dev/tcp/localhost/$PORT
 if [ $? -ne 0 ]; then
 	echo "Test 2 failed: Could not connect to TPM"
 	exit 1
 fi
 
-exec 200>&-
+exec 100>&-
 
 wait_port_closed $PORT $PID
 # Give it time to fully shut down


### PR DESCRIPTION
The return code of change_process_owner must be negative.
This patch fixes one occurrence.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>