### PR TITLE
Add support for --print-capabilities command line option

### DIFF
--- a/man/man8/swtpm.8
+++ b/man/man8/swtpm.8
@@ -359,6 +359,43 @@ The \fIlog\fR action is only available if libseccomp supports logging.
 .Sp
 This option is only available on Linux and only if swtpm was compiled with
 libseccomp support.
+.IP "\fB\-\-print\-capabilities\fR (since v0.2)" 4
+.IX Item "--print-capabilities (since v0.2)"
+Print capabilities that were added to swtpm after version 0.1. The output
+may contain the following:
+.Sp
+.Vb 9
+\&    {
+\&      "type": "swtpm",
+\&      "features": [
+\&        "cmdarg\-seccomp",
+\&        "cmdarg\-key\-fd",
+\&        "cmdarg\-pwd\-fd",
+\&        "tpm\-send\-command\-header",
+\&      ]
+\&    }
+.Ve
+.Sp
+The meaning of the feature verbs is as follows:
+.RS 4
+.IP "\fBcmdarg-seccomp\fR" 4
+.IX Item "cmdarg-seccomp"
+The \fI\-\-seccomp\fR option is supported.
+.IP "\fBcmdarg-key-fd\fR" 4
+.IX Item "cmdarg-key-fd"
+The \fI\-\-key\fR option supports the \fIfd=\fR parameter.
+.IP "\fBcmdarg-pwd-fd\fR" 4
+.IX Item "cmdarg-pwd-fd"
+The \fI\-\-key\fR option supports the \fIpwdfd=\fR parameter.
+.IP "\fBtpm-send-command-header\fR" 4
+.IX Item "tpm-send-command-header"
+The \s-1TPM 2\s0 commands may be prefixed by a header that carries a 4\-byte
+command, 1 byte for locality, and 4\-byte \s-1TPM 2\s0 command length indicator.
+The \s-1TPM 2\s0 will respond by preprending a 4\-byte response indicator and a
+4\-byte trailer. All data is sent in big endian format.
+.RE
+.RS 4
+.RE
 .IP "\fB\-h|\-\-help\fR" 4
 .IX Item "-h|--help"
 Display usage info.

--- a/man/man8/swtpm.pod
+++ b/man/man8/swtpm.pod
@@ -274,6 +274,46 @@ The I<log> action is only available if libseccomp supports logging.
 This option is only available on Linux and only if swtpm was compiled with
 libseccomp support.
 
+=item B<--print-capabilities> (since v0.2)
+
+Print capabilities that were added to swtpm after version 0.1. The output
+may contain the following:
+
+    {
+      "type": "swtpm",
+      "features": [
+        "cmdarg-seccomp",
+        "cmdarg-key-fd",
+        "cmdarg-pwd-fd",
+        "tpm-send-command-header",
+      ]
+    }
+
+The meaning of the feature verbs is as follows:
+
+=over 4
+
+=item B<cmdarg-seccomp>
+
+The I<--seccomp> option is supported.
+
+=item B<cmdarg-key-fd>
+
+The I<--key> option supports the I<fd=> parameter.
+
+=item B<cmdarg-pwd-fd>
+
+The I<--key> option supports the I<pwdfd=> parameter.
+
+=item B<tpm-send-command-header>
+
+The TPM 2 commands may be prefixed by a header that carries a 4-byte
+command, 1 byte for locality, and 4-byte TPM 2 command length indicator.
+The TPM 2 will respond by preprending a 4-byte response indicator and a
+4-byte trailer. All data is sent in big endian format.
+
+=back
+
 =item B<-h|--help>
 
 Display usage info.

--- a/man/man8/swtpm_cuse.8
+++ b/man/man8/swtpm_cuse.8
@@ -273,6 +273,32 @@ The \fIlog\fR action is only available if libseccomp supports logging.
 .Sp
 This option is only available on Linux and only if swtpm was compiled with
 libseccomp support.
