### PR TITLE
Support PC Client Platform TPM Profile Specification for TPM 2.0 V1.04, rev 37

### DIFF
--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -122,9 +122,7 @@ TPMA_NV_WRITEDEFINE=$((0x2000))
 TPM2_NV_INDEX_RSA_EKCert=$((0x01c00002))
 TPM2_NV_INDEX_RSA_EKTemplate=$((0x01c00004))
 # For ECC follow "TCG EK Credential Profile For TPM Family 2.0; Level 0"
-# Specification Version 2.1; Revision 12; 17 August 2018 (Draft)
-TPM2_NV_INDEX_ECC_EKCert=$((0x01c0000a))
-TPM2_NV_INDEX_ECC_EKTemplate=$((0x01c0000c))
+# Specification Version 2.1; Revision 13; 10 December 2018
 TPM2_NV_INDEX_PlatformCert=$((0x01c08000))
 
 TPM2_NV_INDEX_ECC_SECP384R1_HI_EKCert=$((0x01c00016))
@@ -146,9 +144,6 @@ NB256=${NB32}${NB32}${NB32}${NB32}${NB32}${NB32}${NB32}${NB32}
 # Nonce used for EK creation; 2 bytes length + nonce
 NONCE_RSA='\x01\x00'${NB256}
 NONCE_RSA_SIZE=256
-
-NONCE_ECC_256='\x00\x20'${NB32}
-NONCE_ECC_256_SIZE=32
 
 NONCE_ECC_384='\x00\x30'${NB32}${NB16}
 NONCE_ECC_384_SIZE=48
@@ -1145,92 +1140,6 @@ function tpm2_createprimary_rsa_params()
 	return 0
 }
 
-# Create the primary key as a NIST P256 ECC key (EK equivalent)
-#
-# @param1: flags
-# @param2: filename for template
-tpm2_createprimary_ek_ecc_nist_p256()
-{
-	local flags="$1"
-	local templatefile="$2"
-
-	local min_exp symkeydata keyflags totlen publen offset authpolicy
-
-	if [ $((flags & SETUP_ALLOW_SIGNING_F)) -ne 0 ] && \
-	   [ $((flags & SETUP_DECRYPTION_F)) -ne 0 ]; then
-		# keyflags: fixedTPM, fixedParent, sensitiveDatOrigin,
-		# adminWithPolicy, sign, decrypt
-		keyflags=$((0x000600b2))
-		# symmetric: TPM_ALG_NULL
-		symkeydata='\\x00\\x10'
-		publen=$((0x36 + 2 * NONCE_ECC_256_SIZE))
-		totlen=$((0x5f + 2 * NONCE_ECC_256_SIZE))
-		min_exp=930
-		# offset of length indicator for key
-		offset=210
-	elif [ $((flags & SETUP_ALLOW_SIGNING_F)) -ne 0 ]; then
-		# keyflags: fixedTPM, fixedParent, sensitiveDatOrigin,
-		# adminWithPolicy, sign
-		keyflags=$((0x000400b2))
-		# symmetric: TPM_ALG_NULL
-		symkeydata='\\x00\\x10'
-		publen=$((0x36 + 2 * NONCE_ECC_256_SIZE))
-		totlen=$((0x5f + 2 * NONCE_ECC_256_SIZE))
-		min_exp=930
-		# offset of length indicator for key
-		offset=210
-	else
-		# keyflags: fixedTPM, fixedParent, sensitiveDatOrigin,
-		# adminWithPolicy, restricted, decrypt
-		keyflags=$((0x000300b2))
-		# symmetric: TPM_ALG_AES, 128bit, TPM_ALG_CFB
-		symkeydata='\\x00\\x06\\x00\\x80\\x00\\x43'
-		publen=$((0x3a + 2 * NONCE_ECC_256_SIZE))
-		totlen=$((0x63 + 2 * NONCE_ECC_256_SIZE))
-		# some version of TPM2 returns 942, another 990
-		min_exp=942
-		# offset of length indicator for key
-		offset=222
-	fi
-
-	# authPolicy from Ek Credential Profile; Spec v 2.1; rev12; p. 38
-	authpolicy='\\x83\\x71\\x97\\x67\\x44\\x84\\xb3\\xf8\\x1a\\x90\\xcc\\x8d'
-	authpolicy+='\\x46\\xa5\\xd7\\x24\\xfd\\x52\\xd7\\x6e\\x06\\x52\\x0b\\x64'
-	authpolicy+='\\xf2\\xa1\\xda\\x1b\\x33\\x14\\x69\\xaa'
-
-	tpm2_createprimary_ecc_params '\\x40\\x00\\x00\\x0b' "${keyflags}" \
-	    "${symkeydata}" "${publen}" "${totlen}" "${min_exp}" "${offset}" \
-	    "32" "${authpolicy}" "${templatefile}" "3" "11" "$NONCE_ECC_256"
-	return $?
-}
-
-# Create primary storage key as a NIST P256 ECC key
-#
-# @param1: flags
-tpm2_createprimary_spk_ecc_nist_p256()
-{
-	local flags="$1"
-
-	local min_exp symkeydata keyflags totlen publen offset
-
-	# keyflags: fixedTPM, fixedParent, sensitiveDataOrigin,
-	# userWithAuth, noDA, restricted, decrypt
-	keyflags=$((0x00030472))
-	# symmetric: TPM_ALG_AES, 128bit, TPM_ALG_CFB
-	symkeydata='\\x00\\x06\\x00\\x80\\x00\\x43'
-	publen=$((0x1a + 2 * NONCE_ECC_256_SIZE))
-	totlen=$((0x43 + 2 * NONCE_ECC_256_SIZE))
-	# some version of TPM2 returns 942, another 990
-	min_exp=894
-	# offset of length indicator for key
-	offset=126
-
-	tpm2_createprimary_ecc_params '\\x40\\x00\\x00\\x0b' "${keyflags}" \
-	    "${symkeydata}" "${publen}" "${totlen}" "${min_exp}" "${offset}" \
-	    "32" "" "" "3" "11" "$NONCE_ECC_256"
-	return $?
-}
-
 # Create the primary key as a NIST P384 ECC key (EK equivalent)
 #
 # @param1: flags
