### PR TITLE
swtpm: Fix illegal heap access while parsing options

### DIFF
--- a/src/swtpm/options.c
+++ b/src/swtpm/options.c
@@ -227,13 +227,17 @@ options_parse(char *opts, const OptionDesc optdesc[], char **error)
 
     tok = strtok_r(opts_bak, ",", &saveptr);
     while (tok) {
+        size_t toklen = strlen(tok);
+
         found = false;
         i = 0;
         while (optdesc[i].name) {
             size_t len = strlen(optdesc[i].name);
-            if (tok[len] == '=' &&
+
+            if (toklen > len + 1 && tok[len] == '=' &&
                 !strncmp(optdesc[i].name, tok, len)) {
-                const char *v = &tok[len+1];
+                const char *v = &tok[len + 1];
+
                 if (option_value_add(ovs, optdesc[i], v, error) < 0)
                     goto error;
                 found = true;


### PR DESCRIPTION
Fix an illegal heap access while parsing the options by making
sure that we do not access the tok variable beyond its size
when comparing a character to '=' and later on when accessing
the value after the '='.

This bug was discovered by configuring as follows on Fedora 28:
  CFLAGS="-fsanitize=address -g -ggdb" LIBS="-lasan" \
    ./configure --prefix=/usr

and running tests like this:

  sudo bash -c "SWTPM_TEST_EXPENSIVE=1 make -j32 check"

The test case test_tpm2_ctrlchannel2 indicated the error.

It looks like gcc on Ubuntu Xenial on Travis did not detect this
error.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>