### PR TITLE
Fix a bug when using --vtpm-proxy and extend SELinux policy for F30

### DIFF
--- a/src/selinux/swtpm_svirt.te
+++ b/src/selinux/swtpm_svirt.te
@@ -19,6 +19,10 @@ allow svirt_t user_tmp_t:sock_file { create setattr };
 allow svirt_t swtpm_exec_t:file { entrypoint map };
 # libvirt specific rules needed on F28
 allow svirt_t virtd_t:unix_stream_socket { read write getopt getattr accept };
+# virt_var_run_t rules needed on F30
+allow svirt_t virt_var_run_t:dir { add_name remove_name write };
+allow svirt_t virt_var_run_t:file { create getattr open read unlink write };
+allow svirt_t virt_var_run_t:sock_file { create setattr };
 
 allow svirt_tcg_t virtd_t:fifo_file { write read };
 allow svirt_tcg_t virt_var_run_t:sock_file { create setattr };

--- a/src/swtpm/swtpm_io.c
+++ b/src/swtpm/swtpm_io.c
@@ -66,6 +66,7 @@
 #include "swtpm_debug.h"
 #include "swtpm_io.h"
 #include "tpmlib.h"
+#include "utils.h"
 
 /*
   global variables
@@ -225,7 +226,7 @@ TPM_RESULT SWTPM_IO_Write(TPM_CONNECTION_FD *connection_fd,       /* read/write 
     for (i = 0; i < iovcnt; i++)
         totlen += iovec[i].iov_len;
 
-    nwritten = writev(connection_fd->fd, iovec, iovcnt);
+    nwritten = writev_full(connection_fd->fd, iovec, iovcnt);
     if (nwritten < 0) {
         logprintf(STDERR_FILENO, "SWTPM_IO_Write: Error, writev() %d %s\n",
                   errno, strerror(errno));


### PR DESCRIPTION
There was an EIO error occurring when using 'swtpm chardev --vtpm-proxy' due to the `writev()`, which does not seem to work with a chardev.

Also Fedora 30 needs more SELinux rules.