@@ -1476,7 +1385,7 @@ tpm2_create_ek()
 	[ $? -ne 0 ] && return 1
 
 	if [ $((flags & SETUP_TPM2_ECC_F)) -ne 0 ]; then
-		res=$(tpm2_createprimary_ek_ecc_nist_p256 "$flags" "${ektemplatefile}")
+		res=$(tpm2_createprimary_ek_ecc_nist_p384 "$flags" "${ektemplatefile}")
 	else
 		res=$(tpm2_createprimary_ek_rsa "$flags" "${ektemplatefile}")
 	fi
@@ -1688,7 +1597,7 @@ tpm2_create_spk()
 	[ $? -ne 0 ] && return 1
 
 	if [ $((flags & SETUP_TPM2_ECC_F)) -ne 0 ]; then
-		res=$(tpm2_createprimary_spk_ecc_nist_p256 "$flags")
+		res=$(tpm2_createprimary_spk_ecc_nist_p384 "$flags")
 	else
 		res=$(tpm2_createprimary_spk_rsa "$flags")
 	fi

--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -1489,6 +1489,151 @@ tpm2_create_ek()
 	return 0
 }
 
+# Create the TPM2 RSA or ECC EK along with its cert and write them into
+# NVRAM
+#
+# @param1: flags
+# @param2: configuration file
+# @param3: certificates directory
+# @param4: VM identifier
+tpm2_create_ek_and_cert()
+{
+	local flags="$1"
+	local config_file="$2"
+	local certs_dir="$3"
+	local vmid="$4"
+
+	local PLATFORM_CERT_FILE="$certsdir/platform.cert"
+	local EK_CERT_FILE="$certsdir/ek.cert"
+	local EK_TEMP_FILE="$certsdir/ektemplate"
+
+	local ek nvindex nvindex_str
+	local nvindexattrs=$((TPMA_NV_PLATFORMCREATE | \
+		TPMA_NV_AUTHREAD | \
+		TPMA_NV_OWNERREAD | \
+		TPMA_NV_PPREAD | \
+		TPMA_NV_PPWRITE | \
+		TPMA_NV_NO_DA | \
+		TPMA_NV_WRITEDEFINE))
+
+	if [ $((flags & SETUP_CREATE_EK_F)) -ne 0 ]; then
+		ek=$(tpm2_create_ek "$flags" "${TPM2_EK_HANDLE}" "${EK_TEMP_FILE}")
+		if [ $? -ne 0 ]; then
+			logerr "tpm2_create_ek failed"
+			return 1
+		fi
+		logit "Successfully created EK with handle" \
+		      "$(printf "0x%08x" ${TPM2_EK_HANDLE})."
+
+		if [ $((flags & SETUP_TPM2_ECC_F)) -eq 0 ]; then
+			nvindex=${TPM2_NV_INDEX_RSA_EKTemplate}
+		else
+			nvindex=${TPM2_NV_INDEX_ECC_EKTemplate}
+		fi
+		nvindex_str="$(printf "0x%08x" ${nvindex})"
+
+		if [ $((flags & SETUP_ALLOW_SIGNING_F )) -ne 0 ]; then
+			tpm2_nv_define ${nvindex} ${nvindexattrs} \
+				"$(get_filesize "${EK_TEMP_FILE}")"
+			if [ $? -ne 0 ]; then
+				logerr "Could not create NVRAM area ${nvindex_str}" \
+				       "for EK template."
+				return 1
+			fi
+			tpm2_nv_write ${nvindex} "${EK_TEMP_FILE}"
+			if [ $? -ne 0 ]; then
+				logerr "Could not write EK template into" \
+				       "NVRAM area ${nvindex_str}."
+				return 1
+			fi
+			if [ $((flags & SETUP_LOCK_NVRAM_F)) -ne 0 ]; then
+				tpm2_nv_writelock ${nvindex}
+				if [ $? -ne 0 ]; then
+					logerr "Could not lock EK template NVRAM" \
+					       "area ${nvindex_str}."
+					return 1
+				fi
+			fi
+			logit "Successfully created NVRAM area ${nvindex_str} for EK template."
+		fi
+		rm -f "${EK_TEMP_FILE}"
+	fi
+
+	# have external program create the certificates now
+	call_create_certs "$flags" "$config_file" "$certsdir" "$ek" "$vmid"
+	if [ $? -ne 0 ]; then
+		return 1
+	fi
+
+	if [ $((flags & SETUP_EK_CERT_F)) -ne 0 ] && \
+	   [ -r "${EK_CERT_FILE}" ]; then
+
+		if [ $((flags & SETUP_TPM2_ECC_F)) -eq 0 ]; then
+			nvindex=${TPM2_NV_INDEX_RSA_EKCert}
+		else
+			nvindex=${TPM2_NV_INDEX_ECC_EKCert}
+		fi
+		nvindex_str="$(printf "0x%08x" ${nvindex})"
+
+		tpm2_nv_define ${nvindex} ${nvindexattrs} \
+			"$(get_filesize "${EK_CERT_FILE}")"
+		if [ $? -ne 0 ]; then
+			logerr "Could not create NVRAM area ${nvindex_str}" \
+			       "for EK certificate."
+			return 1
+		fi
+		tpm2_nv_write ${nvindex} "${EK_CERT_FILE}"
+		if [ $? -ne 0 ]; then
+			logerr "Could not write EK certificate into" \
+			       "NVRAM area ${nvindex_str}."
+			return 1
+		fi
+		if [ $((flags & SETUP_LOCK_NVRAM_F)) -ne 0 ]; then
+			tpm2_nv_writelock ${nvindex}
+			if [ $? -ne 0 ]; then
+				logerr "Could not lock EK certificate NVRAM" \
+				       "area ${nvindex_str}."
+				return 1
+			fi
+		fi
+		logit "Successfully created NVRAM area ${nvindex_str} for EK certificate."
+		rm -f "${EK_CERT_FILE}"
+	fi
+
+	if [ $((flags & SETUP_PLATFORM_CERT_F)) -ne 0 ] && \
+	   [ -r "${PLATFORM_CERT_FILE}" ] ; then
+
+		nvindex=${TPM2_NV_INDEX_PlatformCert}
+		nvindex_str="$(printf "0x%08x" ${nvindex})"
+
+		tpm2_nv_define ${nvindex} ${nvindexattrs} \
+			"$(get_filesize "${PLATFORM_CERT_FILE}")"
+		if [ $? -ne 0 ]; then
+			logerr "Could not create NVRAM area ${nvindex_str}" \
+			       "for platform certificate."
+			return 1
+		fi
+		tpm2_nv_write ${nvindex} "${PLATFORM_CERT_FILE}"
+		if [ $? -ne 0 ]; then
+			logerr "Could not write platform certificate into" \
+			       "NVRAM area ${nvindex_str}."
+			return 1
+		fi
+		if [ $((flags & SETUP_LOCK_NVRAM_F)) -ne 0 ]; then
+			tpm2_nv_writelock ${nvindex}
+			if [ $? -ne 0 ]; then
+				logerr "Could not lock platform certificate" \
+				       "NVRAM area ${nvindex_str}."
+				return 1
+			fi
+		fi
+		logit "Successfully created NVRAM area ${nvindex_str}" \
+		      "for platform certificate."
+		rm -f "${PLATFORM_CERT_FILE}"
+	fi
+	return 0
+}
+
 # Create the platform key, either RSA or ECC
 #
 # @param1: flags
