### PR TITLE
Travis: Checkout a certain libtpms revision

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,9 @@ before_install:
 script:
   - if [ ! -d libtpms ]; then git clone https://github.com/stefanberger/libtpms; fi
   - cd libtpms
+  - if [ -n "${LIBTPMS_GIT_CHECKOUT}" ]; then
+       git checkout "${LIBTPMS_GIT_CHECKOUT}" -b testing;
+    fi
   - CFLAGS="${LIBTPMS_CFLAGS:--g -O2}" LDFLAGS="${LIBTPMS_LDFLAGS}"
        ./autogen.sh --with-openssl --prefix=${LIBTPMS_PREFIX:-/usr} --with-tpm2 ${LIBTPMS_CONFIG}
        && make -j$(${NPROC:-nproc})
@@ -119,6 +122,7 @@ matrix:
            LIBTPMS_CFLAGS="-I/usr/local/opt/openssl/include"
            LIBTPMS_LDFLAGS="-L/usr/local/opt/openssl/lib"
            LIBTPMS_PREFIX="${HOME}"
+           LIBTPMS_GIT_CHECKOUT="origin/stable-0.6.0"
            CFLAGS="-I/usr/local/opt/openssl/include -I${HOME}/include"
            LDFLAGS="-L/usr/local/opt/openssl/lib -L${HOME}/lib"
            PKG_CONFIG_PATH="${HOME}/lib/pkgconfig"


### PR DESCRIPTION
Allow specifying a libtpms revision to test with, defaulting to
master branch.

Have the OS X test use the stable-0.6.0 branch.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>