### PR TITLE
swtpm: Add --print-capabilities to help screen of 'swtpm chardev'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,14 +121,14 @@ matrix:
       os: osx
       compiler: clang
       before_script:
-      - brew upgrade gnutls
-      - brew install expect
-      - brew install libtasn
-      - brew install glib
-      - brew install gawk
-      - brew install gmp
-      - brew tap discoteq/discoteq
-      - brew install flock
-      - brew install socat
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade gnutls || true
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install expect
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install libtasn
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install glib
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install gawk
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install gmp
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew tap discoteq/discoteq
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install flock
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install socat
       # To run the pkcs11 test with softhsm we need SUDO (above)
-      - brew install softhsm
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install softhsm

--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -207,6 +207,8 @@ static void usage(FILE *file, const char *prgname, const char *iface)
     "                 : Choose the action of the seccomp profile when a\n"
     "                   blacklisted syscall is executed; default is kill\n"
 #endif
+    "--print-capabilites\n"
+    "                 : print capabilities and terminate\n"
     "-h|--help        : display this help screen and terminate\n"
     "\n",
     prgname, iface);


### PR DESCRIPTION
The --print-capabilities is missing in the 'swtpm chardev' help screen
but the code is there to interpret the command line flag. This patch
adds the missing lines to the help screen.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>