### PR TITLE
Enable run_test.sh on x86_64 again due to better detection of 32 bit swtpm

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -7,33 +7,40 @@ fi
 
 unset SWTPM
 
+# Comment the following to compile and test with CUSE interface
+WITHOUT_CUSE="--without-cuse"
+
 # FIXME:
 # Due to some bug in glib2 for i686 we don't seem to be able to run a
 # 32bit swtpm with cuse interface correctly. The g_cond_wait_until()
 # doesn't behave as it does with 64bit. test_hashing2 gets stuck.
 
 
-CFLAGS='-m64' ./configure --with-openssl --with-gnutls --prefix=/usr --libdir=/lib64 && \
+CFLAGS='-m64' ./configure --with-openssl --with-gnutls --prefix=/usr --libdir=/lib64 ${WITHOUT_CUSE} && \
  make clean && \
  make -j$(nproc) &&
  sudo make -j$(nproc) install &&
  cp /usr/bin/swtpm /tmp/swtpm64 &&
- make -j$(nproc) check &&
+ make -j$(nproc) check ||
+ exit 1
+[ -z "${WITHOUT_CUSE}" ] &&
  sudo make -j$(nproc) check ||
  exit 1
 
 PKG_CONFIG_PATH=/usr/lib/pkgconfig \
- CFLAGS='-m32' ./configure --with-openssl --with-gnutls --prefix=/usr --libdir=/lib && \
+ CFLAGS='-m32' ./configure --with-openssl --with-gnutls --prefix=/usr --libdir=/lib ${WITHOUT_CUSE} && \
  make clean && \
  make -j$(nproc) &&
  sudo make -j$(nproc) install &&
  cp /usr/bin/swtpm /tmp/swtpm32 &&
  make -j$(nproc) check &&
- SWTPM_EXE=/tmp/swtpm64 make -j$(nproc) check &&
+ SWTPM_EXE=/tmp/swtpm64 make -j$(nproc) check ||
+ exit 1
+[ -z "${WITHOUT_CUSE}" ] &&
  sudo SWTPM_EXE=/tmp/swtpm64 make -j$(nproc) check ||
  exit 1
 
-CFLAGS='-m64' ./configure --with-openssl --with-gnutls --prefix=/usr --libdir=/lib64 && \
+CFLAGS='-m64' ./configure --with-openssl --with-gnutls --prefix=/usr --libdir=/lib64 ${WITHOUT_CUSE} && \
  make clean && \
  make -j$(nproc) &&
  SWTPM_EXE=/tmp/swtpm32 make -j$(nproc) check &&

--- a/tests/_test_tpm2_derived_keys
+++ b/tests/_test_tpm2_derived_keys
@@ -250,18 +250,23 @@ test5_exp2+=' 00 00 01 00 00'
 # 64bit TPMs. We only test 64bit TPMs with the above expected
 # return values.
 #
-case "$(uname -p)" in
-ppc64le|x86_64)
-	echo "[Assuming ${SWTPM_EXE} is 64bit]"
-	tx_cmd 1 0 "$test1_cmd" "$test1_exp" "" || exit 1 && echo "Test 1: OK"
-	tx_cmd 1 1 "$test2_cmd" "$test2_exp" "" || exit 1 && echo "Test 2: OK"
-	tx_cmd 1 1 "$test3_cmd" "$test3_exp" "" || exit 1 && echo "Test 3: OK"
-	tx_cmd 1 1 "$test4_cmd" "$test4_exp" "$error_unsupt_algo" || exit 1 && echo "Test 4: OK"
-	tx_cmd 1 1 "$test5_cmd1" "$test5_exp1" "" || exit 1
-	tx_cmd 0 0 "$test5_cmd2" "$test5_exp2" "" || exit 1 && echo "Test 5: OK"
+case "$(uname -s)" in
+Linux)
+	# Only 64bit apps will link with libs in /lib64/ dirs
+	if [ -n "$(grep -E "\/lib64\/" /proc/${SWTPM_PID}/maps)" ]; then
+		tx_cmd 1 0 "$test1_cmd" "$test1_exp" "" || exit 1 && echo "Test 1: OK"
+		tx_cmd 1 1 "$test2_cmd" "$test2_exp" "" || exit 1 && echo "Test 2: OK"
+		tx_cmd 1 1 "$test3_cmd" "$test3_exp" "" || exit 1 && echo "Test 3: OK"
+		tx_cmd 1 1 "$test4_cmd" "$test4_exp" "$error_unsupt_algo" || exit 1 && echo "Test 4: OK"
+		tx_cmd 1 1 "$test5_cmd1" "$test5_exp1" "" || exit 1
+		tx_cmd 0 0 "$test5_cmd2" "$test5_exp2" "" || exit 1 && echo "Test 5: OK"
+	else
+		echo "This test currently only runs with 64bit swtpm. ${SWTPM_EXE} seems 32bit."
+	fi
 	;;
 *)
-	echo "This test currently only works with 64bit TPMs"
+	echo "This test currently only runs on Linux"
+	;;
 esac
 
 # Get revision of TPM 2.0 implementation; we need >= 155 for subsequent tests


### PR DESCRIPTION
This series of patches allows to run run_test.sh on x86_64 hosts again. It needed better detection of a 32 bit swtpm for which the test_tpm2_derived_keys had to skip certain tests for which we only have expected return values for 64bit swtpm's.
