### PR TITLE
tests: Allow seccomp override w/ SWTPM_TEST_SECCOMP_OPT env var

### DIFF
--- a/tests/_test_init
+++ b/tests/_test_init
@@ -33,13 +33,12 @@ source ${TESTDIR}/common
 rm -f $STATE_FILE $VOLATILE_STATE_FILE 2>/dev/null
 
 if has_seccomp_support ${SWTPM_EXE}; then
-	seccomp_params="--seccomp action=none"
+	SWTPM_TEST_SECCOMP_OPT="--seccomp action=none"
 fi
 
 run_swtpm ${SWTPM_INTERFACE} \
 	--tpmstate dir=$TPM_PATH \
-	--pid file=$PID_FILE \
-	${seccomp_params}
+	--pid file=$PID_FILE
 
 display_processes_by_name "$SWTPM"
 

--- a/tests/_test_tpm2_init
+++ b/tests/_test_tpm2_init
@@ -32,10 +32,10 @@ source ${TESTDIR}/common
 rm -f $STATE_FILE $VOLATILE_STATE_FILE 2>/dev/null
 
 if has_seccomp_support ${SWTPM_EXE}; then
-	seccomp_params="--seccomp action=none"
+	SWTPM_TEST_SECCOMP_OPT="--seccomp action=none"
 fi
 
-run_swtpm ${SWTPM_INTERFACE} --tpm2 ${seccomp_params}
+run_swtpm ${SWTPM_INTERFACE} --tpm2
 
 display_processes_by_name "$SWTPM"
 

--- a/tests/common
+++ b/tests/common
@@ -259,7 +259,8 @@ function run_swtpm()
 			exit 1
 		fi
 
