### PR TITLE
Enable test suite to run all tests with valgrind as root

### DIFF
--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -2102,7 +2102,7 @@ main()
 	local flags=0
 	local tpm_state_path=""
 	local config_file="$DEFAULT_CONFIG_FILE"
-	local vmid=""
+	local vmid="" tmp
 	local ret
 	local keyfile pwdfile cipher="aes-128-cbc"
 	local keyfile_fd pwdfile_fd
@@ -2251,7 +2251,8 @@ main()
 		exit 1
 	fi
 
-	if [ ! -x "$(echo $SWTPM | cut -d " " -f1)" ]; then
+	tmp="$(echo $SWTPM | cut -d" " -f1)"
+	if [ ! -x "$(type -P $tmp)" ]; then
 		logerr "TPM at $SWTPM is not an executable."
 		exit 1
 	fi
@@ -2273,7 +2274,8 @@ main()
 		exit 1
 	fi
 
-	if [ ! -x "$(echo $SWTPM_IOCTL | cut -d " " -f1)" ]; then
+	tmp="$(echo $SWTPM_IOCTL | cut -d" " -f1)"
+	if [ ! -x "$(type -P $tmp)" ]; then
 		logerr "swtpm_ioctl at $SWTPM_IOCTL is not an executable."
 		exit 1
 	fi

--- a/tests/_test_init
+++ b/tests/_test_init
@@ -32,7 +32,7 @@ source ${TESTDIR}/common
 
 rm -f $STATE_FILE $VOLATILE_STATE_FILE 2>/dev/null
 
-if has_seccomp_support ${SWTPM_EXE}; then
+if has_seccomp_support "${SWTPM_EXE}"; then
 	seccomp_params="--seccomp action=none"
 fi
 
@@ -110,7 +110,7 @@ if [ "$(id -u)" != "0" ]; then
 	fi
 fi
 
-check_seccomp_profile ${SWTPM_EXE} ${SWTPM_PID} 0
+check_seccomp_profile "${SWTPM_EXE}" ${SWTPM_PID} 0
 if [ $? -ne 0 ]; then
 	exit 1
 fi

--- a/tests/_test_tpm2_init
+++ b/tests/_test_tpm2_init
@@ -31,7 +31,7 @@ source ${TESTDIR}/common
 
 rm -f $STATE_FILE $VOLATILE_STATE_FILE 2>/dev/null
 
-if has_seccomp_support ${SWTPM_EXE}; then
+if has_seccomp_support "${SWTPM_EXE}"; then
 	seccomp_params="--seccomp action=none"
 fi
 
@@ -93,7 +93,7 @@ if [ "$(id -u)" != "0" ]; then
 	fi
 fi
 
-check_seccomp_profile ${SWTPM_EXE} ${SWTPM_PID} 0
+check_seccomp_profile "${SWTPM_EXE}" ${SWTPM_PID} 0
 if [ $? -ne 0 ]; then
 	exit 1
 fi

--- a/tests/common
+++ b/tests/common
@@ -735,8 +735,14 @@ function validate_pidfile()
 {
 	local pid="$1"
 	local pidfile="$2"
+	local rpid="$(cat $pidfile)"
 
-	if [ "$PID" != "$(cat $PID_FILE)" ]; then
+	if [ -z "$rpid" ]; then
+		sleep 0.1
+		rpid="$(cat $pidfile)"
+	fi
+
+	if [ "$pid" != "$rpid" ]; then
 		echo "Error: pid file contains unexpected PID value."
 		echo "expected: $pid"
 		echo "actual  : $(cat $pidfile)"

--- a/tests/common
+++ b/tests/common
@@ -190,6 +190,54 @@ function wait_serversocket_gone()
   return 0
 }
 
+# Wait for a TCP port to open for listening
+# @1: port
+# @2: id of process to open port
+# @3: timeout in seconds
+function wait_port_open()
+{
+	local port=$1
+	local pid=$2
+	local timeout=$3
+
+	local loops=$((timeout * 10)) loop
+
+	for ((loop = 0; loop < loops; loop++)); do
+		if [ -n "$(netstat -naptl 2>/dev/null |
+			   grep "LISTEN" |
+			   grep " $pid/" |
+			   grep ":$port ")" ]; then
+			return 1
+		fi
+		sleep 0.1
+	done
+	return 0
+}
+
+# Wait for a TCP listening port to close
+# @1: port
+# @2: id of process to close port
+# @3: timeout in seconds
+function wait_port_closed()
+{
+	local port=$1
+	local pid=$2
+	local timeout=$3
+
+	local loops=$((timeout * 10)) loop
+
+	for ((loop = 0; loop < loops; loop++)); do
+		if [ -z "$(netstat -naptl 2>/dev/null |
+			   grep "LISTEN" |
+			   grep " $pid/" |
+			   grep ":$port ")" ]; then
+			return 1
+		fi
+		sleep 0.1
+	done
+	return 0
+}
+
 # Run the swtpm_ioctl command
 #
 # @param1: type of interface

--- a/tests/test_commandline
+++ b/tests/test_commandline
@@ -30,41 +30,6 @@ export TCSD_TCP_DEVICE_HOSTNAME=localhost
 export TCSD_TCP_DEVICE_PORT=$PORT
 export TCSD_USE_TCP_DEVICE=1
 
