### PR TITLE
Sigpipe fixes

### DIFF
--- a/src/swtpm/mainloop.c
+++ b/src/swtpm/mainloop.c
@@ -150,7 +150,7 @@ int mainLoop(struct mainLoopParams *mlp,
                     .events = POLLIN,
                     .revents = 0,
                 }, {
-                    .fd = ctrlfd,
+                    .fd = -1,
                     .events = POLLIN,
                     .revents = 0,
                 } , {
@@ -168,6 +168,8 @@ int mainLoop(struct mainLoopParams *mlp,
             /* only listend for clients if we don't have one */
             if (connection_fd.fd < 0)
                 pollfds[DATA_SERVER_FD].fd = sockfd;
+            if (ctrlclntfd < 0)
+                pollfds[CTRL_SERVER_FD].fd = ctrlfd;
 
             ready = poll(pollfds, 5, -1);
             if (ready < 0 && errno == EINTR)

--- a/src/swtpm_bios/tpm_bios.c
+++ b/src/swtpm_bios/tpm_bios.c
@@ -47,6 +47,7 @@
 #include <netdb.h>
 #include <sys/un.h>
 #include <getopt.h>
+#include <signal.h>
 
 #include "sys_dependencies.h"
 #include "swtpm.h"
@@ -771,6 +772,11 @@ int main(int argc, char *argv[])
 			print_usage(argv[0]);
 			return EXIT_FAILURE;
 		}
+	}
+
+	if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
+		fprintf(stderr, "Could not install signal handler for SIGPIPE.");
+		return EXIT_FAILURE;
 	}
 
 	if (tpm2) {

--- a/src/swtpm_ioctl/tpm_ioctl.c
+++ b/src/swtpm_ioctl/tpm_ioctl.c
@@ -153,6 +153,7 @@ static int do_hash_start_data_end(int fd, bool is_chardev, const char *input)
     int n;
     size_t idx;
     ptm_hdata hdata;
+    size_t inputlen;
 
     memset(&hdata, 0, sizeof(hdata));
 
@@ -176,7 +177,9 @@ static int do_hash_start_data_end(int fd, bool is_chardev, const char *input)
                 devtoh32(is_chardev, res));
         return 1;
     }
-    if (strlen(input) == 1 && input[0] == '-') {
+    inputlen = strlen(input);
+
+    if (inputlen == 1 && input[0] == '-') {
         /* read data from stdin */
         while (1) {
             idx = 0;
@@ -202,8 +205,8 @@ static int do_hash_start_data_end(int fd, bool is_chardev, const char *input)
         }
     } else {
         idx = 0;
-        while (idx < strlen(input)) {
-            size_t tocopy = strlen(input) - idx;
+        while (idx < inputlen) {
+            size_t tocopy = inputlen - idx;
 
             if (tocopy > sizeof(hdata.u.req.data))
                 tocopy = sizeof(hdata.u.req.data);

--- a/src/swtpm_ioctl/tpm_ioctl.c
+++ b/src/swtpm_ioctl/tpm_ioctl.c
@@ -66,6 +66,7 @@
 #include <sys/stat.h>
 #include <netdb.h>
 #include <sys/param.h>
+#include <signal.h>
 
 #include <swtpm/tpm_ioctl.h>
 
@@ -1001,6 +1002,11 @@ int main(int argc, char *argv[])
         if (tmp) {
             if (sscanf(tmp, "%zu", &buffersize) != 1 || buffersize < 1)
                 buffersize = 1;
+        }
+    } else {
+        if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
+            fprintf(stderr, "Could not install signal handler for SIGPIPE.");
+            goto exit;
         }
     }
 


### PR DESCRIPTION
This series of patches fixes a couple of issues related to closed pipes. swtpm_ioctl and swtpm_bios need to ignore SIGPIPE so they can receive EPIPE from a failing write()/writev(). 

Swtpm should no accept any new control channel connections while it still has a control channel client but wait until this client has closed, otherwise we may end up closing the new control channel client's fd if poll() indicated that the previous client closed the connection.