### PR TITLE
swtpm: Invoke print capabilites after choosing TPM version

### DIFF
--- a/src/swtpm/cuse_tpm.c
+++ b/src/swtpm/cuse_tpm.c
@@ -1414,6 +1414,7 @@ int swtpm_cuse_main(int argc, char **argv, const char *prgname, const char *ifac
     int n, tpmfd;
     char path[PATH_MAX];
     int ret = 0;
+    bool printcapabilities = false;
 
     memset(&cinfo, 0, sizeof(cinfo));
     memset(&param, 0, sizeof(param));
@@ -1505,8 +1506,8 @@ int swtpm_cuse_main(int argc, char **argv, const char *prgname, const char *ifac
             fprintf(stdout, usage, prgname, iface);
             goto exit;
         case 'a':
-            ret = capabilities_print_json(true);
-            goto exit;
+            printcapabilities = true;
+            break;
         case 'v': /* version */
             fprintf(stdout, "TPM emulator CUSE interface version %d.%d.%d, "
                     "Copyright (c) 2014-2015 IBM Corp.\n",
@@ -1532,6 +1533,11 @@ int swtpm_cuse_main(int argc, char **argv, const char *prgname, const char *ifac
         logprintf(STDERR_FILENO,
                   "Error: Could not choose TPM version.\n");
         ret = EXIT_FAILURE;
+        goto exit;
+    }
+
+    if (printcapabilities) {
+        ret = capabilities_print_json(true) ? EXIT_FAILURE : EXIT_SUCCESS;
         goto exit;
     }
 

--- a/src/swtpm/swtpm.c
+++ b/src/swtpm/swtpm.c
@@ -233,6 +233,7 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
     time_t              start_time;
 #endif
     unsigned int seccomp_action;
+    bool printcapabilities = false;
     static struct option longopts[] = {
         {"daemon"    ,       no_argument, 0, 'd'},
         {"help"      ,       no_argument, 0, 'h'},
@@ -373,8 +374,8 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
             exit(EXIT_SUCCESS);
 
         case 'a':
-            ret = capabilities_print_json(false);
-            exit(ret ? EXIT_FAILURE : EXIT_SUCCESS);
+            printcapabilities = true;
+            break;
 
         case 'r':
             runas = optarg;
@@ -411,6 +412,11 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
         logprintf(STDERR_FILENO,
                   "Error: Could not choose TPM version.\n");
         exit(EXIT_FAILURE);
+    }
+
+    if (printcapabilities) {
+        ret = capabilities_print_json(false);
+        exit(ret ? EXIT_FAILURE : EXIT_SUCCESS);
     }
 
     if (handle_ctrlchannel_options(ctrlchdata, &mlp.cc) < 0 ||

--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -254,6 +254,7 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
 #endif
     bool need_init_cmd = true;
     unsigned int seccomp_action;
+    bool printcapabilities = false;
     static struct option longopts[] = {
         {"daemon"    ,       no_argument, 0, 'd'},
         {"help"      ,       no_argument, 0, 'h'},
@@ -380,8 +381,8 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
             exit(EXIT_SUCCESS);
 
         case 'a':
-            ret = capabilities_print_json(false);
-            exit(ret ? EXIT_FAILURE : EXIT_SUCCESS);
+            printcapabilities = true;
+            break;
 
         case 'r':
             runas = optarg;
@@ -466,6 +467,11 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
         logprintf(STDERR_FILENO,
                   "Error: Could not choose TPM version.\n");
         exit(EXIT_FAILURE);
+    }
+
+    if (printcapabilities) {
+        ret = capabilities_print_json(false);
+        exit(ret ? EXIT_FAILURE : EXIT_SUCCESS);
     }
 
     SWTPM_NVRAM_Set_TPMVersion(mlp.tpmversion);


### PR DESCRIPTION
Invoke the printing of the capabilites after choosing the TPM version
in libtpms.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>