### PR TITLE
swtpm_setup: bugfix: Create ECC storage primary key in owner hierarchy

### DIFF
--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -1175,7 +1175,8 @@ tpm2_createprimary_spk_ecc_nist_p384()
 	# offset of length indicator for key
 	offset=126
 
-	tpm2_createprimary_ecc_params '\\x40\\x00\\x00\\x0b' "${keyflags}" \
+	# TPM_RH_OWNER
+	tpm2_createprimary_ecc_params '\\x40\\x00\\x00\\x01' "${keyflags}" \
 	    "${symkeydata}" "${publen}" "${totlen}" "${min_exp}" "${offset}" \
 	    "48" "" "" "4" "12" "$NONCE_ECC_384"
 	return $?


### PR DESCRIPTION
The ECC storage primary key was mistakently created in the endorsement
hierarchy but should be in the owner hierarchy. This patch corrects this
to have this key created in the owner hierarchy (like the RSA key),
thus using 0x40 00 00 01.

This only mattered if one used --create-spk and --ecc together.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>