### PR TITLE
swtpm: Only call memcpy if tocopy != 0 (coverity)

### DIFF
--- a/src/swtpm/tpmlib.c
+++ b/src/swtpm/tpmlib.c
@@ -421,6 +421,7 @@ uint32_t tpmlib_create_startup_cmd(uint16_t startupType,
         break;
     }
 
-    memcpy(buffer, &ts, tocopy);
+    if (tocopy)
+        memcpy(buffer, &ts, tocopy);
     return tocopy;
 }


### PR DESCRIPTION
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>