### PR TITLE
tests: Skip seccomp check if env. sets up seccomp profile

### DIFF
--- a/tests/common
+++ b/tests/common
@@ -707,6 +707,15 @@ function check_seccomp_profile()
 		return 0
 	fi
 
+	tmp=$(grep -E "^Seccomp" /proc/self/status |
+		cut -d":" -f2 |
+		tr -d '\t')
+	if [ "${tmp}" != "0" ]; then
+		echo "check_seccomp_profile: skipping check since test env." \
+		"runs with in a seccomp profile overriding --seccomp"
+		return 0
+	fi
+
 	tmp=$(grep -E "^Seccomp" /proc/${swtpm_pid}/status |
 		cut -d":" -f2 |
 		tr -d '\t')


### PR DESCRIPTION
If the test environment is running in a seccomp profile do not check
that the seccomp profile of the swtpm process runs with the action
provided in --seccomp action=... since the environment may override
this.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>