### PR TITLE
swtpm: Handle EINTR for poll/read/write's

### DIFF
--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -416,9 +416,14 @@ wait_chunk:
         to = timeout.tv_sec * 1000 + timeout.tv_nsec / 1E6;
 
         /* wait for the next chunk */
-        n = poll(&pollfd, 1, to);
-        if (n <= 0)
-            return n;
+        while (true) {
+            n = poll(&pollfd, 1, to);
+            if (n < 0 && errno == EINTR)
+                continue;
+            if (n <= 0)
+                return n;
+            break;
+        }
         /* we should have data now */
     }
     return recvd;

--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -183,7 +183,7 @@ static int ctrlchannel_return_state(ptm_getstate *pgs, int fd)
                      iov[1].iov_base, min(iov[1].iov_len, 1024));
     }
 
-    n = writev(fd, iov, iovcnt);
+    n = writev_full(fd, iov, iovcnt);
     if (n < 0) {
         logprintf(STDERR_FILENO,
                   "Error: Could not send response: %s\n", strerror(errno));
@@ -247,7 +247,7 @@ static int ctrlchannel_receive_state(ptm_setstate *pss, ssize_t n, int fd)
 
 err_send_resp:
     pss->u.resp.tpm_result = htobe32(res);
-    n = write(fd, pss, sizeof(pss->u.resp.tpm_result));
+    n = write_full(fd, pss, sizeof(pss->u.resp.tpm_result));
     if (n < 0) {
         logprintf(STDERR_FILENO,
                   "Error: Could not send response: %s\n", strerror(errno));
@@ -864,15 +864,10 @@ int ctrlchannel_process_fd(int fd,
 send_resp:
     TPM_PrintAll(" Ctrl Rsp:", " ", output.body, min(out_len, 1024));
 
-    n = write(fd, output.body, out_len);
+    n = write_full(fd, output.body, out_len);
     if (n < 0) {
         logprintf(STDERR_FILENO,
                   "Error: Could not send response: %s\n", strerror(errno));
-        close(fd);
-        fd = -1;
-    } else if ((size_t)n != out_len) {
-        logprintf(STDERR_FILENO,
-                  "Error: Could not send complete response\n");
         close(fd);
         fd = -1;
     }

--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -227,7 +227,7 @@ static int ctrlchannel_receive_state(ptm_setstate *pss, ssize_t n, int fd)
         offset += n;
         remain -= n;
         if (remain) {
-            n = read(fd, pss->u.req.data, sizeof(pss->u.req.data));
+            n = read_eintr(fd, pss->u.req.data, sizeof(pss->u.req.data));
             if (n < 0) {
                 res = TPM_IOERROR;
                 close(fd);
@@ -341,7 +341,7 @@ static ssize_t ctrlchannel_recv_cmd(int fd,
                 msg->msg_iov[0].iov_len > buffer_len)
                 return -1;
         } else
-            n = read(fd, msg->msg_iov[0].iov_base + recvd, buffer_len - recvd);
+            n = read_eintr(fd, msg->msg_iov[0].iov_base + recvd, buffer_len - recvd);
         if (n <= 0)
             return n;
         recvd += n;
@@ -677,7 +677,7 @@ int ctrlchannel_process_fd(int fd,
             if (!remain)
                 break;
 
-            n = read(fd, &data->u.req.data, sizeof(data->u.req.data));
+            n = read_eintr(fd, &data->u.req.data, sizeof(data->u.req.data));
             if (n <= 0) {
                 res = TPM_IOERROR;
                 break;

--- a/src/swtpm/key.c
+++ b/src/swtpm/key.c
@@ -51,6 +51,7 @@
 
 #include "key.h"
 #include "logging.h"
+#include "utils.h"
 
 /*
  * key_format_from_string:
@@ -212,7 +213,7 @@ key_load_key_fd(int fd, enum key_format keyformat,
     char filebuffer[2 + 256/4 + 1 + 1];
     ssize_t len;
 
-    len = read(fd, filebuffer, sizeof(filebuffer) - 1);
+    len = read_eintr(fd, filebuffer, sizeof(filebuffer) - 1);
     if (len < 0) {
         logprintf(STDERR_FILENO, "Unable to read key: %s\n",
                   strerror(errno));
@@ -316,7 +317,7 @@ key_from_pwdfile_fd(int fd, unsigned char *key, size_t *keylen,
             goto exit;
         }
 
-        len = read(fd, &filebuffer[offset], filelen - offset);
+        len = read_eintr(fd, &filebuffer[offset], filelen - offset);
         if (len < 0) {
             logprintf(STDERR_FILENO,
                       "Unable to read passphrase: %s\n",

--- a/src/swtpm/logging.c
+++ b/src/swtpm/logging.c
@@ -51,6 +51,7 @@
 #include <stdbool.h>
 
 #include "logging.h"
+#include "utils.h"
 
 #include <libtpms/tpm_library.h>
 
@@ -245,12 +246,12 @@ static int _logprintf(int fd, const char *format, va_list ap, bool check_indent)
 
     if (!check_indent || log_check_string(buf) >= 0) {
         if (log_prefix) {
-            ret = write(fd, log_prefix, strlen(log_prefix));
+            ret = write_full(fd, log_prefix, strlen(log_prefix));
             if (ret < 0)
                 goto err_exit;
             len = ret;
         }
-        ret = write(fd, buf, strlen(buf));
+        ret = write_full(fd, buf, strlen(buf));
         if (ret < 0)
             goto err_exit;
         ret += len;

--- a/src/swtpm/utils.c
+++ b/src/swtpm/utils.c
@@ -304,3 +304,28 @@ ssize_t writev_full(int fd, const struct iovec *iov, int iovcnt)
 
     return n;
 }
+
+/*
+ * read_einter: Read bytes from a file descriptor into a buffer
+ *              and handle EINTR. Perform one read().
+ *
+ * @fd: file descriptor to read from
+ * @buffer: buffer
+ * @buflen: length of buffer
+ *
+ * Returns -1 in case an error occurred, number of bytes read otherwise.
+ */
+ssize_t read_eintr(int fd, void *buffer, size_t buflen)
+{
+    ssize_t n;
+
+    while (true) {
+        n = read(fd, buffer, buflen);
+        if (n < 0) {
+            if (errno == EINTR)
+                continue;
+            return -1;
+        }
+        return n;
+    }
+}

--- a/src/swtpm/utils.c
+++ b/src/swtpm/utils.c
@@ -221,3 +221,86 @@ char *fd_to_filename(int fd)
 
 #endif
 }
+
+/*
+ * write_full: Write all bytes of a buffer into the file descriptor
+ *             and handle partial writes on the way.
+ *
+ * @fd: file descriptor to write to
+ * @buffer: buffer
+ * @buflen: length of buffer
+ *
+ * Returns -1 in case not all bytes could be transferred, number of
+ * bytes written otherwise (must be equal to buflen).
+ */
+ssize_t write_full(int fd, const void *buffer, size_t buflen)
+{
+    size_t written = 0;
+    ssize_t n;
+
+    while (written < buflen) {
+        n = write(fd, buffer, buflen - written);
+        if (n == 0)
+            return -1;
+        if (n < 0) {
+            if (errno == EINTR)
+                continue;
+            return -1;
+        }
+        written += n;
+        buffer += n;
+    }
+    return written;
+}
+
+/*
+ * writev_full: Write all bytes of an iovec into the file descriptor
+ *              and handle partial writes on the way.
+ * @fd: file descriptor to write to
+ * @iov: pointer to iov
+ * @iovcnt: length of iov array
+ *
+ * Returns -1 in case not all bytes could be transferred, number of
+ * bytes written otherwise (must be equal to buflen).
+ */
+ssize_t writev_full(int fd, const struct iovec *iov, int iovcnt)
+{
+    int i;
+    size_t off;
+    unsigned char *buf;
+    ssize_t n;
+    size_t bytecount = 0;
+    size_t numbufs = 0;
+    size_t lastidx = -1;
+
+    for (i = 0; i < iovcnt; i++) {
+        if (iov[i].iov_len) {
+            bytecount += iov[i].iov_len;
+            numbufs++;
+            lastidx = i;
+        }
+    }
+
+    if (numbufs == 1)
+        return write_full(fd, iov[lastidx].iov_base, iov[lastidx].iov_len);
+
+    buf = malloc(bytecount);
+    if (!buf) {
+        errno = ENOMEM;
+        return -1;
+    }
+
+    off = 0;
+    for (i = 0; i < iovcnt; i++) {
+        if (!iov[i].iov_len)
+            continue;
+        memcpy(&buf[off], iov[i].iov_base, iov[i].iov_len);
+        off += iov[i].iov_len;
+    }
+
+    n = write_full(fd, buf, off);
+
+    free(buf);
+
+    return n;
+}

--- a/src/swtpm/utils.h
+++ b/src/swtpm/utils.h
@@ -61,4 +61,6 @@ char *fd_to_filename(int fd);
 ssize_t write_full(int fd, const void *buffer, size_t buflen);
 ssize_t writev_full(int fd, const struct iovec *iov, int iovcnt);
 
+ssize_t read_eintr(int fd, void *buffer, size_t buflen);
+
 #endif /* _SWTPM_UTILS_H_ */

--- a/src/swtpm/utils.h
+++ b/src/swtpm/utils.h
@@ -41,6 +41,7 @@
 #include "config.h"
 
 #include <signal.h>
+#include <sys/uio.h>
 
 #include <libtpms/tpm_library.h>
 
@@ -56,5 +57,8 @@ int change_process_owner(const char *owner);
 void tpmlib_debug_libtpms_parameters(TPMLIB_TPMVersion);
 
 char *fd_to_filename(int fd);
+
+ssize_t write_full(int fd, const void *buffer, size_t buflen);
+ssize_t writev_full(int fd, const struct iovec *iov, int iovcnt);
 
 #endif /* _SWTPM_UTILS_H_ */

--- a/tests/common
+++ b/tests/common
@@ -718,3 +718,19 @@ function check_seccomp_profile()
 	fi
 	return 0
 }
+
+# Validate the content of the pid file
+# @1: Expected PID
+# @2: pid file filename
+function validate_pidfile()
+{
+	local pid="$1"
+	local pidfile="$2"
+
+	if [ "$PID" != "$(cat $PID_FILE)" ]; then
+		echo "Error: pid file contains unexpected PID value."
+		echo "expected: $pid"
+		echo "actual  : $(cat $pidfile)"
+		exit 1
+	fi
+}

--- a/tests/test_ctrlchannel
+++ b/tests/test_ctrlchannel
@@ -82,7 +82,7 @@ $SWTPM_EXE socket \
 	--ctrl type=unixio,path=$SWTPM_CTRL_UNIX_PATH,mode=${FILEMODE}${FOWNER} \
 	--log file=$LOG_FILE,level=20 \
 	$RUNAS &
-
+PID=$!
 exec 100>&-
 exec 101>&-
 
@@ -91,7 +91,7 @@ if wait_for_file $PID_FILE 3; then
 	exit 1
 fi
 
-PID="$(cat $PID_FILE)"
+validate_pidfile $PID $PID_FILE
 
 # Get the capability bits: CMD_GET_CAPABILITY = 0x00 00 00 01
 res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x01')"
@@ -219,6 +219,7 @@ run_swtpm ${SWTPM_INTERFACE} \
 	--pid file=$PID_FILE \
 	--log file=$LOG_FILE \
 	$RUNAS
+PID=$SWTPM_PID
 
 if wait_for_file ${PID_FILE} 4; then
 	echo "Error: Socket TPM did not write pidfile."
@@ -226,7 +227,7 @@ if wait_for_file ${PID_FILE} 4; then
 	exit 1
 fi
 
-PID="$(cat $PID_FILE)"
+validate_pidfile $PID $PID_FILE
 
 swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 
@@ -456,13 +457,14 @@ run_swtpm ${SWTPM_INTERFACE} \
 	--key pwdfile=${TESTDIR}/data/tpmstate2/pwdfile.txt,kdf=sha512 \
 	--log file=$LOG_FILE,level=20 \
 	--flags not-need-init
+PID=$SWTPM_PID
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: Socket TPM did not write pidfile."
 	exit 1
 fi
 
-PID="$(cat $PID_FILE)"
+validate_pidfile $PID $PID_FILE
 
 # Read PCR 10
 swtpm_open_cmddev ${SWTPM_INTERFACE} 100
@@ -521,13 +523,14 @@ run_swtpm ${SWTPM_INTERFACE} \
 	--key pwdfile=${TESTDIR}/data/tpmstate2/pwdfile.txt,kdf=sha512 \
 	--log file=$LOG_FILE \
 	--flags not-need-init
+PID=$SWTPM_PID
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: Socket TPM did not write pidfile."
 	exit 1
 fi
 
-PID="$(cat $PID_FILE)"
+validate_pidfile $PID $PID_FILE
 
 # Read PCR 10 -- this should fail now
 swtpm_open_cmddev ${SWTPM_INTERFACE} 100

--- a/tests/test_ctrlchannel2
+++ b/tests/test_ctrlchannel2
@@ -32,14 +32,14 @@ function cleanup()
 # use a pseudo terminal
 exec 100<>/dev/ptmx
 $SWTPM_EXE chardev --fd 100 --tpmstate dir=$TPMDIR --pid file=$PID_FILE --ctrl type=unixio,path=$SOCK_PATH &
+PID=$!
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: Chardev TPM did not write pidfile."
 	exit 1
 fi
 
-PID="$(cat $PID_FILE)"
-
+validate_pidfile $PID $PID_FILE
 
 # Get the capability bits: CMD_GET_CAPABILITY = 0x00 00 00 01
 act=$($SWTPM_IOCTL --unix $SOCK_PATH -c 2>&1)
@@ -130,13 +130,14 @@ $SWTPM_EXE socket \
 	--tpmstate dir=$TPMDIR \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH &
+PID=$!
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: Socket TPM did not write pidfile."
 	exit 1
 fi
 
-PID="$(cat $PID_FILE)"
+validate_pidfile $PID $PID_FILE
 
 # Get the capability bits: CMD_GET_CAPABILITY = 0x00 00 00 01
 act=$($SWTPM_IOCTL --unix $SOCK_PATH -c 2>&1)
@@ -316,14 +317,14 @@ $SWTPM_EXE socket \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--key pwdfile=${TESTDIR}/data/tpmstate2/pwdfile.txt,kdf=sha512 \
 	--flags not-need-init &
+PID=$!
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: Socket TPM did not write pidfile."
 	exit 1
 fi
 
-PID="$(cat $PID_FILE)"
-
+validate_pidfile $PID $PID_FILE
 
 # Read PCR 10
 exec 100<>/dev/tcp/localhost/65431
@@ -372,14 +373,14 @@ $SWTPM_EXE socket \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--key pwdfile=${TESTDIR}/data/tpmstate2/pwdfile.txt,kdf=sha512 \
 	--flags not-need-init &
+PID=$!
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: Socket TPM did not write pidfile."
 	exit 1
 fi
 
-PID="$(cat $PID_FILE)"
-
+validate_pidfile $PID $PID_FILE
 
 # Read PCR 10 -- this should fail now
 exec 100<>/dev/tcp/localhost/65431

--- a/tests/test_tpm2_ctrlchannel2
+++ b/tests/test_tpm2_ctrlchannel2
@@ -44,13 +44,14 @@ $SWTPM_EXE chardev \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH,mode=${FILEMODE}${FOWNER} \
 	--tpm2 &
+PID=$!
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: Chardev TPM did not write pidfile."
 	exit 1
 fi
 
-PID="$(cat $PID_FILE)"
+validate_pidfile $PID $PID_FILE
 
 # Get the capability bits: CMD_GET_CAPABILITY = 0x00 00 00 01
 act=$($SWTPM_IOCTL --unix $SOCK_PATH -c 2>&1)
@@ -151,13 +152,14 @@ $SWTPM_EXE socket \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--log file=$LOGFILE,level=20 \
 	--tpm2 &
+PID=$!
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: Socket TPM did not write pidfile."
 	exit 1
 fi
 
-PID="$(cat $PID_FILE)"
+validate_pidfile $PID $PID_FILE
 
 exec 100<>/dev/tcp/localhost/65532
 
@@ -346,13 +348,14 @@ $SWTPM_EXE socket \
 	--key pwdfile=${TESTDIR}/data/tpm2state2/pwdfile.txt,kdf=sha512 \
 	--tpm2 \
 	--flags not-need-init &
+PID=$!
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: Socket TPM did not write pidfile."
 	exit 1
 fi
 
-PID="$(cat $PID_FILE)"
+vaidate_pidfile $PID $PID_FILE
 
 # Read PCR 10
 exec 100<>/dev/tcp/localhost/65532
@@ -403,13 +406,14 @@ $SWTPM_EXE socket \
 	--key pwdfile=${TESTDIR}/data/tpm2state2/pwdfile.txt,kdf=sha512 \
 	--tpm2 \
 	--flags not-need-init &
+PID=$!
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: Socket TPM did not write pidfile."
 	exit 1
 fi
 
-PID="$(cat $PID_FILE)"
+validate_pidfile $PID $PID_FILE
 
 # Read PCR 10 -- this should fail now
 exec 100<>/dev/tcp/localhost/65532


### PR DESCRIPTION
Only some places for poll and read are handling the EINTR correctly
so far. Fix this now for the rest of poll/read/write's in use.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>