+.IP "\fB\-\-print\-capabilities\fR (since v0.2)" 4
+.IX Item "--print-capabilities (since v0.2)"
+Print capabilities that were added to swtpm after version 0.1. The output
+may contain the following:
+.Sp
+.Vb 7
+\&    {
+\&      "type": "swtpm",
+\&      "features": [
+\&        "cmdarg\-seccomp",
+\&        "cmdarg\-key\-fd"
+\&      ]
+\&    }
+.Ve
+.Sp
+The meaning of the feature verbs is as follows:
+.RS 4
+.IP "\fBcmdarg-seccomp\fR" 4
+.IX Item "cmdarg-seccomp"
+The \fI\-\-seccomp\fR option is supported.
+.IP "\fBcmdarg-key-fd\fR" 4
+.IX Item "cmdarg-key-fd"
+The \fI\-\-key\fR option supports the \fIfd=\fR parameter.
+.RE
+.RS 4
+.RE
 .SH "EXAMPLES"
 .IX Header "EXAMPLES"
 To start the \s-1CUSE TPM\s0 and have it create the character device /dev/foo,

--- a/man/man8/swtpm_cuse.pod
+++ b/man/man8/swtpm_cuse.pod
@@ -154,6 +154,33 @@ The I<log> action is only available if libseccomp supports logging.
 This option is only available on Linux and only if swtpm was compiled with
 libseccomp support.
 
+=item B<--print-capabilities> (since v0.2)
+
+Print capabilities that were added to swtpm after version 0.1. The output
+may contain the following:
+
+    {
+      "type": "swtpm",
+      "features": [
+        "cmdarg-seccomp",
+        "cmdarg-key-fd"
+      ]
+    }
+
+The meaning of the feature verbs is as follows:
+
+=over 4
+
+=item B<cmdarg-seccomp>
+
+The I<--seccomp> option is supported.
+
+=item B<cmdarg-key-fd>
+
+The I<--key> option supports the I<fd=> parameter.
+
+=back
+
 =back
 
 =head1 EXAMPLES

--- a/man/man8/swtpm_setup.8
+++ b/man/man8/swtpm_setup.8
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "swtpm_setup 8"
-.TH swtpm_setup 8 "2019-07-01" "swtpm" ""
+.TH swtpm_setup 8 "2019-07-09" "swtpm" ""
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -277,6 +277,32 @@ A file to copy \s-1TCSD\s0's system_ps_file to. The system_ps_file contains the
 needed by \s-1TCSD\s0 for key related functions.
 .Sp
 This option is only useful with \s-1TPM 1.2\s0 and in if ownership is taken.
+.IP "\fB\-\-print\-capabilities\fR (since v0.2)" 4
+.IX Item "--print-capabilities (since v0.2)"
+Print capabilities that were added to swtpm_setup after version 0.1. The output
+contains the following:
+.Sp
+.Vb 7
+\&    {
+\&      "type": "swtpm_setup",
+\&      "features": [
+\&        "cmdarg\-keyfile\-fd",
+\&        "cmdarg\-pwdfile\-fd"
+\&      ]
+\&    }
+.Ve
+.Sp
+The meaning of the feature verbs is as follows:
+.RS 4
+.IP "\fBcmdarg-key-fd\fR" 4
+.IX Item "cmdarg-key-fd"
+The \fI\-\-keyfile\-fd\fR option is supported.
+.IP "\fBcmdarg-pwd-fd\fR" 4
+.IX Item "cmdarg-pwd-fd"
+The \fI\-\-pwdfile\-fd\fR option is supported.
+.RE
+.RS 4
+.RE
 .IP "\fB\-\-help, \-h\fR" 4
 .IX Item "--help, -h"
 Display the help screen

--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -173,6 +173,33 @@ needed by TCSD for key related functions.
 
 This option is only useful with TPM 1.2 and in if ownership is taken.
 
+=item B<--print-capabilities> (since v0.2)
+
+Print capabilities that were added to swtpm_setup after version 0.1. The output
+contains the following:
+
+    {
+      "type": "swtpm_setup",
+      "features": [
+        "cmdarg-keyfile-fd",
+        "cmdarg-pwdfile-fd"
+      ]
+    }
+
+The meaning of the feature verbs is as follows:
+
+=over 4
+
+=item B<cmdarg-key-fd>
+
+The I<--keyfile-fd> option is supported.
+
+=item B<cmdarg-pwd-fd>
+
+The I<--pwdfile-fd> option is supported.
+
+=back
+
 =item B<--help, -h>
 
 Display the help screen

