### PR TITLE
tests: Protect variable with executable with quotes

### DIFF
--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -16,7 +16,7 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-if has_seccomp_support ${SWTPM_EXE}; then
+if has_seccomp_support "${SWTPM_EXE}"; then
 	seccomp='"cmdarg-seccomp", '
 fi
 if [ "${SWTPM_IFACE}" != "cuse" ]; then


### PR DESCRIPTION
The test_print_capability is failing if SWTPM_EXE is for example
holding more than one parameter like 'valgrind ... /bin/swtpm' since the
variable was not protected with quotes. This patch fixes this.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>