@@ -1854,12 +1999,8 @@ init_tpm2()
 
 	# where external app writes certs into
 	local certsdir="$tpm2_state_path"
-	local ek tmp output nvindex nvindex_str
+	local tmp output
 	local all_pcr_banks active_pcr_banks
-
-	local PLATFORM_CERT_FILE="$certsdir/platform.cert"
-	local EK_CERT_FILE="$certsdir/ek.cert"
-	local EK_TEMP_FILE="$certsdir/ektemplate"
 
 	start_tpm "$SWTPM" "$tpm2_state_path" "$swtpm_keyopt"
 	if [ $? -ne 0 ]; then
@@ -1886,155 +2027,8 @@ init_tpm2()
 		      "handle $(printf "0x%08x" ${TPM2_SPK_HANDLE})."
 	fi
 
-	if [ $((flags & SETUP_CREATE_EK_F)) -ne 0 ]; then
-		ek=$(tpm2_create_ek "$flags" "${TPM2_EK_HANDLE}" \
-		     "${EK_TEMP_FILE}")
-		if [ $? -ne 0 ]; then
-			logerr "tpm2_create_ek failed"
-			return 1
-		fi
-		logit "Successfully created EK with handle" \
-		      "$(printf "0x%08x" ${TPM2_EK_HANDLE})."
-
-		if [ $((flags & SETUP_TPM2_ECC_F)) -eq 0 ]; then
-			nvindex=${TPM2_NV_INDEX_RSA_EKTemplate}
-		else
-			nvindex=${TPM2_NV_INDEX_ECC_EKTemplate}
-		fi
-		nvindex_str="$(printf "0x%08x" ${nvindex})"
-
-		if [ $((flags & SETUP_ALLOW_SIGNING_F )) -ne 0 ]; then
-			tpm2_nv_define \
-				${nvindex} \
-				$((TPMA_NV_PLATFORMCREATE | \
-				   TPMA_NV_AUTHREAD | \
-				   TPMA_NV_OWNERREAD | \
-				   TPMA_NV_PPREAD | \
-				   TPMA_NV_PPWRITE | \
-				   TPMA_NV_NO_DA | \
-				   TPMA_NV_WRITEDEFINE)) \
-				"$(get_filesize "${EK_TEMP_FILE}")"
-			if [ $? -ne 0 ]; then
-				logerr "Could not create NVRAM area ${nvindex_str}" \
-				       "for EK template."
-				return 1
-			fi
-			tpm2_nv_write \
-				${nvindex} \
-				"${EK_TEMP_FILE}"
-			if [ $? -ne 0 ]; then
-				logerr "Could not write EK template into" \
-				       "NVRAM area ${nvindex_str}."
-				return 1
-			fi
-			if [ $((flags & SETUP_LOCK_NVRAM_F)) -ne 0 ]; then
-				tpm2_nv_writelock \
-					${nvindex}
-				if [ $? -ne 0 ]; then
-					logerr "Could not lock EK template NVRAM" \
-					       "area ${nvindex_str}."
-					return 1
-				fi
-			fi
-			logit "Successfully created NVRAM area ${nvindex_str} for EK template."
-		fi
-		rm -f "${EK_TEMP_FILE}"
-	fi
-
-	# have external program create the certificates now
-	call_create_certs "$flags" "$config_file" "$certsdir" "$ek" "$vmid"
-	if [ $? -ne 0 ]; then
-		return 1
-	fi
-
-	if [ $((flags & SETUP_EK_CERT_F)) -ne 0 ] && \
-	   [ -r "${EK_CERT_FILE}" ]; then
-
-		if [ $((flags & SETUP_TPM2_ECC_F)) -eq 0 ]; then
-			nvindex=${TPM2_NV_INDEX_RSA_EKCert}
-		else
-			nvindex=${TPM2_NV_INDEX_ECC_EKCert}
-		fi
-		nvindex_str="$(printf "0x%08x" ${nvindex})"
-
-		tpm2_nv_define \
-			${nvindex} \
-			$((TPMA_NV_PLATFORMCREATE | \
-			   TPMA_NV_AUTHREAD | \
-			   TPMA_NV_OWNERREAD | \
-			   TPMA_NV_PPREAD | \
-			   TPMA_NV_PPWRITE | \
-			   TPMA_NV_NO_DA | \
-			   TPMA_NV_WRITEDEFINE)) \
-			"$(get_filesize "${EK_CERT_FILE}")"
-		if [ $? -ne 0 ]; then
-			logerr "Could not create NVRAM area ${nvindex_str}" \
-			       "for EK certificate."
-			return 1
-		fi
-		tpm2_nv_write \
-			${nvindex} \
-			"${EK_CERT_FILE}"
-		if [ $? -ne 0 ]; then
-			logerr "Could not write EK certificate into" \
-			       "NVRAM area ${nvindex_str}."
-			return 1
-		fi
-		if [ $((flags & SETUP_LOCK_NVRAM_F)) -ne 0 ]; then
-			tpm2_nv_writelock \
-				${nvindex}
-			if [ $? -ne 0 ]; then
-				logerr "Could not lock EK certificate NVRAM" \
-				       "area ${nvindex_str}."
-				return 1
-			fi
-		fi
-		logit "Successfully created NVRAM area ${nvindex_str} for EK certificate."
-		rm -f "${EK_CERT_FILE}"
-	fi
-
-	if [ $((flags & SETUP_PLATFORM_CERT_F)) -ne 0 ] && \
-	   [ -r "${PLATFORM_CERT_FILE}" ] ; then
-
-		nvindex=${TPM2_NV_INDEX_PlatformCert}
-		nvindex_str="$(printf "0x%08x" ${nvindex})"
-
-		tpm2_nv_define \
-			${nvindex} \
-			$((TPMA_NV_PLATFORMCREATE | \
-			   TPMA_NV_AUTHREAD | \
-			   TPMA_NV_OWNERREAD | \
-			   TPMA_NV_PPREAD | \
-			   TPMA_NV_PPWRITE | \
-			   TPMA_NV_NO_DA | \
-			   TPMA_NV_WRITEDEFINE)) \
-			"$(get_filesize "${PLATFORM_CERT_FILE}")"
-		if [ $? -ne 0 ]; then
-			logerr "Could not create NVRAM area ${nvindex_str}" \
-			       "for platform certificate."
-			return 1
-		fi
-		tpm2_nv_write \
-			${nvindex} \
-			"${PLATFORM_CERT_FILE}"
-		if [ $? -ne 0 ]; then
-			logerr "Could not write platform certificate into" \
-			       "NVRAM area ${nvindex_str}."
-			return 1
-		fi
-		if [ $((flags & SETUP_LOCK_NVRAM_F)) -ne 0 ]; then
-			tpm2_nv_writelock \
-				${nvindex}
-			if [ $? -ne 0 ]; then
-				logerr "Could not lock platform certificate" \
-				       "NVRAM area ${nvindex_str}."
-				return 1
-			fi
-		fi
-		logit "Successfully created NVRAM area ${nvindex_str}" \
-		      "for platform certificate."
-		rm -f "${PLATFORM_CERT_FILE}"
-	fi
+	tpm2_create_ek_and_cert "$flags" "$config_file" "$certsdir" "$vmid"
+	[ $? -ne 0 ] && return 1
 
 	if [ "$pcr_banks" != "-" ]; then
 		all_pcr_banks="$(tpm2_get_all_pcr_banks)"

