### PR TITLE
swtpm: Address cygwin compilation warning

### DIFF
--- a/src/swtpm/key.c
+++ b/src/swtpm/key.c
@@ -132,7 +132,7 @@ key_stream_to_bin(const char *input, unsigned char *bin, size_t bin_size)
     int n, num;
 
     while (input[digits] &&
-           !isspace(input[digits]) &&
+           !isspace((int)input[digits]) &&
            bin_size > (size_t)digits / 2) {
         num = sscanf(&input[digits], "%2hhx%n", &bin[digits/2], &n);
         if (num != 1 || n != 2)
@@ -140,7 +140,7 @@ key_stream_to_bin(const char *input, unsigned char *bin, size_t bin_size)
         digits += 2;
     }
 
-    if (input[digits] && !isspace(input[digits]))
+    if (input[digits] && !isspace((int)input[digits]))
         return -1;
 
     return (digits != 0) ? digits : -1;


### PR DESCRIPTION
Compilation on cygwin reports the following issue:

In file included from key.c:43:
key.c: In function ‘key_stream_to_bin’:
key.c:135:26: error: array subscript has type ‘char’ [-Werror=char-subscripts]
  135 |            !isspace(input[digits]) &&
      |                     ~~~~~^~~~~~~~
key.c:143:40: error: array subscript has type ‘char’ [-Werror=char-subscripts]
  143 |     if (input[digits] && !isspace(input[digits]))
      |                                   ~~~~~^~~~~~~~

Address the issue using an explicit cast of char to int.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>