### PR TITLE
Fix swtpm_setup support for passing passphrase via file descriptor

### DIFF
--- a/man/man8/swtpm_setup.8
+++ b/man/man8/swtpm_setup.8
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "swtpm_setup 8"
-.TH swtpm_setup 8 "2019-06-27" "swtpm" ""
+.TH swtpm_setup 8 "2019-07-01" "swtpm" ""
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -231,9 +231,9 @@ The logfile to log to. By default logging goes to stdout and stderr.
 The key file contains an \s-1ASCII\s0 hex key consisting of 32 hex digits with an
 optional leading '0x'. This is the key to be used by the \s-1TPM\s0 emulator
 for encrypting the state of the \s-1TPM.\s0
-.IP "\fB\-\-keyfile <file descriptor\fR>" 4
-.IX Item "--keyfile <file descriptor>"
-Like \fB\-\-keygfile\fR but the key will be read from the file descriptor.
+.IP "\fB\-\-keyfile\-fd <file descriptor\fR>" 4
+.IX Item "--keyfile-fd <file descriptor>"
+Like \fB\-\-keyfile\fR but the key will be read from the file descriptor.
 .IP "\fB\-\-pwdfile <passphrase file\fR>" 4
 .IX Item "--pwdfile <passphrase file>"
 The passphrase file contains a passphrase from which the \s-1TPM\s0 emulator

--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -117,9 +117,9 @@ The key file contains an ASCII hex key consisting of 32 hex digits with an
 optional leading '0x'. This is the key to be used by the TPM emulator
 for encrypting the state of the TPM. 
 
-=item B<--keyfile <file descriptor>>
+=item B<--keyfile-fd <file descriptor>>
 
-Like B<--keygfile> but the key will be read from the file descriptor.
+Like B<--keyfile> but the key will be read from the file descriptor.
 
 =item B<--pwdfile <passphrase file>>
 

--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -873,11 +873,9 @@ init_tpm()
 		logit "Successfully gave up ownership of the TPM."
 
 		# TPM is now disabled and deactivated; enable and activate it
-		stop_tpm 1
-		start_tpm "$SWTPM" "$tpm_state_path"
-
+		output="$($SWTPM_IOCTL --tcp :$((TPM_PORT+1)) -i 2>&1)"
 		if [ $? -ne 0 ]; then
-			logerr "Could not re-start TPM."
+			logerr "Could not re-init TPM."
 			return 1
 		fi
 

--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -882,9 +882,9 @@ init_tpm()
 		fi
 
 		TCSD_TCP_DEVICE_PORT=$TPM_PORT
-		output="$(swtpm_bios -c)"
+		output="$(swtpm_bios -c 2>&1)"
 		if [ $? -ne 0 ]; then
-			logerr "swtpm_bios -c -o failed: $output"
+			logerr "swtpm_bios -c failed: $output"
 			return 1
 		fi
 		logit "Successfully enabled and activated the TPM"

--- a/tests/test_parameters
+++ b/tests/test_parameters
@@ -27,7 +27,13 @@ PARAMETERS=(
 	"--createek --create-ek-cert --create-platform-cert --lock-nvram --config ${TESTDIR}/swtpm_setup.conf --vmid test --display --pwdfile ${TESTDIR}/data/pwdfile.txt"
 	"--createek --create-ek-cert --create-platform-cert --lock-nvram --config ${TESTDIR}/swtpm_setup.conf --vmid test --display --keyfile ${TESTDIR}/data/keyfile256bit.txt --cipher aes-256-cbc"
 	"--createek --create-ek-cert --create-platform-cert --lock-nvram --config ${TESTDIR}/swtpm_setup.conf --vmid test --display --pwdfile ${TESTDIR}/data/pwdfile.txt --cipher aes-256-cbc"
+	"--createek --create-ek-cert --create-platform-cert --lock-nvram --config ${TESTDIR}/swtpm_setup.conf --vmid test --display --keyfile-fd 100 --cipher aes-256-cbc"
+	"--createek --create-ek-cert --create-platform-cert --lock-nvram --config ${TESTDIR}/swtpm_setup.conf --vmid test --display --pwdfile-fd 101 --cipher aes-256-cbc"
 )
+
+# Open read-only file descriptors referenced in test cases
+exec 100<${TESTDIR}/data/keyfile256bit.txt
+exec 101<${TESTDIR}/data/pwdfile.txt
 
 FILESIZES=(
 	1185
@@ -48,6 +54,8 @@ FILESIZES=(
 	1721
 	1788
 	1788
+	1820
+	1820
 	1820
 	1820
 )
@@ -119,5 +127,26 @@ for (( i=0; i<${#PARAMETERS[*]}; i++)); do
 		exit 1
 	fi
 
+	# Make sure the state is encrypted when a key was given.
+	# We expect sequences of 4 0-bytes in unencrypted state
+	# and no such sequences in encrypted state.
+	nullseq="$(cat $TPMDIR/tpm-00.permall | \
+			od -t x1 -A n | tr -d '\n' |
+			grep "00 00 00 00")"
+	if [[ "${PARAMETERS[$i]}" =~ (keyfile|pwdfile) ]]; then
+		if [ -n "${nullseq}" ]; then
+			echo "ERROR: State file is not encrypted with" \
+			     "parameters '${PARAMETERS[$i]}'"
+		fi
+	else
+		if [ -z "${nullseq}" ]; then
+			echo "ERROR: State must not be encrypted with" \
+			     "parameters '${PARAMETERS[$i]}'"
+		fi
+	fi
+
 	echo "SUCCESS with parameters '${PARAMETERS[$i]}'."
 done
+
+exec 100>&-
+exec 101>&-


### PR DESCRIPTION
Fix swtpm_setup support for passing passphrase via file descriptor by not stopping and restarting the TPM 1.2 but instead to use swtpm_ioctl to reinit the TPM 1.2.