-		${SWTPM_EXE} cuse $@ -n ${SWTPM_DEV_NAME##*/}
+		${SWTPM_EXE} cuse $@ ${SWTPM_TEST_SECCOMP_OPT} \
+			-n ${SWTPM_DEV_NAME##*/}
 		rc=$?
 		if [ $rc -ne 0 ]; then
 			echo "Could not run ${SWTPM_EXE} using ${iface}"
@@ -297,6 +298,7 @@ function run_swtpm()
 		fi
 
 		${SWTPM_EXE} socket $@ \
+			${SWTPM_TEST_SECCOMP_OPT} \
 			--server type=tcp,port=${SWTPM_SERVER_PORT}${swtpm_server_disconnect} \
 			--ctrl type=tcp,port=${SWTPM_CTRL_PORT} &
 		rc=$?
@@ -337,6 +339,7 @@ function run_swtpm()
 		fi
 
 		${SWTPM_EXE} socket $@ \
+			${SWTPM_TEST_SECCOMP_OPT} \
 			--server type=tcp,port=${SWTPM_SERVER_PORT}${swtpm_server_disconnect} \
 			--ctrl type=unixio,path=${SWTPM_CTRL_UNIX_PATH} &
 		rc=$?
@@ -378,6 +381,7 @@ function run_swtpm()
 		fi
 
 		${SWTPM_EXE} socket $@ \
+			${SWTPM_TEST_SECCOMP_OPT} \
 			--server type=unixio,path=${SWTPM_CMD_UNIX_PATH} \
 			--ctrl type=tcp,port=${SWTPM_CTRL_PORT} &
 		rc=$?
@@ -418,6 +422,7 @@ function run_swtpm()
 		fi
 
 		${SWTPM_EXE} socket $@ \
+			${SWTPM_TEST_SECCOMP_OPT} \
 			--server type=unixio,path=${SWTPM_CMD_UNIX_PATH} \
 			--ctrl type=unixio,path=${SWTPM_CTRL_UNIX_PATH} &
 		rc=$?
@@ -704,6 +709,9 @@ function check_seccomp_profile()
 	local tmp
 
 	if ! has_seccomp_support "${swtpm_exe}"; then
+		return 0
+	fi
+	if [ -n "${SWTPM_TEST_SECCOMP_OPT}" ]; then
 		return 0
 	fi
 

--- a/tests/test_clientfds.py
+++ b/tests/test_clientfds.py
@@ -40,6 +40,8 @@ def spawn_swtpm():
     cmd = swtpm_exe + " socket --fd=" + str(_fd.fileno())
     cmd += " --ctrl type=unixio,clientfd=" + str(_ctrlfd.fileno())
     cmd += " --pid file=" + pidfile + " --tpmstate dir=" + tpmpath
+    if os.getenv('SWTPM_TEST_SECCOMP_OPT'):
+        cmd += " " + os.getenv('SWTPM_TEST_SECCOMP_OPT')
     print("Running child cmd: %s" % cmd)
     try:
         if sys.version_info[0] >= 3:

--- a/tests/test_commandline
+++ b/tests/test_commandline
@@ -74,7 +74,8 @@ $SWTPM_EXE socket \
 	--tpmstate dir=$TPMDIR,mode=$FILEMODE \
 	--pid file=$PID_FILE \
 	--log fd=100,level=20 \
-	--flags not-need-init &
+	--flags not-need-init \
+	${SWTPM_TEST_SECCOMP_OPT} &
 PID=$!
 exec 100>&-
 
@@ -135,7 +136,12 @@ cleanup
 #         that causes the swtpm process to exit upon connection close
 TPMDIR=`mktemp -d`
 
-$SWTPM_EXE socket --flags not-need-init -p $PORT --tpmstate dir=$TPMDIR -t &>/dev/null &
+$SWTPM_EXE socket \
+	--flags not-need-init \
+	-p $PORT \
+	--tpmstate dir=$TPMDIR \
+	-t \
+	${SWTPM_TEST_SECCOMP_OPT} &>/dev/null &
 PID=$!
 
 wait_port_open $PORT $PID

--- a/tests/test_ctrlchannel
+++ b/tests/test_ctrlchannel
@@ -81,7 +81,8 @@ $SWTPM_EXE socket \
 	--pid $PIDPARAM \
 	--ctrl type=unixio,path=$SWTPM_CTRL_UNIX_PATH,mode=${FILEMODE}${FOWNER} \
 	--log file=$LOG_FILE,level=20 \
-	$RUNAS &
+	$RUNAS \
+	${SWTPM_TEST_SECCOMP_OPT} &
 PID=$!
 exec 100>&-
 exec 101>&-

--- a/tests/test_ctrlchannel2
+++ b/tests/test_ctrlchannel2
@@ -31,7 +31,12 @@ function cleanup()
 
 # use a pseudo terminal
 exec 100<>/dev/ptmx
-$SWTPM_EXE chardev --fd 100 --tpmstate dir=$TPMDIR --pid file=$PID_FILE --ctrl type=unixio,path=$SOCK_PATH &
+$SWTPM_EXE chardev \
+	--fd 100 \
+	--tpmstate dir=$TPMDIR \
+	--pid file=$PID_FILE \
+	--ctrl type=unixio,path=$SOCK_PATH \
+	${SWTPM_TEST_SECCOMP_OPT} &
 PID=$!
 
 if wait_for_file $PID_FILE 3; then
@@ -129,7 +134,8 @@ $SWTPM_EXE socket \
 	--server port=65431,disconnect=true,bindaddr=$BINDADDR \
 	--tpmstate dir=$TPMDIR \
 	--pid file=$PID_FILE \
-	--ctrl type=unixio,path=$SOCK_PATH &
+	--ctrl type=unixio,path=$SOCK_PATH \
+	${SWTPM_TEST_SECCOMP_OPT} &
 PID=$!
 
 if wait_for_file $PID_FILE 3; then
@@ -316,7 +322,8 @@ $SWTPM_EXE socket \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--key pwdfile=${TESTDIR}/data/tpmstate2/pwdfile.txt,kdf=sha512 \
-	--flags not-need-init &
+	--flags not-need-init \
+	${SWTPM_TEST_SECCOMP_OPT} &
 PID=$!
 
 if wait_for_file $PID_FILE 3; then
@@ -372,7 +379,8 @@ $SWTPM_EXE socket \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--key pwdfile=${TESTDIR}/data/tpmstate2/pwdfile.txt,kdf=sha512 \
-	--flags not-need-init &
+	--flags not-need-init \
+	${SWTPM_TEST_SECCOMP_OPT} &
 PID=$!
 
 if wait_for_file $PID_FILE 3; then

--- a/tests/test_ctrlchannel3
+++ b/tests/test_ctrlchannel3
@@ -37,7 +37,8 @@ $SWTPM_EXE socket \
 	--tpmstate dir=$TPMDIR \
 	-t \
 	--pid file=$PID_FILE \
-	--log file=$LOG_FILE,level=20 &
+	--log file=$LOG_FILE,level=20 \
+	${SWTPM_TEST_SECCOMP_OPT} &
 PID=$!
 
 if wait_for_file $PID_FILE 3; then

--- a/tests/test_ctrlchannel4
+++ b/tests/test_ctrlchannel4
@@ -33,7 +33,8 @@ $SWTPM_EXE chardev \
 	--tpmstate dir=$TPMDIR \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SWTPM_CTRL_UNIX_PATH \
-	--log file=$LOG_FILE,level=20 &
+	--log file=$LOG_FILE,level=20 \
+	${SWTPM_TEST_SECCOMP_OPT} &
 
 exec 100>&-
 

--- a/tests/test_parameters
+++ b/tests/test_parameters
@@ -107,7 +107,7 @@ for (( i=0; i<${#PARAMETERS[*]}; i++)); do
 	echo -n "Test $i: "
 	$TPMAUTHORING \
 		--tpm-state $TPMDIR \
-		--tpm "$SWTPM_EXE socket" \
+		--tpm "$SWTPM_EXE socket ${SWTPM_TEST_SECCOMP_OPT}" \
 		--swtpm_ioctl "$SWTPM_IOCTL" \
 		${PARAMETERS[$i]} 2>&1 >/dev/null
 	

--- a/tests/test_samples_create_tpmca
+++ b/tests/test_samples_create_tpmca
@@ -104,7 +104,7 @@ _EOF_
 		--tpm-state ${workdir} \
 		--logfile ${workdir}/logfile \
 		--config ${workdir}/swtpm_setup.conf \
-		--tpm "${SWTPM_EXE} socket" \
+		--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}" \
 		--swtpm_ioctl ${SWTPM_IOCTL} \
 		--take-ownership \
 		${params} \

--- a/tests/test_swtpm_setup_create_cert
+++ b/tests/test_swtpm_setup_create_cert
@@ -70,7 +70,7 @@ $SWTPM_SETUP \
 	--create-ek-cert \
 	--config ${workdir}/swtpm_setup.conf \
 	--logfile ${workdir}/logfile \
-	--tpm "${SWTPM} socket" \
+	--tpm "${SWTPM} socket ${SWTPM_TEST_SECCOMP_OPT}" \
 	--swtpm_ioctl ${SWTPM_IOCTL}
 
 if [ $? -ne 0 ]; then

--- a/tests/test_tpm2_ctrlchannel2
+++ b/tests/test_tpm2_ctrlchannel2
@@ -43,7 +43,8 @@ $SWTPM_EXE chardev \
 	--tpmstate dir=$TPMDIR \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH,mode=${FILEMODE}${FOWNER} \
-	--tpm2 &
+	--tpm2 \
+	${SWTPM_TEST_SECCOMP_OPT} &
 PID=$!
 
 if wait_for_file $PID_FILE 3; then
@@ -151,7 +152,8 @@ $SWTPM_EXE socket \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--log file=$LOGFILE,level=20 \
-	--tpm2 &
+	--tpm2 \
+	${SWTPM_TEST_SECCOMP_OPT} &
 PID=$!
 
 if wait_for_file $PID_FILE 3; then
@@ -347,7 +349,8 @@ $SWTPM_EXE socket \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--key pwdfile=${TESTDIR}/data/tpm2state2/pwdfile.txt,kdf=sha512 \
 	--tpm2 \
-	--flags not-need-init &
+	--flags not-need-init \
+	${SWTPM_TEST_SECCOMP_OPT} &
 PID=$!
 
 if wait_for_file $PID_FILE 3; then
@@ -405,7 +408,8 @@ $SWTPM_EXE socket \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--key pwdfile=${TESTDIR}/data/tpm2state2/pwdfile.txt,kdf=sha512 \
 	--tpm2 \
-	--flags not-need-init &
+	--flags not-need-init \
+	${SWTPM_TEST_SECCOMP_OPT} &
 PID=$!
 
 if wait_for_file $PID_FILE 3; then

--- a/tests/test_tpm2_parameters
+++ b/tests/test_tpm2_parameters
@@ -80,7 +80,7 @@ for (( i=0; i<${#PARAMETERS[*]}; i++)); do
 	echo -n "Test $i: "
 	$TPMAUTHORING \
 		--tpm-state $TPMDIR \
-		--tpm "$SWTPM_EXE socket" \
+		--tpm "$SWTPM_EXE socket ${SWTPM_TEST_SECCOMP_OPT}" \
 		--swtpm_ioctl "$SWTPM_IOCTL" \
 		${PARAMETERS[$i]} 2>&1 >/dev/null
 

--- a/tests/test_tpm2_save_load_state_3
+++ b/tests/test_tpm2_save_load_state_3
@@ -681,7 +681,8 @@ $SWTPM_EXE socket \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--log file=$LOGFILE,level=20 \
-	--tpm2 &
+	--tpm2 \
+	${SWTPM_TEST_SECCOMP_OPT} &
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: (1) Socket TPM did not write pidfile."
@@ -739,7 +740,8 @@ $SWTPM_EXE socket \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--log file=$LOGFILE,level=20 \
-	--tpm2 &
+	--tpm2 \
+	${SWTPM_TEST_SECCOMP_OPT} &
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: (2) Socket TPM did not write pidfile."
@@ -799,7 +801,8 @@ $SWTPM_EXE socket \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--log file=$LOGFILE,level=20 \
-	--tpm2 &
+	--tpm2 \
+	${SWTPM_TEST_SECCOMP_OPT} &
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: (3) Socket TPM did not write pidfile."
@@ -859,7 +862,8 @@ $SWTPM_EXE socket \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--log file=$LOGFILE,level=20 \
-	--tpm2 &
+	--tpm2 \
+	${SWTPM_TEST_SECCOMP_OPT} &
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: (3) Socket TPM did not write pidfile."
@@ -920,7 +924,8 @@ $SWTPM_EXE socket \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--log file=$LOGFILE,level=20 \
-	--tpm2 &
+	--tpm2 \
+	${SWTPM_TEST_SECCOMP_OPT} &
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: (3) Socket TPM did not write pidfile."
@@ -969,7 +974,8 @@ $SWTPM_EXE socket \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--log file=$LOGFILE,level=20 \
-	--tpm2 &
+	--tpm2 \
+	${SWTPM_TEST_SECCOMP_OPT} &
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: (3) Socket TPM did not write pidfile."
@@ -1014,7 +1020,8 @@ $SWTPM_EXE socket \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--log file=$LOGFILE,level=20 \
-	--tpm2 &
+	--tpm2 \
+	${SWTPM_TEST_SECCOMP_OPT} &
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: (3) Socket TPM did not write pidfile."
@@ -1075,7 +1082,8 @@ $SWTPM_EXE socket \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--log file=$LOGFILE,level=20 \
-	--tpm2 &
+	--tpm2 \
+	${SWTPM_TEST_SECCOMP_OPT} &
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: (3) Socket TPM did not write pidfile."
@@ -1124,7 +1132,8 @@ $SWTPM_EXE socket \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--log file=$LOGFILE,level=20 \
-	--tpm2 &
+	--tpm2 \
+	${SWTPM_TEST_SECCOMP_OPT} &
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: (3) Socket TPM did not write pidfile."
@@ -1168,7 +1177,8 @@ $SWTPM_EXE socket \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--log file=$LOGFILE,level=20 \
-	--tpm2 &
+	--tpm2 \
+	${SWTPM_TEST_SECCOMP_OPT} &
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: (3) Socket TPM did not write pidfile."
@@ -1229,7 +1239,8 @@ $SWTPM_EXE socket \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--log file=$LOGFILE,level=20 \
-	--tpm2 &
+	--tpm2 \
+	${SWTPM_TEST_SECCOMP_OPT} &
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: (3) Socket TPM did not write pidfile."
@@ -1275,7 +1286,8 @@ $SWTPM_EXE socket \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--log file=$LOGFILE,level=20 \
-	--tpm2 &
+	--tpm2 \
+	${SWTPM_TEST_SECCOMP_OPT} &
 
 if wait_for_file $PID_FILE 3; then
 	echo "Error: (3) Socket TPM did not write pidfile."

--- a/tests/test_tpm2_swtpm_setup_create_cert
+++ b/tests/test_tpm2_swtpm_setup_create_cert
@@ -70,7 +70,7 @@ $SWTPM_SETUP \
 	--create-platform-cert \
 	--config ${workdir}/swtpm_setup.conf \
 	--logfile ${workdir}/logfile \
-	--tpm "${SWTPM} socket" \
+	--tpm "${SWTPM} socket ${SWTPM_TEST_SECCOMP_OPT}" \
 	--swtpm_ioctl ${SWTPM_IOCTL}
 
 if [ $? -ne 0 ]; then
@@ -107,7 +107,7 @@ $SWTPM_SETUP \
 	--create-ek-cert \
 	--config ${workdir}/swtpm_setup.conf \
 	--logfile ${workdir}/logfile \
-	--tpm "${SWTPM} socket" \
+	--tpm "${SWTPM} socket ${SWTPM_TEST_SECCOMP_OPT}" \
 	--swtpm_ioctl ${SWTPM_IOCTL} \
 	--overwrite
 

--- a/tests/test_tpm2_vtpm_proxy
+++ b/tests/test_tpm2_vtpm_proxy
@@ -38,7 +38,13 @@ source ${TESTDIR}/load_vtpm_proxy
 
 rm -f $STATE_FILE $VOLATILE_STATE_FILE 2>/dev/null
 
-$SWTPM_EXE chardev --tpm2 --vtpm-proxy --tpmstate dir=$TPM_PATH --ctrl type=unixio,path=$SOCK_PATH --pid file=$PID_FILE &>$LOGFILE &
+$SWTPM_EXE chardev \
+	--tpm2 \
+	--vtpm-proxy \
+	--tpmstate dir=$TPM_PATH \
+	--ctrl type=unixio,path=$SOCK_PATH \
+	--pid file=$PID_FILE \
+	${SWTPM_TEST_SECCOMP_OPT} &>$LOGFILE &
 sleep 0.5
 PID=$(ps aux | grep $SWTPM | grep -E " file=${PID_FILE}\$" | gawk '{print $2}')
 

--- a/tests/test_vtpm_proxy
+++ b/tests/test_vtpm_proxy
@@ -38,7 +38,11 @@ source ${TESTDIR}/load_vtpm_proxy
 
 rm -f $STATE_FILE $VOLATILE_STATE_FILE 2>/dev/null
 
-$SWTPM_EXE chardev --vtpm-proxy --tpmstate dir=$TPM_PATH --ctrl type=unixio,path=$SOCK_PATH --pid file=$PID_FILE &>$LOGFILE &
+$SWTPM_EXE chardev --vtpm-proxy \
+	--tpmstate dir=$TPM_PATH \
+	--ctrl type=unixio,path=$SOCK_PATH \
+	--pid file=$PID_FILE \
+	${SWTPM_TEST_SECCOMP_OPT} &>$LOGFILE &
 sleep 0.5
 PID=$(ps aux | grep $SWTPM | grep -E " file=${PID_FILE}\$" | gawk '{print $2}')
 


### PR DESCRIPTION
The Ubuntu (PPA) build system executes the build on an environment that
has problems with seccomp profiles. It does not allow us to run the test
suite with swtpm applying its seccomp profile since it fails with a
'bad system call' error. To work around this we introduce the env. variable
SWTPM_TEST_SECCOMP_OPT that we can set to "--seccomp action=none" to avoid
having swtpm apply it seccomp profile.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>