### PR TITLE
tests: Wait longer for port to close when running with valgrind

### DIFF
--- a/tests/test_commandline
+++ b/tests/test_commandline
@@ -131,7 +131,7 @@ fi
 
 exec 100>&-
 
-if wait_port_closed $PORT $PID 4; then
+if wait_port_closed $PORT $PID 8; then
 	echo "Test 2 failed: TPM did not close port"
 	exit 1
 fi


### PR DESCRIPTION
Give swtpm more time to close the port. This became an issue when running
the tests and all executables are valgrind'ed.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>