--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -146,6 +146,9 @@ NONCE_RSA_SIZE=256
 NONCE_ECC_256='\x00\x20'${NB32}
 NONCE_ECC_256_SIZE=32
 
+NONCE_EMPTY='\x00\x00'
+NONCE_EMPTY_SIZE=0
+
 trap "cleanup" SIGTERM EXIT
 
 logit()
@@ -1221,6 +1224,92 @@ tpm2_createprimary_spk_ecc_nist_p256()
 	return $?
 }
 
+# Create the primary key as a NIST P384 ECC key (EK equivalent)
+#
+# @param1: flags
+# @param2: filename for template
+tpm2_createprimary_ek_ecc_nist_p384()
+{
+	local flags="$1"
+	local templatefile="$2"
+
+	local min_exp symkeydata keyflags totlen publen offset authpolicy
+
+	if [ $((flags & SETUP_ALLOW_SIGNING_F)) -ne 0 ] && \
+	   [ $((flags & SETUP_DECRYPTION_F)) -ne 0 ]; then
+		# keyflags: fixedTPM, fixedParent, sensitiveDatOrigin,
+		# userWithAuth, adminWithPolicy, sign, decrypt
+		keyflags=$((0x000600f2))
+		# symmetric: TPM_ALG_NULL
+		symkeydata='\\x00\\x10'
+		publen=$((0x46 + 2 * NONCE_EMPTY_SIZE))
+		totlen=$((0x6f + 2 * NONCE_EMPTY_SIZE))
+		min_exp=1026
+		# offset of length indicator for key
+		offset=258
+	elif [ $((flags & SETUP_ALLOW_SIGNING_F)) -ne 0 ]; then
+		# keyflags: fixedTPM, fixedParent, sensitiveDatOrigin,
+		# userWithAuth, adminWithPolicy, sign
+		keyflags=$((0x000400f2))
+		# symmetric: TPM_ALG_NULL
+		symkeydata='\\x00\\x10'
+		publen=$((0x46 + 2 * NONCE_EMPTY_SIZE))
+		totlen=$((0x6f + 2 * NONCE_EMPTY_SIZE))
+		min_exp=1026
+		# offset of length indicator for key
+		offset=258
+	else
+		# keyflags: fixedTPM, fixedParent, sensitiveDatOrigin,
+		# userWithAuth, adminWithPolicy, restricted, decrypt
+		keyflags=$((0x000300f2))
+		# symmetric: TPM_ALG_AES, 256bit, TPM_ALG_CFB
+		symkeydata='\\x00\\x06\\x01\\x00\\x00\\x43'
+		publen=$((0x4a + 2 * NONCE_EMPTY_SIZE))
+		totlen=$((0x73 + 2 * NONCE_EMPTY_SIZE))
+		# minimum expected return
+		min_exp=1038
+		# offset of length indicator for key
+		offset=270
+	fi
+
+	# authPolicy from Ek Credential Profile; Spec v 2.1; rev12; p. 43
+	authpolicy='\\xB2\\x6E\\x7D\\x28\\xD1\\x1A\\x50\\xBC\\x53\\xD8\\x82\\xBC'
+	authpolicy+='\\xF5\\xFD\\x3A\\x1A\\x07\\x41\\x48\\xBB\\x35\\xD3\\xB4\\xE4'
+	authpolicy+='\\xCB\\x1C\\x0A\\xD9\\xBD\\xE4\\x19\\xCA\\xCB\\x47\\xBA\\x09'
+	authpolicy+='\\x69\\x96\\x46\\x15\\x0F\\x9F\\xC0\\x00\\xF3\\xF8\\x0E\\x12'
+
+	tpm2_createprimary_ecc_params '\\x40\\x00\\x00\\x0b' "${keyflags}" \
+	    "${symkeydata}" "${publen}" "${totlen}" "${min_exp}" "${offset}" \
+	    "48" "${authpolicy}" "${templatefile}" "4" "12" "$NONCE_EMPTY"
+	return $?
+}
+
+# Create primary storage key as a NIST P384 ECC key
+#
+# @param1: flags
+tpm2_createprimary_spk_ecc_nist_p384()
+{
+	local flags="$1"
+
+	local min_exp symkeydata keyflags totlen publen offset
+
+	# keyflags: fixedTPM, fixedParent, sensitiveDataOrigin,
+	# userWithAuth, noDA, restricted, decrypt
+	keyflags=$((0x00030472))
+	# symmetric: TPM_ALG_AES, 256bit, TPM_ALG_CFB
+	symkeydata='\\x00\\x06\\x01\\x00\\x00\\x43'
+	publen=$((0x1a + 2 * NONCE_ECC_384_SIZE))
+	totlen=$((0x43 + 2 * NONCE_ECC_384_SIZE))
+	min_exp=990
+	# offset of length indicator for key
+	offset=126
+
+	tpm2_createprimary_ecc_params '\\x40\\x00\\x00\\x0b' "${keyflags}" \
+	    "${symkeydata}" "${publen}" "${totlen}" "${min_exp}" "${offset}" \
+	    "48" "" "" "4" "12" "$NONCE_ECC_384"
+	return $?
+}
+
 tpm2_createprimary_ecc_params()
 {
 	local primaryhandle="$1"
@@ -1313,6 +1402,12 @@ tpm2_createprimary_ecc_params()
 	res="$(echo "0x${rsp:30:12}" | sed -n 's/ //pg'),"
 	len=$((keylen*3))
 	res+="$(echo x=${rsp:$off1:$len},y=${rsp:$off2:$len} | sed -n 's/ //pg')"
+
+	case "$curveid" in
+	3)	;;
+	4)	res+=",id=secp384r1";;
+	esac
+
 	echo "$res"
 
 	if [ -n "${templatefile}" ]; then

