### PR TITLE
swtpm: Only accept() new client ctrl connection if we have none

### DIFF
--- a/src/swtpm/mainloop.c
+++ b/src/swtpm/mainloop.c
@@ -150,7 +150,7 @@ int mainLoop(struct mainLoopParams *mlp,
                     .events = POLLIN,
                     .revents = 0,
                 }, {
-                    .fd = ctrlfd,
+                    .fd = -1,
                     .events = POLLIN,
                     .revents = 0,
                 } , {
@@ -168,6 +168,8 @@ int mainLoop(struct mainLoopParams *mlp,
             /* only listend for clients if we don't have one */
             if (connection_fd.fd < 0)
                 pollfds[DATA_SERVER_FD].fd = sockfd;
+            if (ctrlclntfd < 0)
+                pollfds[CTRL_SERVER_FD].fd = ctrlfd;
 
             ready = poll(pollfds, 5, -1);
             if (ready < 0 && errno == EINTR)


### PR DESCRIPTION
Only accept new client connection on the control channel if we
currently do not have a client on the control channel.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>