### PR TITLE
swtpm: Add option --profile and load libtpms dynamically

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -150,8 +150,10 @@ openssl)
 	AC_CHECK_HEADERS([openssl/aes.h],[],
 			 AC_MSG_ERROR(Is openssl-devel/libssl-dev installed?))
 	AC_MSG_RESULT([Building with openssl crypto library])
+	LIBCRYPTO_LIBS=$(pkg-config --libs openssl)
 	;;
 esac
+AC_SUBST([LIBCRYPTO_LIBS])
 
 LIBTASN1_LIBS=$(pkg-config --libs libtasn1)
 if test $? -ne 0; then

--- a/src/swtpm/Makefile.am
+++ b/src/swtpm/Makefile.am
@@ -66,10 +66,10 @@ libswtpm_libtpms_la_CFLAGS = \
 	$(LIBSECCOMP_CFLAGS)
 
 libswtpm_libtpms_la_LIBADD = \
-	$(LIBTPMS_LIBS) \
 	$(GLIB_LIBS) \
 	$(LIBRT_LIBS) \
-	$(LIBSECCOMP_LIBS)
+	$(LIBSECCOMP_LIBS) \
+	$(LIBCRYPTO_LIBS)
 
 bin_PROGRAMS = swtpm
 if WITH_CUSE
@@ -100,8 +100,7 @@ swtpm_LDADD = \
 	-L$(PWD)/.libs -lswtpm_libtpms \
 	$(LIBFUSE_LIBS) \
 	$(GLIB_LIBS) \
-	$(GTHREAD_LIBS) \
-	$(LIBTPMS_LIBS)
+	$(GTHREAD_LIBS)
 
 swtpm_cuse_DEPENDENCIES = $(privlib_LTLIBRARIES)
 
@@ -119,10 +118,9 @@ swtpm_cuse_LDADD = \
 	-L$(PWD)/.libs -lswtpm_libtpms \
 	$(LIBFUSE_LIBS) \
 	$(GLIB_LIBS) \
-	$(GTHREAD_LIBS) \
-	$(LIBTPMS_LIBS)
+	$(GTHREAD_LIBS)
 
-AM_CPPFLAGS   = 
-LDADD         = -ltpms
+AM_CPPFLAGS   =
+LDADD         =
 
 CLEANFILES = *.gcno *.gcda *.gcov

--- a/src/swtpm/common.h
+++ b/src/swtpm/common.h
@@ -53,6 +53,7 @@ int handle_server_options(char *options, struct server **s);
 int handle_locality_options(char *options, uint32_t *flags);
 int handle_flags_options(char *options, bool *need_init_cmd,
                          uint16_t *startupType);
+int handle_profile_options(char *options);
 #ifdef WITH_SECCOMP
 int handle_seccomp_options(char *options, unsigned int *seccomp_action);
 #else

--- a/src/swtpm/logging.c
+++ b/src/swtpm/logging.c
@@ -34,7 +34,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
- 
+
 #include "config.h"
 
 #include "sys_dependencies.h"
@@ -52,6 +52,7 @@
 
 #include "logging.h"
 #include "utils.h"
+#include "tpmlib.h"
 
 #include <libtpms/tpm_library.h>
 
@@ -216,7 +217,9 @@ void log_global_free(void)
 {
     free(log_prefix);
     log_prefix = NULL;
-    TPMLIB_SetDebugPrefix(NULL);
+    if (tpmlib_is_loaded()) {
+        TPMLIB_SetDebugPrefix(NULL);
+    }
 }
 
 /*


### PR DESCRIPTION
This PR is related to stefanberger/libtpms#115. To dynamically load a libtpms library (aka _profile_) during runtime, an option, `--profile name=<name>` is added to `swtpm`, `swtpm_cuse` and `swtpm_chardev`.

The profile is loaded as stated below:

- If `--profile name=<name>` is given
   - if `<name>` is `default`, load default profile `libtpms.so`/`libtpms.dylib`
   - otherwise load `libtpms-<name>.so`/`libtpms-<name>.dylib`
- If no option `--profile` was given
   - load default profile `libtpms.so`/`libtpms.dylib`

I did not implement testing, yet. What do you think?