### PR TITLE
Fix a 1 letter typo in INSTALL instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -65,5 +65,5 @@ rpmbuild -ba dist/swtpm.spec
 
 To build a Debian package on a Debian compatible host do:
 
-echo "libtpms 0 libtpms" > ./debian/shlibs.local
+echo "libtpms0 libtpms" > ./debian/shlibs.local
 debuild -us -uc


### PR DESCRIPTION
Building the swtpm debian package the correct debian/shlibs.local stanza is

```
libtpms0 libtpms
```

The instructions in INSTALL add an extra space. I removed it.
