### PR TITLE
swtpm: Add missing --print-capabilities to help screen of 'swtpm char…

### DIFF
--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -207,6 +207,8 @@ static void usage(FILE *file, const char *prgname, const char *iface)
     "                 : Choose the action of the seccomp profile when a\n"
     "                   blacklisted syscall is executed; default is kill\n"
 #endif
+    "--print-capabilites\n"
+    "                 : print capabilities and terminate\n"
     "-h|--help        : display this help screen and terminate\n"
     "\n",
     prgname, iface);


### PR DESCRIPTION
…dev'

The --print-capabilities is missing in the 'swtpm chardev' help screen
but the code is there to interpret the command line flag. This patch
adds the missing lines to the help screen.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>