--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -127,7 +127,11 @@ TPM2_NV_INDEX_ECC_EKCert=$((0x01c0000a))
 TPM2_NV_INDEX_ECC_EKTemplate=$((0x01c0000c))
 TPM2_NV_INDEX_PlatformCert=$((0x01c08000))
 
-TPM2_EK_HANDLE=$((0x81010001))
+TPM2_NV_INDEX_ECC_SECP384R1_HI_EKCert=$((0x01c00016))
+TPM2_NV_INDEX_ECC_SECP384R1_HI_EKTemplate=$((0x01c00017))
+
+TPM2_EK_RSA_HANDLE=$((0x81010001))
+TPM2_EK_ECC_SECP384R1_HANDLE=$((0x81010016))
 TPM2_SPK_HANDLE=$((0x81000001))
 
 # Default logging goes to stderr
@@ -145,6 +149,9 @@ NONCE_RSA_SIZE=256
 
 NONCE_ECC_256='\x00\x20'${NB32}
 NONCE_ECC_256_SIZE=32
+
+NONCE_ECC_384='\x00\x30'${NB32}${NB16}
+NONCE_ECC_384_SIZE=48
 
 NONCE_EMPTY='\x00\x00'
 NONCE_EMPTY_SIZE=0
@@ -1507,7 +1514,7 @@ tpm2_create_ek_and_cert()
 	local EK_CERT_FILE="$certsdir/ek.cert"
 	local EK_TEMP_FILE="$certsdir/ektemplate"
 