--- a/src/selinux/swtpm_svirt.te
+++ b/src/selinux/swtpm_svirt.te
@@ -20,7 +20,7 @@ allow svirt_t swtpm_exec_t:file { entrypoint map };
 # libvirt specific rules needed on F28
 allow svirt_t virtd_t:unix_stream_socket { read write getopt getattr accept };
 
-allow svirt_tcg_t virtd_t:fifo_file write;
+allow svirt_tcg_t virtd_t:fifo_file { write read };
 allow svirt_tcg_t virt_var_run_t:sock_file { create setattr };
 allow svirt_tcg_t virt_var_run_t:file { create open read write };
 allow svirt_tcg_t virt_var_run_t:dir { write add_name remove_name };

--- a/src/swtpm/Makefile.am
+++ b/src/swtpm/Makefile.am
@@ -5,6 +5,7 @@
 #
 
 noinst_HEADERS = \
+	capabilities.h \
 	common.h \
 	ctrlchannel.h \
 	key.h \
@@ -32,6 +33,7 @@ privlibdir = $(libdir)/@PACKAGE@
 privlib_LTLIBRARIES = libswtpm_libtpms.la
 
 libswtpm_libtpms_la_SOURCES = \
+	capabilities.c \
 	common.c \
 	ctrlchannel.c \
 	key.c \

--- a/src/swtpm/capabilities.c
+++ b/src/swtpm/capabilities.c
@@ -1,0 +1,84 @@
+/*
+ * capabilities.c -- capabilities
+ *
+ * (c) Copyright IBM Corporation 2019.
+ *
+ * Author: Stefan Berger <stefanb@us.ibm.com>
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the names of the IBM Corporation nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "capabilities.h"
+#include "logging.h"
+
+int capabilities_print_json(bool cusetpm)
+{
+    char *string = NULL;
+    int ret = -1;
+    int n;
+#ifdef WITH_SECCOMP
+    bool with_seccomp = 1;
+#else
+    bool with_seccomp = 0;
+#endif
+
+    n =  asprintf(&string,
+         "{ "
+         "\"type\": \"swtpm\", "
+         "\"features\": [ "
+             "%s%s%s%s"
+          " ] "
+         "}",
+         !cusetpm     ? "\"tpm-send-command-header\", ": "",
+         with_seccomp ? "\"cmdarg-seccomp\", "         : "",
+         true         ? "\"cmdarg-key-fd\", "          : "",
+         true         ? "\"cmdarg-pwd-fd\""            : ""
+    );
+
+    if (n < 0) {
+        logprintf(STDERR_FILENO, "Out of memory\n");
+        goto cleanup;
+    }
+
+    ret = 0;
+
+    fprintf(stdout, "%s\n", string);
+
+cleanup:
+    free(string);
+
+    return ret;
+}

--- a/src/swtpm/capabilities.h
+++ b/src/swtpm/capabilities.h
@@ -1,0 +1,45 @@
+/*
+ * capabilities.h -- capabilities
+ *
+ * (c) Copyright IBM Corporation 2019.
+ *
+ * Author: Stefan Berger <stefanb@us.ibm.com>
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the names of the IBM Corporation nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SWTPM_CAPABILITIES_H
+#define SWTPM_CAPABILITIES_H
+
+#include <stdbool.h>
+
+int capabilities_print_json(bool cusetpm);
+
+#endif /* SWTPM_CAPABILITIES_H */

--- a/src/swtpm/common.c
+++ b/src/swtpm/common.c
@@ -236,6 +236,7 @@ static const OptionDesc flags_opt_desc[] = {
     END_OPTION_DESC
 };
 
