### PR TITLE
Enable spaces in paths

### DIFF
--- a/samples/swtpm-create-tpmca
+++ b/samples/swtpm-create-tpmca
@@ -13,16 +13,16 @@ logit()
 	if [ -z "$LOGFILE" ]; then
 		echo "$@" >&1
 	else
-		echo "$@" >> $LOGFILE
+		echo "$@" >> "$LOGFILE"
 	fi
 }
 
 logerr()
 {
 	if [ -z "$LOGFILE" ]; then
-		echo "Error: $@" >&2
+		echo "Error: $*" >&2
 	else
-		echo "Error: $@" >> $LOGFILE
+		echo "Error: $*" >> "$LOGFILE"
 	fi
 }
 
@@ -32,10 +32,10 @@ logerr()
 function get_filesize()
 {
 	if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-) ]]; then
-		stat -c%s $1
+		stat -c%s "$1"
 	else
 		# OpenBSD
-		stat -f%z $1
+		stat -f%z "$1"
 	fi
 }
 
@@ -48,7 +48,7 @@ function get_filesize()
 run_tpmtool() {
 	local prg out rc
 
-	prg="spawn tpmtool $@
+	prg="spawn tpmtool "$@"
 		expect {
 			\"Enter SRK password:\" {
 				send \"${TPM_SRK_PASSWORD}\n\"
@@ -89,47 +89,42 @@ create_localca_cert() {
 	local tpmkeyurl params
 	local msg output
 
-	if ! [ -r "${cakey}" ] || ! [ -r ${cacert} ]; then
-		local passparam
-
-		if [ -n "${SWTPM_ROOTCA_PASSWORD}" ]; then
-			passparam="--password ${SWTPM_ROOTCA_PASSWORD}"
-		fi
-		msg=$(${CERTTOOL} \
+	if ! [ -r "${cakey}" ] || ! [ -r "${cacert}" ]; then
+		msg=$("${CERTTOOL}" \
 			--generate-privkey \
-			--outfile ${cakey} \
-			${passparam} \
+			${SWTPM_ROOTCA_PASSWORD:+--password "${SWTPM_ROOTCA_PASSWORD}"} \
+			--outfile "${cakey}" \
 			2>&1)
 		[ $? -ne 0 ] && {
 			logerr "Could not create root-CA key ${cakey}."
 			logerr "${msg}"
 			return 1
 		}
-		chmod 640 ${cakey}
+		chmod 640 "${cakey}"
 
-		echo "cn=swtpm-localca-rootca" > ${template}
-		echo "ca" >> ${template}
-		echo "cert_signing_key" >> ${template}
-		echo "expiration_days = 3650" >> ${template}
+		echo "cn=swtpm-localca-rootca" > "${template}"
+		echo "ca" >> "${template}"
+		echo "cert_signing_key" >> "${template}"
+		echo "expiration_days = 3650" >> "${template}"
 
-		msg=$(GNUTLS_PIN=${SWTPM_ROOTCA_PASSWORD} ${CERTTOOL} \
+		msg=$(GNUTLS_PIN="${SWTPM_ROOTCA_PASSWORD}" ${CERTTOOL} \
 			--generate-self-signed \
-			--template ${template} \
-			--outfile ${cacert} \
-			--load-privkey ${cakey} \
+			--template "${template}" \
+			--outfile "${cacert}" \
+			--load-privkey "${cakey}" \
 			2>&1)
 
 		if [ $? -ne 0 ]; then
 			logerr "Could not create root CA."
 			logerr "${msg}"
-			rm -f ${cakey} ${template}
+			rm -f "${cakey}" "${template}"
 			return 1
 		fi
 	else
 		logit "Reusing existing root CA"
 	fi
 
-	rm -f ${tpmkey} ${tpmpubkey} ${tpmca}
+	rm -f "${tpmkey}" "${tpmpubkey}" "${tpmca}"
 
 	if [ $((flags & FLAG_SRK_WELL_KNOWN)) -ne 0 ]; then
 		unset GNUTLS_PIN
@@ -153,7 +148,7 @@ create_localca_cert() {
 		fi
 	else
 		rm -f "${tpmkey}"
-		msg="$(run_tpmtool --generate-rsa --signing --outfile "${tpmkey}" ${params})"
+		msg="$(run_tpmtool --generate-rsa --signing --outfile \"${tpmkey}\" ${params})"
 		if [ $? -ne 0 ]; then
 			logerr "Could not create signing key with tpmtool"
 			logerr "${msg}"
@@ -165,33 +160,33 @@ create_localca_cert() {
 			rm -f "${tpmkey}"
 			return 1
 		fi
-		chmod 640 ${tpmkey}
-		tpmkeyurl=tpmkey:file=${tpmkey}
+		chmod 640 "${tpmkey}"
+		tpmkeyurl="tpmkey:file=${tpmkey}"
 	fi
 
 	rm -f "${tpmpubkey}"
-	msg=$(run_tpmtool --pubkey=${tpmkeyurl} --outfile "${tpmpubkey}" ${params})
+	msg=$(run_tpmtool "--pubkey=${tpmkeyurl}" --outfile \"${tpmpubkey}\" ${params})
 	if [ $? -ne 0 ] || \
-           [ ! -r ${tpmpubkey} ] || [ $(get_filesize "${tpmpubkey}") -eq 0 ]; then
+           [ ! -r "${tpmpubkey}" ] || [ $(get_filesize "${tpmpubkey}") -eq 0 ]; then
 		logerr "Error: Could not get TPM public key"
 		logerr "${msg}"
 		rm -f "${tpmkey}" "${tpmpubkey}"
 		return 1
 	fi
 
-	echo "cn=swtpm-localca" > ${template}
-	echo "ca" >> ${template}
-	echo "cert_signing_key" >> ${template}
-	echo "expiration_days = 3650" >> ${template}
+	echo "cn=swtpm-localca" > "${template}"
+	echo "ca" >> "${template}"
+	echo "cert_signing_key" >> "${template}"
+	echo "expiration_days = 3650" >> "${template}"
 
 	msg=$(${CERTTOOL} \
 		--generate-certificate \
-		--template ${template} \
-		--outfile ${tpmca} \
-		--load-ca-privkey ${cakey} \
-		--load-ca-certificate ${cacert} \
-		--load-privkey ${tpmkeyurl} \
-		--load-pubkey ${tpmpubkey} \
+		--template "${template}" \
+		--outfile "${tpmca}" \
+		--load-ca-privkey "${cakey}" \
+		--load-ca-certificate "${cacert}" \
+		--load-privkey "${tpmkeyurl}" \
+		--load-pubkey "${tpmpubkey}" \
 		2>&1)
 
 	if [ $? -ne 0 ]; then
@@ -222,20 +217,20 @@ TSS_TCSD_PORT = ${TSS_TCSD_PORT}"
 	echo "${output}"
 
 	if [ "$(id -u)" -eq 0 ]; then
-		chown "${owner}":"${group}" ${dir}
+		chown "${owner}:${group}" "${dir}"
 
-		pushd ${dir} &>/dev/null
+		pushd "${dir}" &>/dev/null
 		if [ $? -eq 0 ]; then
-			chown "${owner}":"${group}" *
+			chown "${owner}:${group}" ./*
 			popd &>/dev/null
 		fi
 
 		if [ -n "${outfile}" ]; then
-			chown "${owner}":"${group}" "${outfile}"
+			chown "${owner}:${group}" "${outfile}"
 		fi
 	fi
 
-	rm -f ${template}
+	rm -f "${template}"
 
 	return 0
 } #create_localca_cert
@@ -253,7 +248,7 @@ usage() {
 	cat << _EOF_
 Create a TPM-based CA for signing EK and platform certificates.
 
-Usage: $(basename $1) [options]
+Usage: $(basename "$1") [options]
 
 THIS SCRIPT IS EXPERIMENTAL
 

--- a/samples/swtpm-localca.in
+++ b/samples/swtpm-localca.in
@@ -71,16 +71,16 @@ logit()
 	if [ -z "$LOGFILE" ]; then
 		echo "$@" >&1
 	else
-		echo "$@" >> $LOGFILE
+		echo "$@" >> "$LOGFILE"
 	fi
 }
 
 logerr()
 {
 	if [ -z "$LOGFILE" ]; then
-		echo "Error: $@" >&2
+		echo "Error: $*" >&2
 	else
-		echo "Error: $@" >> $LOGFILE
+		echo "Error: $*" >> "$LOGFILE"
 	fi
 }
 
@@ -90,9 +90,9 @@ flock_fd()
 
 	case "${UNAME_S}" in
 	Darwin)
-		flock $fd;;
+		flock "$fd";;
 	*)
-		flock -x $fd;;
+		flock -x "$fd";;
 	esac
 }
 
@@ -105,13 +105,13 @@ get_config_value() {
 	local defaultvalue="$3"
 	local tmp
 
-	if [ ! -r $configfile ]; then
+	if [ ! -r "$configfile" ]; then
 		logerr "Cannot read config file $configfile"
 		return 1
 	fi
 
 	tmp=$(sed -n "s/^${configname}[[:space:]]*=[[:space:]]*//p" \
-		$configfile)
+		"$configfile")
 	tmp=${tmp%% }
 	if [ -z "$tmp" ]; then
 		if [ -n "$defaultvalue" ]; then
@@ -123,7 +123,7 @@ get_config_value() {
 		# don't let eval execute subshells: removed '`' and
 		# convert '$(' to '('
 		tmp=$(echo "$tmp" | sed -e 's/\$(/(/g' -e 's/`\(.*\)`/\1/g')
-		echo $(eval echo "$tmp")
+		echo "$(eval echo "$tmp")"
 	fi
 
 	return 0
@@ -155,7 +155,7 @@ make_dir() {
 get_next_cert_serial() {
 	local serial
 
-	touch ${LOCK}
+	touch "${LOCK}"
 	(
 		# Avoid concurrent creation of next serial
 		flock_fd 100
@@ -163,22 +163,22 @@ get_next_cert_serial() {
 			logerr "Could not get lock ${LOCK}"
 			return 1
 		fi
-		if [ ! -r ${CERTSERIAL} ]; then
-			echo -n "0" > ${CERTSERIAL}
+		if [ ! -r "${CERTSERIAL}" ]; then
+			echo -n "0" > "${CERTSERIAL}"
 		fi
-		serial=$(cat ${CERTSERIAL})
+		serial=$(cat "${CERTSERIAL}")
 		if ! [[ "$serial" =~ ^[0-9]+$ ]]; then
 			serial=1
 		else
 			serial=$((serial+1))
 		fi
-		echo -n $serial > ${CERTSERIAL}
+		echo -n $serial > "${CERTSERIAL}"
 		if [ $? -ne 0 ]; then
 			logerr "Could not write cert serial number file"
 			return 1
 		fi
 		echo $serial
-	) 100>${LOCK}
+	) 100>"${LOCK}"
 
 	return 0
 }
@@ -192,19 +192,19 @@ create_cert() {
 	local tpm_spec_params="$6"
 	local tpm_attr_params="$7"
 
-	local serial=$(get_next_cert_serial)
-	local options="" rc=0 keyparms=""
+	local options="" rc=0 keyparms="" serial skfile skpkcs
 
+	serial=$(get_next_cert_serial)
 	if [ -z "$serial" ]; then
 		return 1
 	fi
 
 	if [ -r "${LOCALCA_OPTIONS}" ]; then
-		options=$(cat ${LOCALCA_OPTIONS})
+		options=$(cat "${LOCALCA_OPTIONS}")
 	fi
 
 	if [ -n "${SIGNKEY_PASSWORD}" ]; then
-		options="$options --signkey-password ${SIGNKEY_PASSWORD}"
+		options="$options --signkey-password \"${SIGNKEY_PASSWORD}\""
 	fi
 
 	if [ -n "${PARENTKEY_PASSWORD}" ]; then
@@ -235,12 +235,19 @@ create_cert() {
 
 	# if ek contains x=..,y=... it's an ECC key
 	if [[ "$ek" =~ x=.*,y=.* ]]; then
-		keyparms="--ecc-x \"$(echo $ek | \
+		keyparms="--ecc-x \"$(echo "$ek" | \
 		                sed -n 's/x=\([[:xdigit:]]*\),.*/\1/p')\" "
-		keyparms+="--ecc-y \"$(echo $ek | \
+		keyparms+="--ecc-y \"$(echo "$ek" | \
 		                sed -n 's/.*y=\([[:xdigit:]]*\)/\1/p')\""
 	else
 		keyparms="--modulus \"${ek}\""
+	fi
+
+	# we need to escape it if string contains ';'
+	if [[ "$SIGNKEY" = "${SIGNKEY%;*}" ]]; then
+		skfile="${SIGNKEY}"
+	else
+		skpkcs="$(escape_pkcs11_url "${SIGNKEY}")"
 	fi
 
 	case "$typ" in
@@ -253,12 +260,13 @@ create_cert() {
 			$options \
 			$tpm_spec_params \
 			$tpm_attr_params \
-			--signkey "$(escape_pkcs11_url ${SIGNKEY})" \
-			--issuercert ${ISSUERCERT} \
-			--out-cert ${dir}/ek.cert \
+			${skpkcs:+--signkey "$skpkcs"} \
+			${skfile:+--signkey \"$skfile\"} \
+			--issuercert \"${ISSUERCERT}\" \
+			--out-cert \"${dir}/ek.cert\" \
 			$keyparms \
 			--days $((10*365)) \
-			--serial $serial
+			--serial \"$serial\"
 			if [ $? -eq 0 ]; then
 				logit "Successfully created EK certificate locally."
 			else
@@ -276,12 +284,13 @@ create_cert() {
 			$options \
 			$tpm_attr_params \
 			--type platform \
-			--signkey ${SIGNKEY} \
-			--issuercert ${ISSUERCERT} \
-			--out-cert ${dir}/platform.cert \
+			${skpkcs:+--signkey "$skpkcs"} \
+			${skfile:+--signkey \"$skfile\"} \
+			--issuercert \"${ISSUERCERT}\" \
+			--out-cert \"${dir}/platform.cert\" \
 			$keyparms \
 			--days $((10*365)) \
-			--serial $serial
+			--serial \"$serial\"
 			if [ $? -eq 0 ]; then
 				logit "Successfully created platform certificate locally."
 			else
@@ -300,7 +309,7 @@ create_cert() {
 # here as well so that we get an Authority Key Id in our EK cert.
 #
 create_localca_cert() {
-	touch ${LOCK}
+	touch "${LOCK}"
 	(
 		# Avoid concurrent creation of keys and certs
 		flock_fd 100
@@ -308,50 +317,46 @@ create_localca_cert() {
 			logerr "Could not get lock ${LOCK}"
 			return 1
 		fi
-		if [ ! -d ${STATEDIR} ]; then
+		if [ ! -d "${STATEDIR}" ]; then
 			# RPM installation must have created this already ...
 			# so user tss can use it (user tss cannot create it)
-			mkdir -p ${STATEDIR}
+			mkdir -p "${STATEDIR}"
 		fi
-		if [ ! -r ${SIGNKEY} ]; then
-			local dir=$(dirname ${SIGNKEY})
+		if [ ! -r "${SIGNKEY}" ]; then
+			local dir=$(dirname "${SIGNKEY}")
 			local cakey=${dir}/swtpm-localca-rootca-privkey.pem
 			local cacert=${dir}/swtpm-localca-rootca-cert.pem
-			local msg passparam
-
-			if [ -n "${SWTPM_ROOTCA_PASSWORD}" ]; then
-				passparam="--password ${SWTPM_ROOTCA_PASSWORD}"
-			fi
+			local msg
 
 			# create a CA first
-			msg=$(${CERTTOOL} \
+			msg=$("${CERTTOOL}" \
 				--generate-privkey \
-				--outfile ${cakey} \
-				${passparam} \
+				${SWTPM_ROOTCA_PASSWORD:+--password "${SWTPM_ROOTCA_PASSWORD}"} \
+				--outfile "${cakey}" \
 				2>&1)
 			[ $? -ne 0 ] && {
 				logerr "Could not create root-CA key ${cakey}."
 				logerr "${msg}"
 				return 1
 			}
-			chmod 640 ${cakey}
+			chmod 640 "${cakey}"
 
 			local tmp=$(mktemp)
-			echo "cn=swtpm-localca-rootca" > ${tmp}
-			echo "ca" >> ${tmp}
-			echo "cert_signing_key" >> ${tmp}
-			echo "expiration_days = 3650" >> ${tmp}
+			echo "cn=swtpm-localca-rootca" > "${tmp}"
+			echo "ca" >> "${tmp}"
+			echo "cert_signing_key" >> "${tmp}"
+			echo "expiration_days = 3650" >> "${tmp}"
 
-			msg=$(GNUTLS_PIN=${SWTPM_ROOTCA_PASSWORD} ${CERTTOOL} \
+			msg=$(GNUTLS_PIN="${SWTPM_ROOTCA_PASSWORD}" "${CERTTOOL}" \
 				--generate-self-signed \
-				--template ${tmp} \
-				--outfile ${cacert} \
-				--load-privkey ${cakey} \
+				--template "${tmp}" \
+				--outfile "${cacert}" \
+				--load-privkey "${cakey}" \
 				2>&1)
 			[ $? -ne 0 ] && {
 				logerr "Could not create root CA."
 				logerr "${msg}"
-				rm -f ${cakey}
+				rm -f "${cakey}"
 				return 1
 			}
 
@@ -360,47 +365,47 @@ create_localca_cert() {
 				export GNUTLS_PIN=${SIGNKEY_PASSWORD}
 			fi
 
-			msg=$(${CERTTOOL} \
+			msg=$("${CERTTOOL}" \
 				--generate-privkey \
-				--outfile ${SIGNKEY} \
+				--outfile "${SIGNKEY}" \
 				2>&1)
 			[ $? -ne 0 ] && {
-				rm -f ${cakey} ${cacert}
+				rm -f "${cakey}" "${cacert}"
 				logerr "Could not create local-CA key ${SIGNKEY}."
 				logerr "${msg}"
 				return 1
 			}
-			chmod 640 ${SIGNKEY}
+			chmod 640 "${SIGNKEY}"
 
-			echo "cn=swtpm-localca" > ${tmp}
-			echo "ca" >> ${tmp}
-			echo "cert_signing_key" >> ${tmp}
-			echo "expiration_days = 3650" >> ${tmp}
+			echo "cn=swtpm-localca" > "${tmp}"
+			echo "ca" >> "${tmp}"
+			echo "cert_signing_key" >> "${tmp}"
+			echo "expiration_days = 3650" >> "${tmp}"
 
-			msg=$(GNUTLS_PIN=${SWTPM_ROOTCA_PASSWORD} ${CERTTOOL} \
+			msg=$(GNUTLS_PIN="${SWTPM_ROOTCA_PASSWORD}" "${CERTTOOL}" \
 				--generate-certificate \
-				--template ${tmp} \
-				--outfile ${ISSUERCERT} \
-				--load-privkey ${SIGNKEY} \
-				--load-ca-privkey ${cakey} \
-				--load-ca-certificate ${cacert} \
+				--template "${tmp}" \
+				--outfile "${ISSUERCERT}" \
+				--load-privkey "${SIGNKEY}" \
+				--load-ca-privkey "${cakey}" \
+				--load-ca-certificate "${cacert}" \
 				2>&1)
 			[ $? -ne 0 ] && {
-				rm -f ${cakey} ${cacert} ${SIGNKEY}
+				rm -f "${cakey}" "${cacert}" "${SIGNKEY}"
 				logerr "Could not create local CA."
 				logerr "${msg}"
 				return 1
 			}
-			rm -f ${tmp}
+			rm -f "${tmp}"
 		fi
-	) 100>${LOCK}
+	) 100>"${LOCK}"
 
 	return 0
 }
 
 usage() {
        cat <<_EOF_
-Usage: $(basename $1) [options]
+Usage: $(basename "$1") [options]
 
 The following options are supported:
 
@@ -513,7 +518,7 @@ main() {
 	done
 
 	if [ -n "$LOGFILE" ]; then
-		touch $LOGFILE &>/dev/null
+		touch "$LOGFILE" &>/dev/null
 		if [ ! -w "$LOGFILE" ]; then
 			logerr "Cannot write to logfile ${LOGFILE}."
 			exit 1
@@ -538,9 +543,9 @@ main() {
 	STATEDIR="$tmp"
 	make_dir "$STATEDIR"
 	LOCK="${STATEDIR}/.lock.swtpm-localca"
-	if [ ! -w ${LOCK} ]; then
-		touch $LOCK
-		if [ ! -w ${LOCK} ]; then
+	if [ ! -w "${LOCK}" ]; then
+		touch "$LOCK"
+		if [ ! -w "${LOCK}" ]; then
 			logerr "Could not create lock file ${LOCK}."
 			exit 1
 		fi
@@ -553,7 +558,7 @@ main() {
 	fi
 	# SIGNKEY may be a GNUTLS url like tpmkey:file= or tpmkey:uuid=
 	if ! [[ "${SIGNKEY}" =~ ^tpmkey:(file|uuid)= ]]; then
-		make_dir $(dirname "$SIGNKEY")
+		make_dir "$(dirname "$SIGNKEY")"
 	fi
 	SIGNKEY_PASSWORD=$(get_config_value "$LOCALCA_CONFIG" "signingkey_password")
 	PARENTKEY_PASSWORD=$(get_config_value "$LOCALCA_CONFIG" "parentkey_password")
@@ -563,7 +568,7 @@ main() {
 		logerr "Missing issuercert variable in config file $LOCALCA_CONFIG."
 		exit 1
 	fi
-	make_dir $(dirname "$ISSUERCERT")
+	make_dir "$(dirname "$ISSUERCERT")"
 
 	# set global CERTTOOL to gnutls's certtool
 	case "${UNAME_S}" in
@@ -614,7 +619,7 @@ main() {
 
 	CERTSERIAL=$(get_config_value "$LOCALCA_CONFIG" "certserial" \
 	    "${STATEDIR}/certserial")
-	make_dir $(dirname "$CERTSERIAL")
+	make_dir "$(dirname "$CERTSERIAL")"
 
 	create_cert "$flags" "$typ" "$dir" "$ek" "$vmid" "$tpm_spec_params" \
 		"$tpm_attr_params"

--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -51,13 +51,13 @@
 # The launcher 'swtpm_setup' ensures that this range is not used by
 # any valid file descriptors passed as parameters.
 
-SWTPM=`type -P swtpm`
+SWTPM=$(type -P swtpm)
 if [ -n "$SWTPM" ]; then
     SWTPM="$SWTPM socket"
 fi
-SWTPM_IOCTL=`type -P swtpm_ioctl`
+SWTPM_IOCTL=$(type -P swtpm_ioctl)
 
-ECHO=`which echo`
+ECHO=$(which echo)
 if [ -z "$ECHO" ]; then
     echo "Error: external echo program not found."
     exit 1
@@ -107,13 +107,13 @@ TPM_NV_INDEX_LOCK=$((0xFFFFFFFF))
 
 # TPM 2 constants
 TPMA_NV_PLATFORMCREATE=$((0x40000000))
-TPMA_NV_AUTHWRITE=$((0x4))
+#TPMA_NV_AUTHWRITE=$((0x4))
 TPMA_NV_AUTHREAD=$((0x40000))
 TPMA_NV_NO_DA=$((0x2000000))
 TPMA_NV_PPWRITE=$((0x1))
 TPMA_NV_PPREAD=$((0x10000))
 TPMA_NV_OWNERREAD=$((0x20000))
-TPMA_NV_POLICY_DELETE=$((0x400))
+#TPMA_NV_POLICY_DELETE=$((0x400))
 TPMA_NV_WRITEDEFINE=$((0x2000))
 
 # Use standard EK Cert NVRAM, EK and SRK handles per IWG spec.
@@ -153,7 +153,7 @@ logit()
 	if [ -z "$LOGFILE" ]; then
 		echo "$@" >&1
 	else
-		echo "$@" >> $LOGFILE
+		echo "$@" >> "$LOGFILE"
 	fi
 }
 
@@ -162,17 +162,34 @@ logit_cmd()
 	if [ -z "$LOGFILE" ]; then
 		eval "$@" >&1
 	else
-		eval "$@" >> $LOGFILE
+		eval "$@" >> "$LOGFILE"
 	fi
 }
 
 logerr()
 {
 	if [ -z "$LOGFILE" ]; then
-		echo "Error: $@" >&2
+		echo "Error: $*" >&2
 	else
-		echo "Error: $@" >> $LOGFILE
+		echo "Error: $*" >> "$LOGFILE"
 	fi
+}
+
+# Check a variable value for spaces and if it has spaces log an error
+# message and return 1, 0 otherwise
+# @param1: value to check for spaces
+# @param2: description to print in case space is found
+check_spaces()
+{
+	local var="$1"
+	local desc="$2"
+
+	if ! [[ "$var" = "${var%[[:space:]]*}" ]]; then
+		logerr "No spaces allowed in ${desc}: '$var'"
+		return 0
+	fi
+
+	return 1
 }
 
 # Get the size of a file
@@ -182,10 +199,10 @@ get_filesize()
 {
 	case "${UNAME_S}" in
 	OpenBSD|FreeBSD|NetBSD|Darwin|DragonFly)
-		stat -f%z $1
+		stat -f%z "$1"
 		;;
 	*)
-		stat -c%s $1
+		stat -c%s "$1"
 		;;
 	esac
 }
@@ -257,7 +274,7 @@ call_create_certs()
 	local ek="$4"
 	local vmid="$5"
 
-	local logparam tmp
+	local logparam tmp fn
 	local params="" cmd
 
 	if [ -n "$vmid" ]; then
@@ -265,7 +282,7 @@ call_create_certs()
 	fi
 
 	if [ -n "$LOGFILE" ]; then
-		logparam="--logfile $LOGFILE"
+		logparam="--logfile \"$LOGFILE\""
 	fi
 
 	params="${params} $(get_tpm_parameters)"
@@ -305,16 +322,16 @@ call_create_certs()
 	fi
 
 	if [ -n "$create_certs_tool" ]; then
-		local fn=$(basename "${create_certs_tool}")
+		fn=$(basename "${create_certs_tool}")
 
 		if [ $((flags & SETUP_EK_CERT_F)) -ne 0 ]; then
 			cmd="$create_certs_tool \
 				--type ek \
-				--ek "$ek" \
-				--dir "$certdir" \
+				--ek \"$ek\" \
+				--dir \"$certdir\" \
 				${logparam} ${params}"
 			logit "  Invoking: $(echo $cmd | tr -s " ")"
-			tmp="$(eval $cmd 2>&1)"
+			tmp="$(eval "$cmd" 2>&1)"
 			ret=$?
 			logit "$(echo "${tmp}" | sed -e "s/^/$fn: /")"
 			if [ $ret -ne 0 ]; then
@@ -325,11 +342,11 @@ call_create_certs()
 		if [ $((flags & SETUP_PLATFORM_CERT_F)) -ne 0 ]; then
 			cmd="$create_certs_tool \
 				--type platform \
-				--ek "$ek" \
-				--dir "$certdir" \
+				--ek \"$ek\" \
+				--dir \"$(echo $certdir)\" \
 				${logparam} ${params}"
 			logit "  Invoking: $(echo $cmd | tr -s " ")"
-			tmp="$(eval $cmd 2>&1)"
+			tmp="$(eval "$cmd" 2>&1)"
 			ret=$?
 			logit "$(echo "${tmp}" | sed -e "s/^/$fn: /")"
 			if [ $ret -ne 0 ]; then
@@ -346,10 +363,12 @@ call_create_certs()
 #
 # @param1: full path to the TPM executable to use
 # @param2: the directory where the TPM is supposed to write its state to
+# @param3: The --key option parameter to start swtpm with
 start_tpm()
 {
 	local swtpm="$1"
 	local swtpm_state="$2"
+	local swtpm_keyopt="$3"
 
 	local ctr=0 ctr2 ctr3
 	local pidfile="${swtpm_state}/.swtpm_setup.pidfile"
@@ -360,21 +379,22 @@ start_tpm()
 		# kill swtpm if still alive
 		stop_tpm 1
 
-		rm -f $pidfile &>/dev/null
+		rm -f "$pidfile" &>/dev/null
 		$swtpm \
+			${swtpm_keyopt:+--key "${swtpm_keyopt}"} \
 			--flags not-need-init \
-			-p $TPM_PORT \
-			--tpmstate dir=$swtpm_state \
+			-p "$TPM_PORT" \
+			--tpmstate "dir=$swtpm_state" \
 			--ctrl type=tcp,port=$((TPM_PORT+1)) \
-			--pid file=$pidfile \
-			2>&1 1>/dev/null &
+			--pid "file=$pidfile" \
+			&>/dev/null &
 		SWTPM_PID=$!
 
 		# poll for open port (good) or the process to have
 		# disappeared (bad); whatever happens first
 		ctr3=0
 		while :; do
-			kill -0 $SWTPM_PID 2>/dev/null
+			kill -0 "$SWTPM_PID" 2>/dev/null
 			if [ $? -ne 0 ]; then
 				# process dead; try next socket
 				break
@@ -384,16 +404,16 @@ start_tpm()
 			# testing swtpm's port rather than some other
 			# process's
 			ctr2=0
-			while [ -f ${pidfile} ]; do
+			while [ -f "${pidfile}" ]; do
 			        # test the connection to swtpm
-				(exec 100<>/dev/tcp/localhost/$TPM_PORT) 2>/dev/null
+				(exec 100<>"/dev/tcp/localhost/$TPM_PORT") 2>/dev/null
 				if [ $? -ne 0 ]; then
 					if [ $ctr2 -eq 40 ]; then
 						stop_tpm 0
 						break
 					fi
 					sleep 0.05
-					let ctr2=ctr2+1
+					ctr2=$((ctr2 + 1))
 					continue
 				fi
 				exec 100>&-
@@ -402,15 +422,15 @@ start_tpm()
 			done
 			sleep 0.05
 
-			let ctr3=ctr3+1
+			ctr3=$((ctr3 + 1))
 			# at some point the pid file must appear...
-			if [ $ctr3 -eq 40 ] && [ ! -f ${pidfile} ]; then
+			if [ $ctr3 -eq 40 ] && [ ! -f "${pidfile}" ]; then
 				stop_tpm 0
 				break
 			fi
 		done
 
-		let ctr=$ctr+1
+		ctr=$((ctr + 1))
 	done
 
 	return 1
@@ -430,19 +450,19 @@ terminate_proc()
 
 	local c
 
-	kill -0 $pid &>/dev/null
+	kill -0 "$pid" &>/dev/null
 	[ $? -ne 0 ] && return
 
-	kill -SIGTERM $pid &>/dev/null
+	kill -SIGTERM "$pid" &>/dev/null
 	[ $sync -eq 0 ] && return
 
 	# kill hard if necessary
 	for ((c=0; c<50; c++)); do
-		kill -0 $pid &>/dev/null
+		kill -0 "$pid" &>/dev/null
 		[ $? -ne 0 ] && return
 		sleep 0.02
 	done
-	kill -SIGKILL $pid
+	kill -SIGKILL "$pid"
 	logerr "Had to use SIGKILL on $name"
 }
 
@@ -465,11 +485,17 @@ stop_tpm()
 start_tcsd()
 {
 	local TCSD=$1
-	local user=$(id -u -n)
-	local group=$(id -g -n)
-	local ctr=0 ctr2
+
+	local user group ctr=0 ctr2
+
+	user=$(id -u -n)
+	group=$(id -g -n)
 
 	export TSS_TCSD_PORT
+
+	if check_spaces "$TMPDIR" "TMPDIR environment variable"; then
+		return 1
+	fi
 
 	TCSD_CONFIG="$(mktemp)"
 	TCSD_DATA_DIR="$(mktemp -d)"
@@ -484,21 +510,21 @@ start_tcsd()
 	while [ $ctr -lt 100 ]; do
 		TSS_TCSD_PORT=$(get_random 30000 65535)
 
-		cat << EOF >$TCSD_CONFIG
+		cat << EOF >"$TCSD_CONFIG"
 port = $TSS_TCSD_PORT
 system_ps_file = $TCSD_DATA_FILE
 EOF
 		# tcsd requires @TSS_USER@:@TSS_GROUP@ and 0600 on TCSD_CONFIG
 		# -> only root can start
-		chmod 600 $TCSD_CONFIG
+		chmod 600 "$TCSD_CONFIG"
 		if [ $(id -u) -eq 0 ]; then
-			chown @TSS_USER@:@TSS_GROUP@ $TCSD_CONFIG 2>/dev/null
-			chown @TSS_USER@:@TSS_GROUP@ $TCSD_DATA_DIR 2>/dev/null
-			chown @TSS_USER@:@TSS_GROUP@ $TCSD_DATA_FILE 2>/dev/null
+			chown "@TSS_USER@:@TSS_GROUP@" "$TCSD_CONFIG" 2>/dev/null
+			chown "@TSS_USER@:@TSS_GROUP@" "$TCSD_DATA_DIR" 2>/dev/null
+			chown "@TSS_USER@:@TSS_GROUP@" "$TCSD_DATA_FILE" 2>/dev/null
 		fi
 		if [ $? -ne 0 ]; then
 			logerr "Could not change ownership on $TCSD_CONFIG to ${user}:${group}."
-			ls -l $TCSD_CONFIG
+			ls -l "$TCSD_CONFIG"
 			return 1
 		fi
 
@@ -506,14 +532,14 @@ EOF
 		stop_tcsd 1
 		case "$(id -u)" in
 		0)
-			$TCSD -c $TCSD_CONFIG -e -f 2>&1 1>/dev/null &
+			$TCSD -c "$TCSD_CONFIG" -e -f &>/dev/null &
 			TCSD_PID=$!
 			;;
 		*)
 			# for tss user, use the wrapper
-			$TCSD -c $TCSD_CONFIG -e -f 2>&1 1>/dev/null &
+			$TCSD -c "$TCSD_CONFIG" -e -f &>/dev/null &
 			#if [ $? -ne  0]; then
-			#	swtpm_tcsd_launcher -c $TCSD_CONFIG -e -f 2>&1 1>/dev/null &
+			#	swtpm_tcsd_launcher -c $TCSD_CONFIG -e -f &>/dev/null &
 			#fi
 			TCSD_PID=$!
 			;;
@@ -523,7 +549,7 @@ EOF
 		# disappeared (bad); whatever happens first
 	        ctr2=0
 	        while :; do
-			(exec 100<>/dev/tcp/localhost/$TSS_TCSD_PORT) 2>/dev/null
+			(exec 100<>"/dev/tcp/localhost/$TSS_TCSD_PORT") 2>/dev/null
 			if [ $? -ne 0 ]; then
 				if [ $ctr2 -eq 40 ]; then
 					stop_tcsd 0
@@ -536,7 +562,7 @@ EOF
 					break
 				fi
 				# process still alive
-				let ctr2=ctr2+1
+				ctr2=$((ctr2 + 1))
 				sleep 0.05
 				continue
 			fi
@@ -545,7 +571,7 @@ EOF
 			return 0
 		done
 
-		let ctr=$ctr+1
+		ctr=$((ctr + 1))
 	done
 
 	return 1
@@ -622,7 +648,7 @@ send_hex_data()
 # @param1: The request to send
 tpm_transfer()
 {
-	exec 100<>/dev/tcp/127.0.0.1/${TPM_PORT}
+	exec 100<>"/dev/tcp/127.0.0.1/${TPM_PORT}"
 	send_hex_data "$1" >&100
 
 	read_hex_data <&100
@@ -663,6 +689,7 @@ tpm_createendorsementkeypair()
 # @param5: The SRK password to use
 # @param6: The ID of the VM
 # @param7: The filename to copy the TCSD system_ps_file to; optional
+# @param8: The --key option parameter to start swtpm with
 init_tpm()
 {
 	local flags="$1"
@@ -672,16 +699,17 @@ init_tpm()
 	local srkpass="$5"
 	local vmid="$6"
 	local tcsd_system_ps_file="$7"
+	local swtpm_keyopt="$8"
 
 	# where external app writes certs into
 	local certsdir="$tpm_state_path"
-	local ek tmp output
+	local ek tmp output nvidxs passparam
 
 	local PLATFORM_CERT_FILE="$certsdir/platform.cert"
 	local EK_CERT_FILE="$certsdir/ek.cert"
 	local nvramauth="OWNERREAD|OWNERWRITE"
 
-	start_tpm "$SWTPM" "$tpm_state_path"
+	start_tpm "$SWTPM" "$tpm_state_path" "$swtpm_keyopt"
 	if [ $? -ne 0 ]; then
 		logerr "Could not start the TPM."
 		return 1
@@ -697,7 +725,7 @@ init_tpm()
 	fi
 
 	# Creating EK is simple enough to do without the tcsd
-	if [ $((flags & $SETUP_CREATE_EK_F)) -ne 0 ]; then
+	if [ $((flags & SETUP_CREATE_EK_F)) -ne 0 ]; then
 		ek="$(tpm_createendorsementkeypair)"
 		if [ $? -ne 0 ]; then
 			logerr "tpm_createendorsementkeypair failed."
@@ -705,26 +733,26 @@ init_tpm()
 		fi
 		logit "Successfully created EK."
 
-		if [ $((flags & ~$SETUP_CREATE_EK_F)) -eq 0 ]; then
+		if [ $((flags & ~SETUP_CREATE_EK_F)) -eq 0 ]; then
 			return 0
 		fi
 	fi
 
 	# TPM is enabled and activated upon first start
 
-	start_tcsd $TCSD
+	start_tcsd "$TCSD"
 	if [ $? -ne 0 ]; then
 		return 1
 	fi
 
 	# temporarily take ownership if an EK was created
-	if [  $((flags & $SETUP_CREATE_EK_F)) -ne 0 ] ; then
+	if [  $((flags & SETUP_CREATE_EK_F)) -ne 0 ] ; then
 		local parm_z=""
 		local parm_y=""
-		if [ $((flags & $SETUP_SRKPASS_ZEROS_F)) -ne 0 ]; then
+		if [ $((flags & SETUP_SRKPASS_ZEROS_F)) -ne 0 ]; then
 			parm_z="-z"
 		fi
-		if [ $((flags & $SETUP_OWNERPASS_ZEROS_F)) -ne 0 ]; then
+		if [ $((flags & SETUP_OWNERPASS_ZEROS_F)) -ne 0 ]; then
 			parm_y="-y"
 		fi
 		if [ -n "${parm_y}" ] && [ -n "${parm_z}" ]; then
@@ -735,7 +763,7 @@ init_tpm()
 				       "ownership with non-standard password."
 				return 1
 			fi
-			a=$(expect -c "
+			tmp=$(expect -c "
 				set parm_z \"$parm_z\"
 				set parm_y \"$parm_y\"
 				spawn tpm_takeownership \$parm_z \$parm_y
@@ -789,7 +817,7 @@ init_tpm()
 		output="$(tpm_nvdefine \
 			-i $((TPM_NV_INDEX_EKCert|TPM_NV_INDEX_D_BIT)) \
 			-p "${nvramauth}" \
-			-s $(get_filesize "${EK_CERT_FILE}") 2>&1)"
+			-s "$(get_filesize "${EK_CERT_FILE}")" 2>&1)"
 		if [ $? -ne 0 ]; then
 			logerr "Could not create NVRAM area for EK certificate."
 			return 1
@@ -801,7 +829,7 @@ init_tpm()
 			return 1
 		fi
 		logit "Successfully created NVRAM area for EK certificate."
-		rm -f ${EK_CERT_FILE}
+		rm -f "${EK_CERT_FILE}"
 	fi
 
 	if [ $((flags & SETUP_PLATFORM_CERT_F)) -ne 0 ] && \
@@ -809,7 +837,7 @@ init_tpm()
 		output="$(tpm_nvdefine \
 			-i $((TPM_NV_INDEX_PlatformCert|TPM_NV_INDEX_D_BIT)) \
 			-p "${nvramauth}" \
-			-s $(get_filesize "${PLATFORM_CERT_FILE}") 2>&1)"
+			-s "$(get_filesize "${PLATFORM_CERT_FILE}")" 2>&1)"
 		if [ $? -ne 0 ]; then
 			logerr "Could not create NVRAM area for platform" \
 			       "certificate."
@@ -824,14 +852,13 @@ init_tpm()
 		fi
 		logit "Successfully created NVRAM area for platform" \
 		       "certificate."
-		rm -f ${PLATFORM_CERT_FILE}
+		rm -f "${PLATFORM_CERT_FILE}"
 	fi
 
 	if [ $((flags & SETUP_DISPLAY_RESULTS_F)) -ne 0 ]; then
-		local nvidxs=`tpm_nvinfo -n | grep 0x | gawk '{print $1}'`
-		local passparam
+		nvidxs=$(tpm_nvinfo -n | grep 0x | gawk '{print $1}')
 
-		if [ $((flags & $SETUP_OWNERPASS_ZEROS_F)) -ne 0 ]; then
+		if [ $((flags & SETUP_OWNERPASS_ZEROS_F)) -ne 0 ]; then
 			passparam="-z"
 		else
 			passparam="--password=$ownerpass"
@@ -839,7 +866,7 @@ init_tpm()
 
 		for i in $nvidxs; do
 			logit "Content of NVRAM area $i:"
-			tmp="tpm_nvread -i $i $passparam"
+			tmp="$(tpm_nvread -i "$i" "$passparam")"
 			logit_cmd "$cmd"
 		done
 	fi
@@ -855,9 +882,9 @@ init_tpm()
 	fi
 
 	# give up ownership if not wanted
-	if [ $((flags & SETUP_TAKEOWN_F))   -eq 0 -a \
-	     $((flags & SETUP_CREATE_EK_F)) -ne 0 ] ; then
-		if [ $((flags & $SETUP_OWNERPASS_ZEROS_F)) -ne 0 ]; then
+	if [ $((flags & SETUP_TAKEOWN_F))   -eq 0 ] && \
+	   [ $((flags & SETUP_CREATE_EK_F)) -ne 0 ] ; then
+		if [ $((flags & SETUP_OWNERPASS_ZEROS_F)) -ne 0 ]; then
 			tpm_clear -z &>/dev/null
 		else
 			if [ -z "$(type -p expect)" ]; then
@@ -865,7 +892,7 @@ init_tpm()
 				       "ownership with non-standard password."
 				return 1
 			fi
-			a=$(expect -c "
+			tmp=$(expect -c "
 				spawn tpm_clear
 				expect {
 					\"Enter owner password:\" { send \"$ownerpass\n\" }
@@ -1111,15 +1138,15 @@ function tpm2_createprimary_rsa_params()
 		return 1
 	fi
 
-	let off=off+6
+	off=$((off + 6))
 
 	# output: handle,ek
 	res="$(echo "0x${rsp:30:12}" | sed -n 's/ //pg'),"
 	res+="$(echo "${rsp:$off:768}" | sed -n 's/ //pg')"
-	echo $res
+	echo "$res"
 
 	if [ -n "${templatefile}" ]; then
-		$ECHO -en ${temp} > ${templatefile}
+		$ECHO -en "${temp}" > "${templatefile}"
 	fi
 
 	return 0
@@ -1292,16 +1319,16 @@ tpm2_createprimary_ecc_params()
 		return 1
 	fi
 
-	let off1=off1+6
-	let off2=off2+6
+	off1=$((off1 + 6))
+	off2=$((off2 + 6))
 
 	# output: handle,ek
 	res="$(echo "0x${rsp:30:12}" | sed -n 's/ //pg'),"
 	res+="$(echo x=${rsp:$off1:96},y=${rsp:$off2:96} | sed -n 's/ //pg')"
-	echo $res
+	echo "$res"
 
 	if [ -n "${templatefile}" ]; then
-		$ECHO -en ${temp} > ${templatefile}
+		$ECHO -en "${temp}" > "${templatefile}"
 	fi
 
 	return 0
@@ -1365,7 +1392,7 @@ tpm2_create_ek()
 	fi
 	[ $? -ne 0 ] && return 1
 
-	handle=$(echo $res | cut -d "," -f1)
+	handle=$(echo "$res" | cut -d "," -f1)
 
 	# make key permanent
 	if [ -n "$nehandle" ]; then
@@ -1374,7 +1401,7 @@ tpm2_create_ek()
 	fi
 
 	# ek
-	echo $res | cut -d "," -f2-
+	echo "$res" | cut -d "," -f2-
 
 	return 0
 }
@@ -1411,7 +1438,7 @@ tpm2_create_spk()
 	fi
 
 	# ek
-	echo $res | cut -d "," -f2-
+	echo "$res" | cut -d "," -f2-
 
 	return 0
 }
@@ -1433,13 +1460,13 @@ _format()
 	4) f="%08x"; num=$((num & 0xffffffff));;
 	esac
 
-	r="$(printf $f $num)"
+	r="$(printf "$f" "$num")"
 	for ((i = 0; i < ${#r}; i+=2 )); do
 		# prepare for usage with sed -> extra backslashes
 		res+="\\\x${r:$i:2}"
 	done
 
-	echo $res
+	echo "$res"
 }
 
 # Define an NVRAM space
@@ -1502,7 +1529,7 @@ tpm2_nv_write()
 
 	while :; do
 		# read data from file
-		data=$(dd bs=1 skip=${offset} count=${step} if=$fil \
+		data=$(dd bs=1 skip=${offset} count=${step} "if=$fil" \
 		          2>/dev/null| \
 	               read_hex_data | \
 	               sed -n 's/ /\\\\x/pg')
@@ -1519,7 +1546,7 @@ tpm2_nv_write()
 		          -e "s/@DATA@/${data}/" \
 		          -e "s/@OFFSET-2@/$(_format $offset 2)/")
 		totlen=$(( (${#req} / 4) + 10))
-		req=$(echo ${reqhdr}${req} | \
+		req=$(echo "${reqhdr}${req}" | \
 		      sed -e "s/@TOTLEN-4@/$(_format $totlen 4)/")
 
 		rsp="$(tpm_transfer "$req")"
@@ -1532,7 +1559,7 @@ tpm2_nv_write()
 			break
 		fi
 
-	        let offset=$offset+step
+	        offset=$((offset + step))
 	done
 
 	return $rc
@@ -1622,7 +1649,7 @@ function tpm2_set_active_pcr_banks()
 	local all_pcr_banks="$2"
 
 	local req rsp exp pcr_bank totlen count
-	local OIFS="$IFS" active=""
+	local active=""
 
 	req='\x80\x02@TOTLEN-4@\x00\x00\x01\x2b'
 	req+='\x40\x00\00\x0c'
@@ -1633,7 +1660,7 @@ function tpm2_set_active_pcr_banks()
 	count=0
 
 	# enable the ones the user wants
-	for pcr_bank in $(echo ${pcr_banks} | tr "," "\n"); do
+	for pcr_bank in $(echo "${pcr_banks}" | tr "," "\n"); do
 		# skip if not even available
 		! [[ ",${all_pcr_banks}," =~ ",${pcr_bank}," ]] && continue
 		case "${pcr_bank}" in
@@ -1660,7 +1687,7 @@ function tpm2_set_active_pcr_banks()
 	fi
 
 	# disable the rest
-	for pcr_bank in $(echo ${all_pcr_banks} | tr "," "\n"); do
+	for pcr_bank in $(echo "${all_pcr_banks}" | tr "," "\n"); do
 		# skip over those to activate
 		[[ ",${pcr_banks}," =~ ",${pcr_bank}," ]] && continue
 
@@ -1682,7 +1709,7 @@ function tpm2_set_active_pcr_banks()
 
 	totlen=$((totlen + count * 6))
 
-	req=$(echo $req | \
+	req=$(echo "$req" | \
 	      sed -e "s/@TOTLEN-4@/$(_format "$totlen" 4)/" \
 	          -e "s/@COUNT-4@/$(_format "$count" 4)/")
 
@@ -1730,6 +1757,7 @@ function tpm2_shutdown
 # @param5: The SRK password to use
 # @param6: The ID of the VM
 # @param7: The set of PCR banks to activate
+# @param8: The --key option parameter to start swtpm with
 init_tpm2()
 {
 	local flags="$1"
@@ -1739,17 +1767,18 @@ init_tpm2()
 	local srkpass="$5"
 	local vmid="$6"
 	local pcr_banks="$7"
+	local swtpm_keyopt="$8"
 
 	# where external app writes certs into
 	local certsdir="$tpm2_state_path"
-	local ek tmp output nvindex nxindex_str
+	local ek tmp output nvindex nvindex_str
 	local all_pcr_banks active_pcr_banks
 
 	local PLATFORM_CERT_FILE="$certsdir/platform.cert"
 	local EK_CERT_FILE="$certsdir/ek.cert"
 	local EK_TEMP_FILE="$certsdir/ektemplate"
 
-	start_tpm "$SWTPM" "$tpm2_state_path"
+	start_tpm "$SWTPM" "$tpm2_state_path" "$swtpm_keyopt"
 	if [ $? -ne 0 ]; then
 		logerr "Could not start the TPM 2."
 		return 1
@@ -1764,17 +1793,17 @@ init_tpm2()
 		return 1
 	fi
 
-	if [ $((flags & $SETUP_CREATE_SPK_F)) -ne 0 ]; then
+	if [ $((flags & SETUP_CREATE_SPK_F)) -ne 0 ]; then
 		pk=$(tpm2_create_spk "$flags" "${TPM2_SPK_HANDLE}")
 		if [ $? -ne 0 ]; then
-			logerr "tpm2_create_spk failed"
+			logerr "tpm2_create_spk failed: $pk"
 			return 1
 		fi
 		logit "Successfully created storage primary key with " \
 		      "handle $(printf "0x%08x" ${TPM2_SPK_HANDLE})."
 	fi
 
-	if [ $((flags & $SETUP_CREATE_EK_F)) -ne 0 ]; then
+	if [ $((flags & SETUP_CREATE_EK_F)) -ne 0 ]; then
 		ek=$(tpm2_create_ek "$flags" "${TPM2_EK_HANDLE}" \
 		     "${EK_TEMP_FILE}")
 		if [ $? -ne 0 ]; then
@@ -1791,7 +1820,7 @@ init_tpm2()
 		fi
 		nvindex_str="$(printf "0x%08x" ${nvindex})"
 
-		if [ $((flags & $SETUP_ALLOW_SIGNING_F )) -ne 0 ]; then
+		if [ $((flags & SETUP_ALLOW_SIGNING_F )) -ne 0 ]; then
 			tpm2_nv_define \
 				${nvindex} \
 				$((TPMA_NV_PLATFORMCREATE | \
@@ -1801,7 +1830,7 @@ init_tpm2()
 				   TPMA_NV_PPWRITE | \
 				   TPMA_NV_NO_DA | \
 				   TPMA_NV_WRITEDEFINE)) \
-				$(get_filesize "${EK_TEMP_FILE}")
+				"$(get_filesize "${EK_TEMP_FILE}")"
 			if [ $? -ne 0 ]; then
 				logerr "Could not create NVRAM area ${nvindex_str}" \
 				       "for EK template."
@@ -1826,7 +1855,7 @@ init_tpm2()
 			fi
 			logit "Successfully created NVRAM area ${nvindex_str} for EK template."
 		fi
-		rm -f ${EK_TEMP_FILE}
+		rm -f "${EK_TEMP_FILE}"
 	fi
 
 	# have external program create the certificates now
@@ -1854,7 +1883,7 @@ init_tpm2()
 			   TPMA_NV_PPWRITE | \
 			   TPMA_NV_NO_DA | \
 			   TPMA_NV_WRITEDEFINE)) \
-			$(get_filesize "${EK_CERT_FILE}")
+			"$(get_filesize "${EK_CERT_FILE}")"
 		if [ $? -ne 0 ]; then
 			logerr "Could not create NVRAM area ${nvindex_str}" \
 			       "for EK certificate."
@@ -1878,7 +1907,7 @@ init_tpm2()
 			fi
 		fi
 		logit "Successfully created NVRAM area ${nvindex_str} for EK certificate."
-		rm -f ${EK_CERT_FILE}
+		rm -f "${EK_CERT_FILE}"
 	fi
 
 	if [ $((flags & SETUP_PLATFORM_CERT_F)) -ne 0 ] && \
@@ -1896,7 +1925,7 @@ init_tpm2()
 			   TPMA_NV_PPWRITE | \
 			   TPMA_NV_NO_DA | \
 			   TPMA_NV_WRITEDEFINE)) \
-			$(get_filesize "${PLATFORM_CERT_FILE}")
+			"$(get_filesize "${PLATFORM_CERT_FILE}")"
 		if [ $? -ne 0 ]; then
 			logerr "Could not create NVRAM area ${nvindex_str}" \
 			       "for platform certificate."
@@ -1921,7 +1950,7 @@ init_tpm2()
 		fi
 		logit "Successfully created NVRAM area ${nvindex_str}" \
 		      "for platform certificate."
-		rm -f ${PLATFORM_CERT_FILE}
+		rm -f "${PLATFORM_CERT_FILE}"
 	fi
 
 	if [ "$pcr_banks" != "-" ]; then
@@ -2116,7 +2145,7 @@ main()
 	local keyfile pwdfile cipher="aes-128-cbc"
 	local keyfile_fd pwdfile_fd
 	local got_ownerpass=0 got_srkpass=0
-	local pcr_banks=""
+	local pcr_banks="" swtpm_keyopt=""
 	local tcsd_system_ps_file=""
 
 	while [ $# -ne 0 ]; do
@@ -2155,10 +2184,10 @@ main()
 		--decryption) flags=$((flags | SETUP_DECRYPTION_F));;
 		--pcr-banks) shift; pcr_banks="${pcr_banks},$1";;
 		--tcsd-system-ps-file) shift; tcsd_system_ps_file="$1";;
-		--version) versioninfo $0; exit 0;;
+		--version) versioninfo "$0"; exit 0;;
 		--print-capabilities) print_capabilities; exit 0;;
-		--help|-h|-?) usage $0; exit 0;;
-		*) logerr "Unknown option $1"; usage $0; exit 1;;
+		--help|-h|-?) usage "$0"; exit 0;;
+		*) logerr "Unknown option $1"; usage "$0"; exit 1;;
 		esac
 		shift
 	done
@@ -2166,7 +2195,7 @@ main()
 	[ $got_ownerpass -eq 0 ] && flags=$((flags | SETUP_OWNERPASS_ZEROS_F))
 	[ $got_srkpass -eq 0 ] && flags=$((flags | SETUP_SRKPASS_ZEROS_F))
 
-	pcr_banks="$(echo $pcr_banks |
+	pcr_banks="$(echo "$pcr_banks" |
 	             tr -s ',' |
 	             sed -e 's/^,//' -e 's/,$//' |
 	             tr '[:upper:]' '[:lower:]')"
@@ -2189,7 +2218,7 @@ main()
 	fi
 
 	if [ -n "$LOGFILE" ]; then
-		touch $LOGFILE &>/dev/null
+		touch "$LOGFILE" &>/dev/null
 		if [ ! -w "$LOGFILE" ]; then
 			echo "Cannot write to logfile ${LOGFILE}." >&2
 			exit 1
@@ -2229,12 +2258,12 @@ main()
 			exit 1
 		fi
 		if [ -n "${tcsd_system_ps_file}" ]; then
-			touch ${tcsd_system_ps_file} &>/dev/null
+			touch "${tcsd_system_ps_file}" &>/dev/null
 			if [ $? -ne 0 ]; then
 				logerr "Cannot write to	${tcsd_system_ps_file}"
 				exit 1
 			fi
-			rm -f ${tcsd_system_ps_file}
+			rm -f "${tcsd_system_ps_file}"
 		fi
 	fi
 
@@ -2260,14 +2289,14 @@ main()
 		exit 1
 	fi
 
-	tmp="$(echo $SWTPM | cut -d" " -f1)"
-	if [ ! -x "$(type -P $tmp)" ]; then
+	tmp="$(echo "$SWTPM" | cut -d" " -f1)"
+	if [ ! -x "$(type -P "$tmp")" ]; then
 		logerr "TPM at $SWTPM is not an executable."
 		exit 1
 	fi
 
 	if [ $((flags & SETUP_TPM2_F)) -eq 0 ]; then
-		TCSD=`type -P tcsd`
+		TCSD=$(type -P tcsd)
 		if [ -z "$TCSD" ]; then
 			logerr "tcsd program not found. (PATH=$PATH)"
 			exit 1
@@ -2283,8 +2312,8 @@ main()
 		exit 1
 	fi
 
-	tmp="$(echo $SWTPM_IOCTL | cut -d" " -f1)"
-	if [ ! -x "$(type -P $tmp)" ]; then
+	tmp="$(echo "$SWTPM_IOCTL" | cut -d" " -f1)"
+	if [ ! -x "$(type -P "$tmp")" ]; then
 		logerr "swtpm_ioctl at $SWTPM_IOCTL is not an executable."
 		exit 1
 	fi
@@ -2308,28 +2337,28 @@ main()
 			logerr "Cannot access keyfile $keyfile."
 			exit 1
 		fi
-		SWTPM="$SWTPM --key file=${keyfile}${cipher}"
+		swtpm_keyopt="file=${keyfile}${cipher}"
 		logit "  The TPM's state will be encrypted with a provided key."
 	elif [ -n "$pwdfile" ]; then
 		if [ ! -r "$pwdfile" ]; then
 			logerr "Cannot access passphrase file $pwdfile."
 			exit 1
 		fi
-		SWTPM="$SWTPM --key pwdfile=${pwdfile}${cipher}"
+		swtpm_keyopt="pwdfile=${pwdfile}${cipher}"
 		logit "  The TPM's state will be encrypted using a key derived from a passphrase."
 	elif [ -n "$keyfile_fd" ]; then
 		if ! [[ "$keyfile_fd" =~ ^[0-9]+$ ]]; then
 			logerr "--keyfile-fd parameter $keyfile_fd is not a valid file descriptor"
 			exit 1
 		fi
-		SWTPM="$SWTPM --key fd=${keyfile_fd}${cipher}"
+		swtpm_keyopt="fd=${keyfile_fd}${cipher}"
 		logit "  The TPM's state will be encrypted with a provided key (fd)."
 	elif [ -n "$pwdfile_fd" ]; then
 		if ! [[ "$pwdfile_fd" =~ ^[0-9]+$ ]]; then
 			logerr "--pwdfile-fd parameter $pwdfile_fd is not a valid file descriptor"
 			exit 1
 		fi
-		SWTPM="$SWTPM --key pwdfd=${pwdfile_fd}${cipher}"
+		swtpm_keyopt="pwdfd=${pwdfile_fd}${cipher}"
 		logit "  The TPM's state will be encrypted using a key derived from a passphrase (fd)."
 	fi
 
@@ -2346,11 +2375,13 @@ main()
 
 	if [ $((flags & SETUP_TPM2_F)) -eq 0 ]; then
 		init_tpm $flags "$config_file" "$tpm_state_path" \
-		        "$ownerpass" "$srkpass" "$vmid" "$tcsd_system_ps_file"
+		        "$ownerpass" "$srkpass" "$vmid" \
+			"$tcsd_system_ps_file" "$swtpm_keyopt"
 	else
 		SWTPM="$SWTPM --tpm2"
 		init_tpm2 $flags "$config_file" "$tpm_state_path" \
-		        "$ownerpass" "$srkpass" "$vmid" "$pcr_banks"
+		        "$ownerpass" "$srkpass" "$vmid" "$pcr_banks" \
+			"$swtpm_keyopt"
 	fi
 	ret=$?
 	if [ $ret -eq 0 ]; then

--- a/tests/common
+++ b/tests/common
@@ -307,7 +307,7 @@ function run_swtpm()
 			exit 1
 		fi
 
-		${SWTPM_EXE} cuse $@ ${SWTPM_TEST_SECCOMP_OPT} \
+		${SWTPM_EXE} cuse "$@" ${SWTPM_TEST_SECCOMP_OPT} \
 			-n ${SWTPM_DEV_NAME##*/}
 		rc=$?
 		if [ $rc -ne 0 ]; then
@@ -345,7 +345,7 @@ function run_swtpm()
 			exit 1
 		fi
 
-		${SWTPM_EXE} socket $@ \
+		${SWTPM_EXE} socket "$@" \
 			${SWTPM_TEST_SECCOMP_OPT} \
 			--server type=tcp,port=${SWTPM_SERVER_PORT}${swtpm_server_disconnect} \
 			--ctrl type=tcp,port=${SWTPM_CTRL_PORT} &
@@ -386,7 +386,7 @@ function run_swtpm()
 			exit 1
 		fi
 
-		${SWTPM_EXE} socket $@ \
+		${SWTPM_EXE} socket "$@" \
 			${SWTPM_TEST_SECCOMP_OPT} \
 			--server type=tcp,port=${SWTPM_SERVER_PORT}${swtpm_server_disconnect} \
 			--ctrl type=unixio,path=${SWTPM_CTRL_UNIX_PATH} &
@@ -428,7 +428,7 @@ function run_swtpm()
 			exit 1
 		fi
 
-		${SWTPM_EXE} socket $@ \
+		${SWTPM_EXE} socket "$@" \
 			${SWTPM_TEST_SECCOMP_OPT} \
 			--server type=unixio,path=${SWTPM_CMD_UNIX_PATH} \
 			--ctrl type=tcp,port=${SWTPM_CTRL_PORT} &
@@ -469,7 +469,7 @@ function run_swtpm()
 			exit 1
 		fi
 
-		${SWTPM_EXE} socket $@ \
+		${SWTPM_EXE} socket "$@" \
 			${SWTPM_TEST_SECCOMP_OPT} \
 			--server type=unixio,path=${SWTPM_CMD_UNIX_PATH} \
 			--ctrl type=unixio,path=${SWTPM_CTRL_UNIX_PATH} &

--- a/tests/test_samples_create_tpmca
+++ b/tests/test_samples_create_tpmca
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+#set -x
 
 # For the license, see the LICENSE file in the root directory.
 
@@ -38,8 +39,8 @@ workdir=$(mktemp -d)
 TCSD_CONF=${workdir}/tcsd.conf
 TCSD_SYSTEM_PS_FILE=${workdir}/system_ps_file
 TCSD_PIDFILE=${workdir}/tcsd.pid
-SWTPM_LOCALCA_DIR=${workdir}/localca
-SWTPM_LOCALCA_CONF=${workdir}/localca/swtpm-localca.conf
+SWTPM_LOCALCA_DIR="${workdir}/my localca"
+SWTPM_LOCALCA_CONF="${workdir}/my localca/swtpm-localca.conf"
 
 function cleanup()
 {
@@ -52,7 +53,7 @@ function cleanup()
 	if [ -n "${BASH_PID}" ]; then
 		kill_quiet -9 ${BASH_PID}
 	fi
-	rm -rf ${workdir}
+	rm -rf "${workdir}"
 }
 
 trap "cleanup" SIGTERM EXIT
@@ -74,13 +75,13 @@ PATH=${ROOT}/src/swtpm_bios:${ROOT}/src/swtpm_cert:${PATH}
 function run_test() {
 	local owner_password="$1"
 	local srk_password="$2"
-	local vtpm_is_tpm2=$3
+	local vtpm_is_tpm2="$3"
 
 	local params certinfo regex regexs fil i skip
 
-	rm -rf ${workdir}/*
+	rm -rf "${workdir}"/*
 
-	cat <<_EOF_ > ${workdir}/swtpm_setup.conf
+	cat <<_EOF_ > "${workdir}/swtpm_setup.conf"
 create_certs_tool=${SWTPM_LOCALCA}
 create_certs_tool_config=${workdir}/swtpm-localca.conf
 create_certs_tool_options=/dev/null
@@ -101,14 +102,14 @@ _EOF_
 	# First setup the TPM and take ownership of it and set SRK password
 	$SWTPM_SETUP \
 		--runas root \
-		--tpm-state ${workdir} \
-		--logfile ${workdir}/logfile \
-		--config ${workdir}/swtpm_setup.conf \
+		--tpm-state "${workdir}" \
+		--logfile "${workdir}/logfile" \
+		--config "${workdir}/swtpm_setup.conf" \
 		--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}" \
-		--swtpm_ioctl ${SWTPM_IOCTL} \
+		--swtpm_ioctl "${SWTPM_IOCTL}" \
 		--take-ownership \
 		${params} \
-		--tcsd-system-ps-file ${TCSD_SYSTEM_PS_FILE} &>/dev/null
+		--tcsd-system-ps-file "${TCSD_SYSTEM_PS_FILE}" >/dev/null
 
 	if [ $? -ne 0 ]; then
 		echo "Error: Could not run $SWTPM_SETUP."
@@ -121,12 +122,12 @@ _EOF_
 
 	run_swtpm ${SWTPM_INTERFACE} \
 		--flags not-need-init \
-		--tpmstate dir=${workdir}
+		--tpmstate "dir=${workdir}"
 
 	swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 
 	# Startup the TPM
-	res="$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0C\x00\x00\x00\x99\x00\x01')"
+	res="$(swtpm_cmd_tx "${SWTPM_INTERFACE}" '\x00\xC1\x00\x00\x00\x0C\x00\x00\x00\x99\x00\x01')"
 	exp=' 00 c4 00 00 00 0a 00 00 00 00'
 	if [ "$res" != "$exp" ]; then
 		echo "Error: Did not get expected result from TPM_Startup(ST_Clear)"
@@ -136,24 +137,24 @@ _EOF_
 	fi
 
 	# Setup the TCSD config file and start TCSD with it
-	cat <<_EOF_ > ${TCSD_CONF}
+	cat <<_EOF_ > "${TCSD_CONF}"
 port = ${TCSD_LISTEN_PORT}
 system_ps_file = ${TCSD_SYSTEM_PS_FILE}
 _EOF_
 
-	chown tss:tss ${TCSD_CONF}
-	chmod 0600 ${TCSD_CONF}
+	chown tss:tss "${TCSD_CONF}"
+	chmod 0600 "${TCSD_CONF}"
 
-	bash -c "TCSD_USE_TCP_DEVICE=1 TCSD_TCP_DEVICE_PORT=${SWTPM_SERVER_PORT} tcsd -c ${TCSD_CONF} -e -f &>/dev/null & echo \$! > ${TCSD_PIDFILE}; wait" &
+	bash -c "TCSD_USE_TCP_DEVICE=1 TCSD_TCP_DEVICE_PORT=${SWTPM_SERVER_PORT} tcsd -c "${TCSD_CONF}" -e -f &>/dev/null & echo \$! > "${TCSD_PIDFILE}"; wait" &
 	BASH_PID=$!
 
-	if wait_for_file ${TCSD_PIDFILE} 3; then
+	if wait_for_file "${TCSD_PIDFILE}" 3; then
 		echo "Error: Could not get TCSD's PID file"
 		exit 1
 	fi
 
-	TCSD_PID=$(cat ${TCSD_PIDFILE})
-	kill_quiet -0 ${TCSD_PID}
+	TCSD_PID=$(cat "${TCSD_PIDFILE}")
+	kill_quiet -0 "${TCSD_PID}"
 	if [ $? -ne 0 ]; then
 		echo "Error: TCSD with pid ${TCSD_PID} must have terminated"
 		exit 1
@@ -166,12 +167,12 @@ _EOF_
 	fi
 
 	${SWTPM_CREATE_TPMCA} \
-		--dir ${SWTPM_LOCALCA_DIR} \
+		--dir "${SWTPM_LOCALCA_DIR}" \
 		${params} \
 		--register \
 		--group tss \
-		--tss-tcsd-port ${TCSD_LISTEN_PORT} \
-		--outfile ${SWTPM_LOCALCA_CONF} &>/dev/null
+		--tss-tcsd-port "${TCSD_LISTEN_PORT}" \
+		--outfile "${SWTPM_LOCALCA_CONF}" &>/dev/null
 
 	if [ $? -ne 0 ]; then
 		echo "Error: Could not create TPM CA"
@@ -183,7 +184,7 @@ _EOF_
 		swtpm-localca-rootca-privkey.pem \
 		swtpm-localca-tpmca-cert.pem \
 		swtpm-localca-tpmca-pubkey.pem; do
-		if [ ! -r ${SWTPM_LOCALCA_DIR}/${fil} ]; then
+		if [ ! -r "${SWTPM_LOCALCA_DIR}/${fil}" ]; then
 			echo "Error: TPM CA tool did not create file ${fil}."
 			exit 1
 		fi
@@ -203,9 +204,9 @@ _EOF_
 		"^TSS_TCSD_PORT = " \
 		${params}; do
 		if [ -n "${regex}" ] && \
-		   [ -z "$(grep -E "${regex}" ${SWTPM_LOCALCA_CONF})" ]; then
+		   [ -z "$(grep -E "${regex}" "${SWTPM_LOCALCA_CONF}")" ]; then
 			echo "Error: Could not find regex '${line}' in CA config file."
-			cat ${SWTPM_LOCALCA_CONF}
+			cat "${SWTPM_LOCALCA_CONF}"
 			exit 1
 		fi
 	done
@@ -222,30 +223,30 @@ _EOF_
 	${SWTPM_LOCALCA} \
 		--type ek \
 		--ek x=739192d8f1004283957a7b1568d610b41c637ccc114aadcac4908c20456468fa,y=59f63ac06f8011f6fdd1460c6bc8e3e0a2d090d4fc188c7e04870e06795ce8ae \
-		--dir ${workdir} --vmid test \
+		--dir "${workdir}" --vmid test \
 		${params} \
 		--tpm-spec-family 2.0 --tpm-spec-revision 146 --tpm-spec-level 00 \
 		--tpm-model swtpm --tpm-version 20170101 --tpm-manufacturer IBM \
-		--configfile ${SWTPM_LOCALCA_CONF} \
+		--configfile "${SWTPM_LOCALCA_CONF}" \
 		--optsfile /dev/null
 	if [ $? -ne 0 ]; then
 		echo "Error: The CA could not sign with the new certificate"
 		exit 1
 	fi
-	if [ ! -f ${workdir}/ek.cert ]; then
+	if [ ! -f "${workdir}/ek.cert" ]; then
 		echo "Error: The CA did not produce a certificate"
 		exit 1
 	fi
 	#  cert was for example 541 bytes long
-	if [ $(get_filesize ${workdir}/ek.cert) -lt 500 ]; then
+	if [ $(get_filesize "${workdir}/ek.cert") -lt 500 ]; then
 		echo "Error: The certificate's size is dubious"
-		ls -l ${workdir}/ek.cert
+		ls -l "${workdir}/ek.cert"
 		exit 1
 	fi
 
 	# Check the contents of the certificate
-	certinfo=$(dd if=${workdir}/ek.cert bs=1 skip=$skip status=none | \
-		   $CERTTOOL -i --inder)
+	certinfo=$(dd "if=${workdir}/ek.cert" bs=1 "skip=$skip" status=none | \
+		   "$CERTTOOL" -i --inder)
 	regexs=('^[[:space:]]+2.23.133.8.1$'
 		'^[[:space:]]+directoryName:.*(,)?2.23.133.2.3=.*'
 		'^[[:space:]]+directoryName:.*(,)?2.23.133.2.2=.*'
@@ -272,21 +273,21 @@ _EOF_
 	done
 
 	# Send SIGTERM to TCSD
-	kill_quiet -15 ${TCSD_PID}
+	kill_quiet -15 "${TCSD_PID}"
 
 	# Shut down TPM
-	run_swtpm_ioctl ${SWTPM_INTERFACE} -s
+	run_swtpm_ioctl "${SWTPM_INTERFACE}" -s
 	if [ $? -ne 0 ]; then
 		echo "Error: Could not shut down the ${SWTPM_INTERFACE} TPM."
 		exit 1
 	fi
 
-	if wait_process_gone ${SWTPM_PID} 4; then
+	if wait_process_gone "${SWTPM_PID}" 4; then
 		echo "Error: ${SWTPM_INTERFACE} TPM should not be running anymore."
 		exit 1
 	fi
 
-	if wait_process_gone ${SWTPM_PID} 4; then
+	if wait_process_gone "${SWTPM_PID}" 4; then
 		echo "Error: tcsd should not be running anymore."
 		exit 1
 	fi

--- a/tests/test_tpm2_samples_swtpm_localca
+++ b/tests/test_tpm2_samples_swtpm_localca
@@ -9,7 +9,7 @@ TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
 SWTPM_LOCALCA=${TOPSRC}/samples/swtpm-localca
 
-workdir=$(mktemp -d)
+workdir=$(mktemp -d "/tmp/path with spaces.XXXXXX")
 
 ek=""
 for ((i = 0; i < 256; i++)); do
@@ -26,7 +26,7 @@ trap "cleanup" SIGTERM EXIT
 
 function cleanup()
 {
-	rm -rf ${workdir}
+	rm -rf "${workdir}"
 }
 
 case "$(uname -s)" in
@@ -36,14 +36,14 @@ Darwin)
 	CERTTOOL=certtool;;
 esac
 
-cat <<_EOF_ > ${workdir}/swtpm-localca.conf
+cat <<_EOF_ > "${workdir}/swtpm-localca.conf"
 statedir=${workdir}
 signingkey = ${SIGNINGKEY}
 issuercert = ${ISSUERCERT}
 certserial = ${CERTSERIAL}
 _EOF_
 
-cat <<_EOF_ > ${workdir}/swtpm-localca.options
+cat <<_EOF_ > "${workdir}/swtpm-localca.options"
 --tpm-manufacturer IBM
 --tpm-model swtpm-libtpms
 --tpm-version 2
@@ -65,12 +65,12 @@ do
 
   ${SWTPM_LOCALCA} \
     --type ek \
-    --ek ${ek} \
-    --dir ${workdir} \
+    --ek "${ek}" \
+    --dir "${workdir}" \
     --vmid test \
     --tpm2 \
-    --configfile ${workdir}/swtpm-localca.conf \
-    --optsfile ${workdir}/swtpm-localca.options \
+    --configfile "${workdir}/swtpm-localca.conf" \
+    --optsfile "${workdir}/swtpm-localca.options" \
     --tpm-spec-family 2.0 --tpm-spec-revision 146 --tpm-spec-level 0 \
     ${params}
   if [ $? -ne 0 ]; then
@@ -78,7 +78,7 @@ do
     exit 1
   fi
 
-  if [ ! -r ${workdir}/ek.cert ]; then
+  if [ ! -r "${workdir}/ek.cert" ]; then
     echo "Error: ${workdir}/ek.cert was not created."
     exit 1
   fi
@@ -89,7 +89,7 @@ do
   for u in $usage; do
     echo $u
     if [ -z "$(${CERTTOOL} -i \
-                 --inder --infile ${workdir}/ek.cert | \
+                 --inder --infile "${workdir}/ek.cert" | \
                 grep "Key Usage" -A2 | \
                 grep "$u")" ]; then
       echo "Error: Could not find key usage $u in key created " \
@@ -103,13 +103,13 @@ do
 
   ${CERTTOOL} \
     -i \
-    --inder --infile ${workdir}/ek.cert \
-    --outfile ${workdir}/ek.pem
+    --inder --infile "${workdir}/ek.cert" \
+    --outfile "${workdir}/ek.pem"
 
   ${CERTTOOL} \
     --verify \
-    --load-ca-certificate ${ISSUERCERT} \
-    --infile ${workdir}/ek.pem
+    --load-ca-certificate "${ISSUERCERT}" \
+    --infile "${workdir}/ek.pem"
   if [ $? -ne 0 ]; then
     echo "Error: Could not verify certificate chain."
     exit 1

--- a/tests/test_tpm2_swtpm_setup_create_cert
+++ b/tests/test_tpm2_swtpm_setup_create_cert
@@ -11,7 +11,7 @@ SWTPM_LOCALCA=${TOPSRC}/samples/swtpm-localca
 SWTPM=${TOPBUILD}/src/swtpm/swtpm
 SWTPM_IOCTL=${TOPBUILD}/src/swtpm_ioctl/swtpm_ioctl
 
-workdir=$(mktemp -d)
+workdir=$(mktemp -d "/tmp/path with spaces.XXXXXX")
 
 SIGNINGKEY=${workdir}/signingkey.pem
 ISSUERCERT=${workdir}/issuercert.pem
@@ -23,7 +23,7 @@ trap "cleanup" SIGTERM EXIT
 
 function cleanup()
 {
-	rm -rf ${workdir}
+	rm -rf "${workdir}"
 }
 
 # Quirk for Cygwin
@@ -36,23 +36,23 @@ fi
 # local CA script automatically creates a signingkey and
 # self-signed certificate
 
-cat <<_EOF_ > ${workdir}/swtpm-localca.conf
+cat <<_EOF_ > "${workdir}/swtpm-localca.conf"
 statedir=${workdir}
 signingkey = ${SIGNINGKEY}
 issuercert = ${ISSUERCERT}
 certserial = ${CERTSERIAL}
 _EOF_
 
-cat <<_EOF_ > ${workdir}/swtpm-localca.options
+cat <<_EOF_ > "${workdir}/swtpm-localca.options"
 --tpm-manufacturer IBM
 --tpm-model swtpm-libtpms
 --tpm-version 2
---platform-manufacturer Fedora
+--platform-manufacturer "Fedora XYZ"
 --platform-version 2.1
---platform-model QEMU
+--platform-model "QEMU A.B"
 _EOF_
 
-cat <<_EOF_ > ${workdir}/swtpm_setup.conf
+cat <<_EOF_ > "${workdir}/swtpm_setup.conf"
 create_certs_tool=${SWTPM_LOCALCA}
 create_certs_tool_config=${workdir}/swtpm-localca.conf
 create_certs_tool_options=${workdir}/swtpm-localca.options
@@ -65,18 +65,18 @@ export PATH=${TOPBUILD}/src/swtpm_cert:${PATH}
 $SWTPM_SETUP \
 	--tpm2 \
 	--allow-signing \
-	--tpm-state ${workdir} \
+	--tpm-state "${workdir}" \
 	--create-ek-cert \
 	--create-platform-cert \
-	--config ${workdir}/swtpm_setup.conf \
-	--logfile ${workdir}/logfile \
+	--config "${workdir}/swtpm_setup.conf" \
+	--logfile "${workdir}/logfile" \
 	--tpm "${SWTPM} socket ${SWTPM_TEST_SECCOMP_OPT}" \
-	--swtpm_ioctl ${SWTPM_IOCTL}
+	--swtpm_ioctl "${SWTPM_IOCTL}"
 
 if [ $? -ne 0 ]; then
 	echo "Error: Could not run $SWTPM_SETUP."
 	echo "Logfile output:"
-	cat ${workdir}/logfile
+	cat "${workdir}/logfile"
 	exit 1
 fi
 
@@ -103,18 +103,18 @@ rm -rf ${SIGNINGKEY} ${ISSUERCERT} ${CERTSERIAL}
 $SWTPM_SETUP \
 	--tpm2 \
 	--ecc \
-	--tpm-state ${workdir} \
+	--tpm-state "${workdir}" \
 	--create-ek-cert \
-	--config ${workdir}/swtpm_setup.conf \
-	--logfile ${workdir}/logfile \
+	--config "${workdir}/swtpm_setup.conf" \
+	--logfile "${workdir}/logfile" \
 	--tpm "${SWTPM} socket ${SWTPM_TEST_SECCOMP_OPT}" \
-	--swtpm_ioctl ${SWTPM_IOCTL} \
+	--swtpm_ioctl "${SWTPM_IOCTL}" \
 	--overwrite
 
 if [ $? -ne 0 ]; then
 	echo "Error: Could not run $SWTPM_SETUP."
 	echo "Logfile output:"
-	cat ${workdir}/logfile
+	cat "${workdir}/logfile"
 	exit 1
 fi
 


### PR DESCRIPTION
Fix serveral issues in the shell scripts reported by shellcheck. We can now use file paths that have spaces in them.