### PR TITLE
tests: Use 'cp -f' for copying over existing files (Travis issue)

### DIFF
--- a/tests/_test_tpm2_derived_keys
+++ b/tests/_test_tpm2_derived_keys
@@ -297,7 +297,7 @@ echo "Testing new CryptAdjustPrimeCandidate implementation"
 # copy all the state files; the files need libtpms (0.8.0) with
 # TPM 2.0 revsion 155; there the seeds are setup so that the fixed
 # RSA key generation algorithm is used
-cp ${TESTDIR}/data/tpm2state4/* ${TPM_PATH}
+cp -f ${TESTDIR}/data/tpm2state4/* ${TPM_PATH}
 
 run_swtpm ${SWTPM_INTERFACE} --tpm2
 


### PR DESCRIPTION
Use 'cp -f' to force-copy over existing files. This solves an issue
seen only on Travis.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>