+#ifdef WITH_SECCOMP
 static const OptionDesc seccomp_opt_desc[] = {
     {
         .name = "action",
@@ -243,6 +244,7 @@ static const OptionDesc seccomp_opt_desc[] = {
     },
     END_OPTION_DESC
 };
+#endif
 
 /*
  * handle_log_options:
@@ -1195,6 +1197,7 @@ int handle_flags_options(char *options, bool *need_init_cmd)
     return 0;
 }
 
+#ifdef WITH_SECCOMP
 static int parse_seccomp_options(char *options, unsigned int *seccomp_action)
 {
     OptionValues *ovs = NULL;
@@ -1253,3 +1256,4 @@ int handle_seccomp_options(char *options, unsigned int *seccomp_action)
 
     return 0;
 }
+#endif /* WITH_SECCOMP */

--- a/src/swtpm/common.h
+++ b/src/swtpm/common.h
@@ -37,6 +37,8 @@
 #ifndef _SWTPM_COMMON_H_
 #define _SWTPM_COMMON_H_
 
+#include "config.h"
+
 #include <stdbool.h>
 
 int handle_log_options(char *options);
@@ -50,7 +52,15 @@ struct server;
 int handle_server_options(char *options, struct server **s);
 int handle_locality_options(char *options, uint32_t *flags);
 int handle_flags_options(char *options, bool *need_init_cmd);
+#ifdef WITH_SECCOMP
 int handle_seccomp_options(char *options, unsigned int *seccomp_action);
+#else
+static inline int handle_seccomp_options(char *options,
+                                         unsigned int *seccomp_action)
+{
+    return 0;
+}
+#endif
 
 #endif /* _SWTPM_COMMON_H_ */
 

--- a/src/swtpm/ctrlchannel.h
+++ b/src/swtpm/ctrlchannel.h
@@ -40,6 +40,8 @@
 
 #include <stdbool.h>
 
+#include <libtpms/tpm_types.h>
+
 struct ctrlchannel;
 struct libtpms_callbacks;
 struct mainLoopParams;

--- a/src/swtpm/cuse_tpm.c
+++ b/src/swtpm/cuse_tpm.c
@@ -80,6 +80,8 @@
 #include "utils.h"
 #include "threadpool.h"
 #include "seccomp_profile.h"
+#include "options.h"
+#include "capabilities.h"
 
 /* maximum size of request buffer */
 #define TPM_REQ_MAX 4096
@@ -233,6 +235,7 @@ static const char *usage =
 "                    :  Choose the action of the seccomp profile when a\n"
 "                       blacklisted syscall is executed; default is kill\n"
 #endif
+"--print-capabilites : print capabilities and terminate\n"
 "-h|--help           :  display this help screen and terminate\n"
 "\n";
 
@@ -1401,6 +1404,8 @@ int swtpm_cuse_main(int argc, char **argv, const char *prgname, const char *ifac
 #ifdef WITH_SECCOMP
         {"seccomp"       , required_argument, 0, 'S'},
 #endif
+        {"print-capabilities"
+                         ,       no_argument, 0, 'a'},
         {NULL            , 0                , 0, 0  },
     };
     struct cuse_info cinfo;
@@ -1502,6 +1507,9 @@ int swtpm_cuse_main(int argc, char **argv, const char *prgname, const char *ifac
             break;
         case 'h': /* help */
             fprintf(stdout, usage, prgname, iface);
+            goto exit;
+        case 'a':
+            ret = capabilities_print_json(true);
             goto exit;
         case 'v': /* version */
             fprintf(stdout, "TPM emulator CUSE interface version %d.%d.%d, "

--- a/src/swtpm/swtpm.c
+++ b/src/swtpm/swtpm.c
@@ -74,6 +74,8 @@
 #include "sys_dependencies.h"
 #include "osx.h"
 #include "seccomp_profile.h"
+#include "options.h"
+#include "capabilities.h"
 
 /* local variables */
 static int notify_fd[2] = {-1, -1};
@@ -184,6 +186,8 @@ static void usage(FILE *file, const char *prgname, const char *iface)
     "                 : Choose the action of the seccomp profile when a\n"
     "                   blacklisted syscall is executed; default is kill\n"
 #endif
+    "--print-capabilites\n"
+    "                 : print capabilities and terminate\n"
     "-h|--help        : display this help screen and terminate\n"
     "\n",
     prgname, iface);
@@ -202,7 +206,7 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
 {
     TPM_RESULT rc = 0;
     int daemonize = FALSE;
-    int opt, longindex;
+    int opt, longindex, ret;
     struct stat statbuf;
     struct mainLoopParams mlp = {
         .cc = NULL,
@@ -251,6 +255,8 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
 #ifdef WITH_SECCOMP
         {"seccomp"   , required_argument, 0, 'S'},
 #endif
+        {"print-capabilities"
+                     ,       no_argument, 0, 'a'},
         {NULL        , 0                , 0, 0  },
     };
 
@@ -367,6 +373,10 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
         case 'h':
             usage(stdout, prgname, iface);
             exit(EXIT_SUCCESS);
+
+        case 'a':
+            ret = capabilities_print_json(false);
+            exit(ret ? EXIT_FAILURE : EXIT_SUCCESS);
 
         case 'r':
             runas = optarg;

--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -76,6 +76,8 @@
 #include "tpmstate.h"
 #include "osx.h"
 #include "seccomp_profile.h"
+#include "options.h"
+#include "capabilities.h"
 
 /* local variables */
 static int notify_fd[2] = {-1, -1};
@@ -222,7 +224,7 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
 {
     TPM_RESULT rc = 0;
     int daemonize = FALSE;
-    int opt, longindex;
+    int opt, longindex, ret;
     struct stat statbuf;
     struct mainLoopParams mlp = {
         .cc = NULL,
@@ -272,6 +274,8 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
 #ifdef WITH_SECCOMP
         {"seccomp"   , required_argument, 0, 'S'},
 #endif
+        {"print-capabilities"
+                     ,       no_argument, 0, 'a'},
         {NULL        , 0                , 0, 0  },
     };
 
@@ -373,6 +377,10 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
         case 'h':
             usage(stdout, prgname, iface);
             exit(EXIT_SUCCESS);
+
+        case 'a':
+            ret = capabilities_print_json(false);
+            exit(ret ? EXIT_FAILURE : EXIT_SUCCESS);
 
         case 'r':
             runas = optarg;

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -152,6 +152,8 @@ int main(int argc, char *argv[])
             change_user = false;
         } else if (!strcmp("--version", argv[i])) {
             change_user = false;
+        } else if (!strcmp("--print-capabilities", argv[i])) {
+            change_user = false;
         } else if (!strcmp("--tpm2", argv[i])) {
             use_tpm2 = true;
         }

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -218,7 +218,7 @@ int main(int argc, char *argv[])
      * In case of TPM 1.2 we allow running this program as 'tss'
      * (E_USER_ID).
      */
-    if (!use_tpm2) {
+    if (!use_tpm2 && change_user) {
         passwd = getpwnam(E_USER_ID);
         if (!passwd) {
             fprintf(stderr, "Could not get account data of user %s.\n", E_USER_ID);

--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -1974,6 +1974,13 @@ TPM emulator setup tool version @SWTPM_VER_MAJOR@.@SWTPM_VER_MINOR@.@SWTPM_VER_M
 EOF
 }
 
+print_capabilities()
+{
+	echo '{ "type": "swtpm_setup",' \
+		'"features": [ "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd" ]'\
+	'}'
+}
+
 usage()
 {
 	versioninfo
@@ -2134,6 +2141,7 @@ main()
 		--pcr-banks) shift; pcr_banks="${pcr_banks},$1";;
 		--tcsd-system-ps-file) shift; tcsd_system_ps_file="$1";;
 		--version) versioninfo $0; exit 0;;
+		--print-capabilities) print_capabilities; exit 0;;
 		--help|-h|-?) usage $0; exit 0;;
 		*) logerr "Unknown option $1"; usage $0; exit 1;;
 		esac

