### PR TITLE
tests: Revert accidental port change from commit 0194fb22a

### DIFF
--- a/tests/test_tpm2_save_load_state_3
+++ b/tests/test_tpm2_save_load_state_3
@@ -701,7 +701,7 @@ function test_primary_volatile_load()
 export TPM_SERVER_TYPE=raw
 export TPM_SERVER_NAME=127.0.0.1
 export TPM_INTERFACE_TYPE=socsim
-export TPM_COMMAND_PORT=55533
+export TPM_COMMAND_PORT=65533
 export TPM_DATA_DIR=$TPMDIR
 export TPM_SESSION_ENCKEY="807e2bfe898ddaed8fa6310e716a24dc" # for sessions
 


### PR DESCRIPTION
Revert the accidental port change from commit 0194fb22a.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>