### PR TITLE
swtpm: Fix vtpm proxy case without startup flags

### DIFF
--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -426,10 +426,9 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
         if (mlp.tpmversion == TPMLIB_TPM_VERSION_2)
             vtpm_new_dev.flags = VTPM_PROXY_FLAG_TPM2;
 
-        /* Will be adjusted for TPM 2;
-         * handle_flags_options() will cause need_init_cmd = false to be set
-         */
+        /* Will be adjusted for TPM 2 */
         mlp.startupType = TPM_ST_CLEAR;
+        need_init_cmd = false;
 
         if (mlp.fd >= 0) {
             logprintf(STDERR_FILENO,

--- a/tests/test_vtpm_proxy
+++ b/tests/test_vtpm_proxy
@@ -41,7 +41,6 @@ rm -f $STATE_FILE $VOLATILE_STATE_FILE 2>/dev/null
 $SWTPM_EXE chardev --vtpm-proxy \
 	--tpmstate dir=$TPM_PATH \
 	--ctrl type=unixio,path=$SOCK_PATH \
-	--flags startup-clear \
 	${SWTPM_TEST_SECCOMP_OPT} \
 	--pid file=$PID_FILE &>$LOGFILE &
 sleep 0.5


### PR DESCRIPTION
'swtpm chardev --vptm-proxy' currently requires a '--flag startup-xyz'
to be passed since otherwise the need_init_cmd variable would not be
set to false. To maintain backwards compatibility we have to always
set the need_init_cmd variable to false for the --vtpm-proxy case.

Roll back one of the test case to not use the startup flag.

Fixes: e6bc4bdf0 ('swtpm: Enable sending startup commands ...')
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>