### PR TITLE
swtpm_setup: Log about encryption and fix c&p error in err msg

### DIFF
--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -2306,12 +2306,14 @@ main()
 			exit 1
 		fi
 		SWTPM="$SWTPM --key fd=${keyfile_fd}${cipher}"
+		logit "  The TPM's state will be encrypted with a provided key (fd)."
 	elif [ -n "$pwdfile_fd" ]; then
 		if ! [[ "$pwdfile_fd" =~ ^[0-9]+$ ]]; then
-			logerr "--keyfile-fd parameter $keyfile_fd is not a valid file descriptor"
+			logerr "--pwdfile-fd parameter $pwdfile_fd is not a valid file descriptor"
 			exit 1
 		fi
 		SWTPM="$SWTPM --key pwdfd=${pwdfile_fd}${cipher}"
+		logit "  The TPM's state will be encrypted using a key derived from a passphrase (fd)."
 	fi
 
 	# tcsd only runs as tss, so we have to be root or tss here; TPM 1.2 only


### PR DESCRIPTION
Fix a cut and paste error in the error message output and be more
verbose in log about encryption when using file descriptors.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>