### PR TITLE
tests: wait for file content in wait_for_file

### DIFF
--- a/tests/common
+++ b/tests/common
@@ -19,8 +19,7 @@ function kill_quiet()
   return $?
 }
 
-# Wait for a regular file to appear; give the process 0.2s to write
-# into the file
+# Wait for a regular file to appear and for it to have > 0 bytes
 #
 # @1: filename
 # @2: timeout in seconds
@@ -32,8 +31,7 @@ function wait_for_file()
   local loops=$((timeout * 10)) loop
 
   for ((loop=0; loop<loops; loop++)); do
-    [ -f "${filename}" ] && {
-      sleep 0.2
+    [ -f "${filename}" ] && [ $(get_filesize ${filename}) != 0 ] && {
       return 1
     }
     sleep 0.1


### PR DESCRIPTION
When the PID_FILE is passed to swtpm as a file descriptor in one test,
we already create a file without content when running
'exec 100<>$PID_FILE'. So we have to extend wait_for_file to also
wait for file content since the 0.2 seconds delay are sometimes not
enough for content to have been written. Otherwise we do not get the
PID of the process. We can extend the function in this way since all
its usages imply that some content should become available.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>