### PR TITLE
swtpm: Remove unnecessary #include <seccomp.h> (fixes SuSE build)

### DIFF
--- a/src/swtpm/cuse_tpm.c
+++ b/src/swtpm/cuse_tpm.c
@@ -58,10 +58,6 @@
 
 #include <glib.h>
 
-#ifdef WITH_SECCOMP
-# include <seccomp.h>
-#endif
-
 #include <libtpms/tpm_library.h>
 #include <libtpms/tpm_tis.h>
 #include <libtpms/tpm_error.h>

--- a/src/swtpm/swtpm.c
+++ b/src/swtpm/swtpm.c
@@ -50,10 +50,6 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
-#ifdef WITH_SECCOMP
-# include <seccomp.h>
-#endif
-
 #include <libtpms/tpm_error.h>
 #include <libtpms/tpm_library.h>
 #include <libtpms/tpm_memory.h>

--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -50,10 +50,6 @@
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 
-#ifdef WITH_SECCOMP
-# include <seccomp.h>
-#endif
-
 #include <libtpms/tpm_error.h>
 #include <libtpms/tpm_library.h>
 #include <libtpms/tpm_memory.h>


### PR DESCRIPTION
It's not necessary anymore to #include <seccomp.h> from the main programs.
Once removed, it also fixes the build on SuSE where seccomp.h is in
seccomp/seccomp.h and we didn't use the LIBSECCOMP_CFLAGS for swtpm.c etc.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>