### PR TITLE
swtpm_setup: return result of called function rather than 0

### DIFF
--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -1529,7 +1529,7 @@ tpm2_create_eks_and_certs()
 	# 2nd key will be an ECC; no more platform cert
 	flags=$(((flags & ~SETUP_PLATFORM_CERT_F) | SETUP_TPM2_ECC_F))
 	tpm2_create_ek_and_cert "$flags" "$config_file" "$certsdir" "$vmid"
-	return 0
+	return $?
 }
 
 # Create the platform key, either RSA or ECC


### PR DESCRIPTION
Return the result of the called function rather than 0.

Fixes: d65f5ae1 ("swtpm_setup: Create RSA 2048 and ECC NIST P256 keys and certs")
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>