### PR TITLE
swtpm: Fix typo in error report: HMAC instead of hash

### DIFF
--- a/src/swtpm/swtpm_nvfile.c
+++ b/src/swtpm/swtpm_nvfile.c
@@ -932,7 +932,7 @@ SWTPM_CheckHMAC(tlv_data *hmac, tlv_data *encrypted_data,
     }
 
     if (memcmp(hmac->u.ptr, md, md_len)) {
-        logprintf(STDOUT_FILENO, "Verification of hash failed. "
+        logprintf(STDOUT_FILENO, "Verification of HMAC failed. "
                   "Data integrity is compromised\n");
         /* TPM_DECRYPT_ERROR indicates (to libtpms) that something
            exists but we have the wrong key. */


### PR DESCRIPTION
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>