### PR TITLE
swtpm: Make coverity happy by handling default case in case statement

### DIFF
--- a/src/swtpm/tpmlib.c
+++ b/src/swtpm/tpmlib.c
@@ -417,7 +417,17 @@ uint32_t tpmlib_create_startup_cmd(uint16_t startupType,
             logprintf(STDERR_FILENO,
                       "TPM 2 does not support startup deactivated.\n");
             break;
+        default:
+            tocopy = 0;
+            logprintf(STDERR_FILENO,
+                      "%s: internal error; unupported startup type for TPM 2\n", __func__);
+            break;
         }
+        break;
+    default:
+        tocopy = 0;
+        logprintf(STDERR_FILENO,
+                  "%s: internal error; invalid TPM version\n", __func__);
         break;
     }
 


### PR DESCRIPTION
Handle the default cases, which shouldn't ever be reachable, and set
the tocopy to '0' so that no unitialized variable gets copied.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>