-	local ek nvindex nvindex_str
+	local ek nvindex nvindex_str keytype
 	local nvindexattrs=$((TPMA_NV_PLATFORMCREATE | \
 		TPMA_NV_AUTHREAD | \
 		TPMA_NV_OWNERREAD | \
@@ -1516,19 +1523,27 @@ tpm2_create_ek_and_cert()
 		TPMA_NV_NO_DA | \
 		TPMA_NV_WRITEDEFINE))
 
+	if [ $((flags & SETUP_TPM2_ECC_F)) -ne 0 ]; then
+		keytype="ECC"
+		tpm2_ek_handle=$TPM2_EK_ECC_SECP384R1_HANDLE
+	else
+		keytype="RSA"
+		tpm2_ek_handle=$TPM2_EK_RSA_HANDLE
+	fi
+
 	if [ $((flags & SETUP_CREATE_EK_F)) -ne 0 ]; then
-		ek=$(tpm2_create_ek "$flags" "${TPM2_EK_HANDLE}" "${EK_TEMP_FILE}")
+		ek=$(tpm2_create_ek "$flags" "${tpm2_ek_handle}" "${EK_TEMP_FILE}")
 		if [ $? -ne 0 ]; then
 			logerr "tpm2_create_ek failed"
 			return 1
 		fi
