### PR TITLE
Travis: Only clone libtpms if libtpms dir does not exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ addons:
 before_install:
   - test $TRAVIS_BRANCH != coverity_scan -o ${TRAVIS_JOB_NUMBER##*.} = 1 || exit 0
 script:
-  - git clone https://github.com/stefanberger/libtpms
+  - if [ ! -d libtpms ]; then git clone https://github.com/stefanberger/libtpms; fi
   - cd libtpms
   - CFLAGS="${LIBTPMS_CFLAGS:--g -O2}" LDFLAGS="${LIBTPMS_LDFLAGS}"
        ./autogen.sh --with-openssl --prefix=${LIBTPMS_PREFIX:-/usr} --with-tpm2


### PR DESCRIPTION
Only build the libtpms dir if it doesn't exist. When we do a Coverity
scan build it looks like we are now running the script afterwards as
well and this creates a build failure due to the 2nd clone.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>