--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -569,7 +569,10 @@ cleanup()
 	# Make sure they are gone for good
 	stop_tpm 1
 	stop_tcsd 1
-	rm -rf "$TCSD_CONFIG" "$TCSD_DATA_FILE" "$TCSD_DATA_DIR"
+	for f in "$TCSD_CONFIG" "$TCSD_DATA_FILE" "$TCSD_DATA_DIR"; do
+		[ -z "${f}" ] && continue
+		rm -rf "${f}"
+	done
 }
 
 # Read hex data passed to this function via a pipe and convert them to a

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -40,7 +40,9 @@ TESTS += \
 	test_swtpm_bios \
 	test_tpm_probe \
 	test_tpm12 \
-	test_wrongorder
+	test_wrongorder \
+	\
+	test_print_capabilities
 
 TESTS += \
 	test_tpm2_derived_keys \
@@ -149,6 +151,7 @@ EXTRA_DIST=$(TESTS) \
 	_test_locality \
 	_test_migration_key \
 	_test_migration_key_2 \
+	_test_print_capabilities \
 	_test_resume_volatile \
 	_test_save_load_encrypted_state \
 	_test_save_load_state \

--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -31,6 +31,23 @@ if [ "${msg}" != "${exp}" ]; then
 	exit 1
 fi
 
