### PR TITLE
Fix some issues for the debian build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -446,8 +446,9 @@ AC_MSG_CHECKING([for whether to build with seccomp profile])
 AC_ARG_WITH([seccomp],
   AC_HELP_STRING([--with-seccomp],
                  [build with seccomp profile]),
-  [],
+  AC_MSG_RESULT([$with_seccomp]),
   [with_seccomp=$with_seccomp_default]
+  AC_MSG_RESULT([$with_seccomp])
 )
 
 if test "$with_seccomp" != "no"; then

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,10 @@
-swtpm (0.2.0-1) RELEASED; urgency medium
+swtpm (0.2.0-1) RELEASED; urgency=medium
 
-  -- Stefan Berger <stefanb@linux.ibm.com>  Tue, 16 Jul 2019 14:21:18 -0500
+ -- Stefan Berger <stefanb@linux.ibm.com>  Tue, 16 Jul 2019 14:21:18 -0500
 
 swtpm (0.2.0~dev1) UNRELEASED; urgency=medium
 
-  -- Stefan Berger <stefanb@linux.ibm.com>  Mon, 04 Feb 2019 14:30:08 -0500
+ -- Stefan Berger <stefanb@linux.ibm.com>  Mon, 04 Feb 2019 14:30:08 -0500
 
 swtpm (0.1.0-1) RELEASED; urgency medium
 

--- a/debian/control
+++ b/debian/control
@@ -4,9 +4,8 @@ Section: misc
 Priority: optional
 Build-Depends: automake,
 	       autoconf,
-	       coreutils,
 	       libtool,
-	       sed,
+	       debhelper (>= 9),
 	       libtpms-dev,
 	       libfuse-dev,
 	       libglib2.0-dev,
@@ -14,7 +13,6 @@ Build-Depends: automake,
 	       expect,
 	       libtasn1-dev,
 	       socat,
-	       findutils,
 	       tpm-tools (>= 1.3.8),
 	       python3-twisted,
 	       gnutls-dev,
@@ -28,8 +26,9 @@ Build-Depends: automake,
 
 Package: swtpm
 Architecture: any
-Depends: swtpm-libs (= ${source:Version}),
-	 ${shlibs:Depends}
+Depends: swtpm-libs (= ${binary:Version}),
+	 ${shlibs:Depends},
+	 ${misc:Depends}
 # linux-image-extra
 Description: Libtpms-based TPM emulator
  The swtpm package provides TPM emulators that listen for TPM commands
@@ -43,14 +42,16 @@ Depends: openssl,
 	 libglib2.0-0,
 	 ${shlibs:Depends},
 	 ${misc:Pre-Depends},
+	 ${misc:Depends}
 Description: Common libraries for TPM emulators
  The swtpm-libs package provides the shared libraries for the swtpm
  and swtpm-cuse packages.
 
 Package: swtpm-cuse
 Architecture: any
-Depends: swtpm-libs (= ${source:Version}),
-	 ${shlibs:Depends}
+Depends: swtpm-libs (= ${binary:Version}),
+	 ${shlibs:Depends},
+	 ${misc:Depends}
 # linux-image-extra
 Description: TPM emulator with CUSE interface
  The swtpm-cuse package provides a CUSE TPM emulator. This emulator
@@ -61,6 +62,7 @@ Description: TPM emulator with CUSE interface
 
 Package: swtpm-dev
 Architecture: any
+Depends: ${misc:Depends}
 Description: Include files for the TPM emulator's CUSE interface
  The swtpm-dev package provides include files for developing clients
  controlling the CUSE TPM through ioctls.
@@ -75,8 +77,9 @@ Description: Tools for the TPM emulator
       tool basically simulates TPM manufacturing where certificates are
       written into the NVRAM of the TPM
   - swtpm_cert: Creation of certificates for the TPM (x509)
-Depends: swtpm (= ${source:Version}),
+Depends: swtpm (= ${binary:Version}),
 	 trousers (>= 0.3.9),
 	 tpm-tools (>= 1.3.8),
 	 ${shlibs:Depends},
+	 ${misc:Depends},
 	 gnutls-bin


### PR DESCRIPTION
This series of patches fixes some issues reported by lintian that are related to the debian control file as well as issues related to the formatting of the changelog file.
Also, the check for libseccomp was not reporting 'yes' or 'no', so fix this as well.