### PR TITLE
Add support for handling data channel command prefixes for TPM 2

### DIFF
--- a/src/swtpm/swtpm_io.c
+++ b/src/swtpm/swtpm_io.c
@@ -53,6 +53,9 @@
 #include <errno.h>
 #include <limits.h>
 #include <arpa/inet.h>
+#include <netinet/in.h> /* BSD: sockaddr_in */
+#include <sys/socket.h> /* BSD: accept() */
+#include <sys/select.h> /* BSD: select() */
 
 #include <libtpms/tpm_error.h>
 #include <libtpms/tpm_error.h>

--- a/src/swtpm/swtpm_io.h
+++ b/src/swtpm/swtpm_io.h
@@ -52,8 +52,8 @@ TPM_RESULT SWTPM_IO_Read(TPM_CONNECTION_FD *connection_fd,
                          uint32_t *paramSize,
                          size_t buffer_size);
 TPM_RESULT SWTPM_IO_Write(TPM_CONNECTION_FD *connection_fd,
-                          const unsigned char *buffer,
-                          size_t buffer_length);
+                          const struct iovec *iovec,
+                          int iovcnt);
 TPM_RESULT SWTPM_IO_Disconnect(TPM_CONNECTION_FD *connection_fd);
 TPM_RESULT SWTPM_IO_SetSocketFD(int fd);
 int SWTPM_IO_GetSocketFD(void);

--- a/src/swtpm/tpmlib.h
+++ b/src/swtpm/tpmlib.h
@@ -70,6 +70,9 @@ TPM_RESULT tpmlib_process(unsigned char **rbuffer, uint32_t *rlength,
                           TPM_MODIFIER_INDICATOR *locality,
                           TPMLIB_TPMVersion tpmversion);
 
+off_t tpmlib_handle_tcg_tpm2_cmd_header(const unsigned char *command,
+                                        uint32_t command_length,
+                                        TPM_MODIFIER_INDICATOR *locality);
 
 struct tpm_req_header {
     uint16_t tag;
@@ -82,6 +85,23 @@ struct tpm_resp_header {
     uint32_t size;
     uint32_t errcode;
 } __attribute__((packed));
+
+struct tpm2_send_command_prefix {
+    uint32_t cmd;
+    uint8_t  locality;
+    uint32_t size; /* size of the following TPM request */
+} __attribute__((packed));
+
+struct tpm2_resp_prefix {
+    uint32_t size; /* size of the following TPM response */
+} __attribute__((packed));
+
+/* Commands in tcg_tpm2_cmd_header 'cmd' */
+#define TPM2_SEND_COMMAND   8
+
+/* Tags supported by TPM2 */
+#define TPM2_ST_NO_SESSION             0x8001
+#define TPM2_ST_SESSIONS               0x8002
 
 /* TPM 1.2 ordinals */
 #define TPMLIB_TPM_ORD_TakeOwnership   0x0000000d

--- a/tests/test_tpm2_ibmtss2
+++ b/tests/test_tpm2_ibmtss2
@@ -55,7 +55,6 @@ pushd utils
 sed -i 's/export CRYPTOLIBRARY.*/export CRYPTOLIBRARY=openssl/' reg.sh
 
 export TPM_SERVER_NAME=localhost
-export TPM_SERVER_TYPE=raw
 export TPM_INTERFACE_TYPE=socsim
 export TPM_COMMAND_PORT=${SWTPM_SERVER_PORT}
 export TPM_PLATFORM_PORT=${SWTPM_CTRL_PORT}


### PR DESCRIPTION
This series of patches add support for handling the data channel command prefixes that TCG uses in case of TPM 2.