### PR TITLE
swtpm_setup: bugfix: Create ECC storage primary key in owner hierarchy

### DIFF
--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -1157,7 +1157,8 @@ tpm2_createprimary_spk_ecc()
 	off1=126
 	off2=228
 
-	tpm2_createprimary_ecc_params '\\x40\\x00\\x00\\x0b' "${keyflags}" \
+	# TPM_RH_OWNER
+	tpm2_createprimary_ecc_params '\\x40\\x00\\x00\\x01' "${keyflags}" \
 	    "${symkeydata}" "${publen}" "${totlen}" "${min_exp}" "${off1}" \
 	    "${off2}" "" ""
 	return $?


### PR DESCRIPTION
The ECC storage primary key was mistakently created in the endorsement
hierarchy but should be in the owner hierarchy. This patch corrects this
to have this key created in the owner hierarchy (like the RSA key),
thus using 0x40 00 00 01.

This only mattered if one used --create-spk and --ecc together.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>