-echo "OK"
+echo "Test 1: OK"
+
+msg="$(${SWTPM_SETUP} --print-capabilities 2>&1)"
+if [ $? -ne 0 ]; then
+	echo "Error: Could not pass --print-capabilities"
+	echo "${msg}"
+	exit 1
+fi
+
+exp='{ "type": "swtpm_setup", "features": [ "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd" ] }'
+if [ "${msg}" != "${exp}" ]; then
+	echo "Unexpected response from ${SWTPM_SETUP} to --print-capabilities:"
+	echo "Actual   : ${msg}"
+	echo "Expected : ${exp}"
+	exit 1
+fi
+
+echo "Test 2: OK"
 
 exit 0

--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# For the license, see the LICENSE file in the root directory.
+#set -x
+
+ROOT=${abs_top_builddir:-$(pwd)/..}
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+
+[ "${SWTPM_IFACE}" == "cuse" ] && source ${TESTDIR}/test_cuse
+source ${TESTDIR}/common
+
+msg="$(${SWTPM_EXE} ${SWTPM_IFACE} --print-capabilities 2>&1)"
+if [ $? -ne 0 ]; then
+	echo "Error: Could not pass --print-capabilities"
+	echo "${msg}"
+	exit 1
+fi
+
+if has_seccomp_support ${SWTPM_EXE}; then
+	seccomp='"cmdarg-seccomp", '
+fi
+if [ "${SWTPM_IFACE}" != "cuse" ]; then
+	noncuse='"tpm-send-command-header", '
+fi
+
+exp='{ "type": "swtpm", "features": [ '${noncuse}${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd" ] }'
+if [ "${msg}" != "${exp}" ]; then
+	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-capabilities:"
+	echo "Actual   : ${msg}"
+	echo "Expected : ${exp}"
+	exit 1
+fi
+
+echo "OK"
+
+exit 0

--- a/tests/common
+++ b/tests/common
@@ -3,6 +3,7 @@ SWTPM=swtpm
 SWTPM_EXE=${SWTPM_EXE:-${ROOT}/src/swtpm/${SWTPM}}
 SWTPM_IOCTL=${SWTPM_IOCTL:-${ROOT}/src/swtpm_ioctl/swtpm_ioctl}
 SWTPM_BIOS=${SWTPM_BIOS:-${ROOT}/src/swtpm_bios/swtpm_bios}
+SWTPM_SETUP=${SWTPM_SETUP:-${ROOT}/src/swtpm_setup/swtpm_setup}
 ECHO=$(type -P echo)
 
 # Note: Do not use file descriptors above 127 due to OpenBSD.

--- a/tests/test_print_capabilities
+++ b/tests/test_print_capabilities
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "$0")"
+
+export SWTPM_IFACE=cuse
+bash _test_print_capabilities
+ret=$?
+[ $ret -ne 0 ] && [ $ret -ne 77 ] && exit $ret
+
+export SWTPM_IFACE=socket
+bash _test_print_capabilities
+ret=$?
+[ $ret -ne 0 ] && [ $ret -ne 77 ] && exit $ret
+
+exit 0


### PR DESCRIPTION
This series of patches adds support for the `--print-capabilities` command line option and addresses issue #143 .