### PR TITLE
Have swtpm report RSA key size capabilities and use to adapt test cases

### DIFF
--- a/man/man8/swtpm.8
+++ b/man/man8/swtpm.8
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "swtpm 8"
-.TH swtpm 8 "2020-02-08" "swtpm" ""
+.TH swtpm 8 "2020-04-23" "swtpm" ""
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -380,7 +380,10 @@ may contain the following:
 \&        "cmdarg\-key\-fd",
 \&        "cmdarg\-pwd\-fd",
 \&        "tpm\-send\-command\-header",
-\&        "flags\-opt\-startup"
+\&        "flags\-opt\-startup",
+\&        "rsa\-keysize\-1024",
+\&        "rsa\-keysize\-2048",
+\&        "rsa\-keysize\-3072"
 \&      ]
 \&    }
 .Ve
@@ -405,6 +408,10 @@ The \s-1TPM 2\s0 will respond by preprending a 4\-byte response indicator and a
 .IP "\fBflags-opt-startup\fR" 4
 .IX Item "flags-opt-startup"
 The \fI\-\-flags\fR option supports the \fIstartup\-...\fR options.
+.IP "\fBrsa\-keysize\-2048\fR" 4
+.IX Item "rsa-keysize-2048"
+The \s-1TPM 2\s0 supports the shown \s-1RSA\s0 key sizes. If none of the
+rsa-keysize verbs is shown then only \s-1RSA 2048\s0 bit keys are supported.
 .RE
 .RS 4
 .RE

--- a/man/man8/swtpm.pod
+++ b/man/man8/swtpm.pod
@@ -294,7 +294,10 @@ may contain the following:
         "cmdarg-key-fd",
         "cmdarg-pwd-fd",
         "tpm-send-command-header",
-        "flags-opt-startup"
+        "flags-opt-startup",
+        "rsa-keysize-1024",
+        "rsa-keysize-2048",
+        "rsa-keysize-3072"
       ]
     }
 
@@ -324,6 +327,11 @@ The TPM 2 will respond by preprending a 4-byte response indicator and a
 =item B<flags-opt-startup>
 
 The I<--flags> option supports the I<startup-...> options.
+
+=item B<rsa-keysize-2048>
+
+The TPM 2 supports the shown RSA key sizes. If none of the
+rsa-keysize verbs is shown then only RSA 2048 bit keys are supported.
 
 =back
 

--- a/tests/_test_tpm2_print_capabilities
+++ b/tests/_test_tpm2_print_capabilities
@@ -23,8 +23,9 @@ if [ "${SWTPM_IFACE}" != "cuse" ]; then
 	noncuse='"tpm-send-command-header", "flags-opt-startup", '
 fi
 
-exp='{ "type": "swtpm", "features": [ '${noncuse}${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd" ] }'
-if [ "${msg}" != "${exp}" ]; then
+# The rsa key size reporting is variable, so use a regex
+exp='\{ "type": "swtpm", "features": \[ '${noncuse}${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd"(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")? \] \}'
+if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-capabilities:"
 	echo "Actual   : ${msg}"
 	echo "Expected : ${exp}"

--- a/tests/test_tpm2_ibmtss2
+++ b/tests/test_tpm2_ibmtss2
@@ -78,8 +78,10 @@ if [ $revision -lt 155 ]; then
 	done
 fi
 
-# libtpms may at some revision start supporting RSA 3072 keys...
-if [ $revision -gt 0 ]; then
+rsa3072=$(run_swtpm_ioctl ${SWTPM_INTERFACE} --info 4 |
+          sed -n 's/.*"RSAKeySizes":\[\([0-9,]*\)\].*/\1/p' |
+          grep 3072)
+if [ -z "$rsa3072" ]; then
 	pushd regtests &>/dev/null
 
 	echo "Modifying test cases related to RSA 3072 keys."
@@ -92,6 +94,8 @@ if [ $revision -gt 0 ]; then
 	sed -i "s| \"-rsa 3072\"||" testsalt.sh
 
 	popd &>/dev/null
+else
+	echo "swptm/libtpms support RSA 3072 bit keys"
 fi
 
 export TPM_SERVER_NAME=127.0.0.1


### PR DESCRIPTION
Have swtpm report libtpms's RSA key size capabilities and use it to adapt test cases so that we run RSA 3072 test cases when libtpms supports them.