### PR TITLE
swtpm_setup: Keep reserved range of file descriptors for swtpm_setup.sh

### DIFF
--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -45,6 +45,12 @@
 # - tcsd      (trousers package with tcsd with -c <configfile> option)
 # - expect    (expect package)
 
+# Note about file descriptor usage:
+#
+# This script may use any file descriptors in the range [100-109].
+# The launcher 'swtpm_setup' ensures that this range is not used by
+# any valid file descriptors passed as parameters.
+
 SWTPM=`type -P swtpm`
 if [ -n "$SWTPM" ]; then
     SWTPM="$SWTPM socket"


### PR DESCRIPTION
swtpm_setup.sh uses file descriptor 100 for 'exec 100 <> ...'.
So we have to make sure that the file descriptor inherited from
the caller of swtpm_setup does not overlap with a reserved range
to be used by swtpm_setup.sh, which we declare to be [100..110].

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>