-		logit "Successfully created EK with handle" \
-		      "$(printf "0x%08x" ${TPM2_EK_HANDLE})."
+		logit "Successfully created $keytype EK with handle" \
+		      "$(printf "0x%08x" ${tpm2_ek_handle})."
 
 		if [ $((flags & SETUP_TPM2_ECC_F)) -eq 0 ]; then
 			nvindex=${TPM2_NV_INDEX_RSA_EKTemplate}
 		else
-			nvindex=${TPM2_NV_INDEX_ECC_EKTemplate}
+			nvindex=${TPM2_NV_INDEX_ECC_SECP384R1_HI_EKTemplate}
 		fi
 		nvindex_str="$(printf "0x%08x" ${nvindex})"
 
@@ -1554,7 +1569,7 @@ tpm2_create_ek_and_cert()
 					return 1
 				fi
 			fi
-			logit "Successfully created NVRAM area ${nvindex_str} for EK template."
+			logit "Successfully created NVRAM area ${nvindex_str} for $keytype EK template."
 		fi
 		rm -f "${EK_TEMP_FILE}"
 	fi
@@ -1571,7 +1586,7 @@ tpm2_create_ek_and_cert()
 		if [ $((flags & SETUP_TPM2_ECC_F)) -eq 0 ]; then
 			nvindex=${TPM2_NV_INDEX_RSA_EKCert}
 		else
