### PR TITLE
tests: Have test_tpm2_ibmtss2 test use tags/v1.3.0 from the TPM 2.0 T…

### DIFF
--- a/tests/test_tpm2_ibmtss2
+++ b/tests/test_tpm2_ibmtss2
@@ -40,19 +40,34 @@ git clone https://git.code.sf.net/p/ibmtpm20tss/tss ibmtpm20tss-tss
 
 pushd ibmtpm20tss-tss &>/dev/null
 
-git checkout tags/v1470
+git checkout tags/v1.3.0
 if [ $? -ne 0 ]; then
 	echo "'Git checkout' failed."
 	exit 1
 fi
 
 autoreconf --force --install
-CFLAGS="" LDFLAGS="" LIBS="" ./configure --disable-tpm-1.2
+#FIXME: Need to pass LIBS on Ubuntu to avoid X509_free linker errors
+CFLAGS="" LDFLAGS="" LIBS="-lz -lssl -lcrypto" ./configure --disable-tpm-1.2
 make -j4
 
 pushd utils
-# FIXME: This may only be needed for v1470
+
 sed -i 's/export CRYPTOLIBRARY.*/export CRYPTOLIBRARY=openssl/' reg.sh
+
+# Adjust test suite to TPM 2.0 revision libtpms is implementing
+revision=$(run_swtpm_ioctl ${SWTPM_INTERFACE} --info 1 |
+           sed 's/.*,"revision":\([^\}]*\).*/\1/')
+echo "Libtpms implements TPM 2.0 revision ${revision}."
+if [ $revision -lt 155 ]; then
+	echo "Removing revision 155 test cases."
+	for t in regtests/testattest155.sh regtests/testx509.sh
+	do
+		rm "${t}"
+		touch "${t}"
+		chmod 777 "${t}"
+	done
+fi
 
 export TPM_SERVER_NAME=localhost
 export TPM_INTERFACE_TYPE=socsim


### PR DESCRIPTION
…SS repo

Use v1.3.0 of the IBM TSS 2.0 repo.

Depending on the revision that libtpms implements, some test cases have to be
replaced with empty files.

The test suite now works with the libtpms stable-0.6.0 and stable-0.7.0
branches. A patch fixing an NV PIN issue needed to be applied to those
branches.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>