-function wait_port_open()
-{
-	local port=$1
-	local pid=$2
-
-	sleep 0.2
-	for ((i = 0; i < 20; i++)); do
-		if [ -n "$(netstat -naptl 2>/dev/null |
-			   grep "LISTEN" |
-			   grep " $pid/" |
-			   grep ":$port ")" ]; then
-			return 0
-		fi
-		sleep 0.2
-	done
-	return 1
-}
-
-function wait_port_closed()
-{
-	local port=$1
-	local pid=$2
-
-	for ((i = 0; i < 20; i++)); do
-		if [ -z "$(netstat -naptl 2>/dev/null |
-			   grep "LISTEN" |
-			   grep " $pid/" |
-			   grep ":$port ")" ]; then
-			return 0
-		fi
-		sleep 0.2
-	done
-	return 1
-}
-
 # Test 1: test port and directory command line parameters; use log level 20
 FILEMODE=641
 exec 100<>$LOG_FILE
@@ -78,7 +43,10 @@ $SWTPM_EXE socket \
 PID=$!
 exec 100>&-
 
-wait_port_open $PORT $PID
+if wait_port_open $PORT $PID 4; then
+	echo "Test 1 failed: TPM did not open port $PORT"
+	exit 1
+fi
 
 kill_quiet -0 $PID
 if [ $? -ne 0 ]; then
@@ -134,7 +102,10 @@ TPMDIR=`mktemp -d`
 $SWTPM_EXE socket --flags not-need-init -p $PORT --tpmstate dir=$TPMDIR -t &>/dev/null &
 PID=$!
 
-wait_port_open $PORT $PID
+if wait_port_open $PORT $PID 4; then
+	echo "Test 1 failed: TPM did not open port $PORT"
+	exit
+fi
 
 exec 20<&1-; exec 21<&2-
 kill_quiet -0 $PID
@@ -154,9 +125,15 @@ fi
 
 exec 100>&-
 
-wait_port_closed $PORT $PID
-# Give it time to fully shut down
-wait_process_gone $PID 6
+if wait_port_closed $PORT $PID 4; then
+	echo "Test 2 failed: TPM did not close port"
+	exit 1
+fi
+
+if wait_process_gone $PID 4; then
+	echo "Test 2 failed: TPM process did not shut down"
+	exit 1
+fi
 
 exec 20<&1-; exec 21<&2-
 kill_quiet -0 $PID

--- a/tests/test_commandline
+++ b/tests/test_commandline
@@ -86,16 +86,12 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-if [ ! -r $PID_FILE ]; then
-	echo "Error: CUSE TPM did not write pidfile."
+if wait_for_file $PID_FILE 3; then
+	echo "Error: ${SWTPM_INTERFACE} TPM did not write pidfile."
 	exit 1
 fi
 
-PIDF="$(cat $PID_FILE)"
-if [ "$PIDF" != "$PID" ]; then
-	echo "Error: CUSE TPM wrote pid $PIDF, but found $PID."
-	exit 1
-fi
+validate_pidfile $PID $PID_FILE
 
 ${SWTPM_BIOS} &>/dev/null
 if [ $? -ne 0 ]; then
@@ -160,7 +156,7 @@ exec 100>&-
 
 wait_port_closed $PORT $PID
 # Give it time to fully shut down
-wait_process_gone $PID 2
+wait_process_gone $PID 6
 
 exec 20<&1-; exec 21<&2-
 kill_quiet -0 $PID

--- a/tests/test_vtpm_proxy
+++ b/tests/test_vtpm_proxy
@@ -38,7 +38,10 @@ source ${TESTDIR}/load_vtpm_proxy
 
 rm -f $STATE_FILE $VOLATILE_STATE_FILE 2>/dev/null
 
-$SWTPM_EXE chardev --vtpm-proxy --tpmstate dir=$TPM_PATH --ctrl type=unixio,path=$SOCK_PATH --pid file=$PID_FILE &>$LOGFILE &
+$SWTPM_EXE chardev --vtpm-proxy \
+	--tpmstate dir=$TPM_PATH \
+	--ctrl type=unixio,path=$SOCK_PATH \
+	--pid file=$PID_FILE &>$LOGFILE &
 sleep 0.5
 PID=$(ps aux | grep $SWTPM | grep -E " file=${PID_FILE}\$" | gawk '{print $2}')
 
@@ -50,12 +53,23 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-TPM_DEVICE=$(sed -n 's,.*\(/dev/tpm[0-9]\+\).*,\1,p' $LOGFILE)
-echo "Using ${TPM_DEVICE}."
+if wait_for_file $PID_FILE 3; then
+	echo "Error: Chardev TPM did not write pidfile."
+	exit 1
+fi
 
-# Wait for chardev to appear
-for ((i = 0; i < 10; i ++)); do
-	[ -c "${TPM_DEVICE}" ] && break
+# Wait for chardev to appear; TPM 1.2 may take a long time to self-test
+# with valgrind
+for ((i = 0; i < 200; i ++)); do
+	if [ -z "${TPM_DEVICE}" ]; then
+		TPM_DEVICE=$(sed -n 's,.*\(/dev/tpm[0-9]\+\).*,\1,p' $LOGFILE)
+		if [ -n "${TPM_DEVICE}" ]; then
+			echo "Using ${TPM_DEVICE}."
+		fi
+	fi
+	if [ -n "${TPM_DEVICE}" ]; then
+		[ -c "${TPM_DEVICE}" ] && break
+	fi
 	sleep 0.1
 done
 if ! [ -c "${TPM_DEVICE}" ]; then


### PR DESCRIPTION
This series of patches fixes a few problems with test cases that allow one to now run all test cases with sudo and the executables wrapped with [Valgrind](https://github.com/stefanberger/swtpm/wiki/Using-Valgrind-to-detect-memory-leaks-and-other-errors).