-			nvindex=${TPM2_NV_INDEX_ECC_EKCert}
+			nvindex=${TPM2_NV_INDEX_ECC_SECP384R1_HI_EKCert}
 		fi
 		nvindex_str="$(printf "0x%08x" ${nvindex})"
 
@@ -1579,7 +1594,7 @@ tpm2_create_ek_and_cert()
 			"$(get_filesize "${EK_CERT_FILE}")"
 		if [ $? -ne 0 ]; then
 			logerr "Could not create NVRAM area ${nvindex_str}" \
-			       "for EK certificate."
+			       "for $keytype EK certificate."
 			return 1
 		fi
 		tpm2_nv_write ${nvindex} "${EK_CERT_FILE}"
@@ -1596,7 +1611,7 @@ tpm2_create_ek_and_cert()
 				return 1
 			fi
 		fi
-		logit "Successfully created NVRAM area ${nvindex_str} for EK certificate."
+		logit "Successfully created NVRAM area ${nvindex_str} for $keytype EK certificate."
 		rm -f "${EK_CERT_FILE}"
 	fi
 
@@ -1631,6 +1646,29 @@ tpm2_create_ek_and_cert()
 		      "for platform certificate."
 		rm -f "${PLATFORM_CERT_FILE}"
 	fi
+	return 0
+}
+
+# Create RSA and ECC EKs and their certs
+# @param1: flags
+# @param2: configuration file
+# @param3: certificates directory
+# @param4: VM identifier
+tpm2_create_eks_and_certs()
+{
+	local flags="$1"
+	local config_file="$2"
+	local certs_dir="$3"
+	local vmid="$4"
+
+	# 1st key will be RSA
+	flags=$((flags & ~SETUP_TPM2_ECC_F))
+	tpm2_create_ek_and_cert "$flags" "$config_file" "$certsdir" "$vmid"
+	[ $? -ne 0 ] && return 1
+
+	# 2nd key will be an ECC; no more platform cert
+	flags=$(((flags & ~SETUP_PLATFORM_CERT_F) | SETUP_TPM2_ECC_F))
+	tpm2_create_ek_and_cert "$flags" "$config_file" "$certsdir" "$vmid"
 	return 0
 }
 
@@ -2027,7 +2065,7 @@ init_tpm2()
 		      "handle $(printf "0x%08x" ${TPM2_SPK_HANDLE})."
 	fi
 
-	tpm2_create_ek_and_cert "$flags" "$config_file" "$certsdir" "$vmid"
+	tpm2_create_eks_and_certs "$flags" "$config_file" "$certsdir" "$vmid"
 	[ $? -ne 0 ] && return 1
 
 	if [ "$pcr_banks" != "-" ]; then
@@ -2130,7 +2168,8 @@ The following options are supported:
 
 --tpm2           : Setup a TPM 2; by default a TPM 1.2 is setup.
 
---createek       : Create the EK
+--createek       : Create the EK; for a TPM 2 an RSA and ECC EK will be
+                   created
 
 --allow-signing  : Create an EK that can be used for signing;
                    this option requires --tpm2.
@@ -2139,7 +2178,8 @@ The following options are supported:
                    this is the default unless --allow-signing is given;
                    this option requires --tpm2.
 
---ecc            : Create ECC keys rather than RSA keys; this requires --tpm2
+--ecc            : This option allows to create a TPM 2's ECC key as storage
+                   primary key; a TPM 2 always gets an RSA and an ECC EK key.
 
 --take-ownership : Take ownership; this option implies --createek
   --ownerpass  <password>


### PR DESCRIPTION
This PR now introduces NIST P384 key creation code and ditches NIST P256 related code. It also changes swtpm_setup so that now an RSA as well as a NIST P384 EK key are created.