### PR TITLE
build-sys: Let swtpm build with in-place libtpms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -159,10 +159,9 @@ if test $? -ne 0; then
 fi
 AC_SUBST([LIBTASN1_LIBS])
 
-LIBTPMS_LIBS=$(pkg-config --libs libtpms)
-if test $? -ne 0; then
-	AC_MSG_ERROR("Is libtpms-devel installed? -- could not get libs for libtpms")
-fi
+PKG_CHECK_MODULES([LIBTPMS],[libtpms],,AC_MSG_WARN("no libtpms.pc found, continuing with standard path"))
+LDFLAGS="$LDFLAGS $LIBTPMS_LDFLAGS"
+CFLAGS="$CFLAGS $LIBTPMS_CFLAGS"
 AC_CHECK_LIB(tpms,
              TPMLIB_ChooseTPMVersion,[true],
              AC_MSG_ERROR("libtpms 0.6 or later is required")
@@ -406,7 +405,8 @@ PKG_PROG_PKG_CONFIG
 AC_MSG_CHECKING([Checking the crypto library libtpms is linked to])
 libtpms_cryptolib=`$PKG_CONFIG --variable cryptolib libtpms`
 if test "x$libtpms_cryptolib" = "x"; then
-  AC_MSG_ERROR([Could not determine the crypto library libtpms is using])
+  AC_MSG_WARN([Could not determine the crypto library libtpms is using, assuming ${cryptolib}])
+  libtpms_cryptolib=${cryptolib}
 fi
 AC_MSG_RESULT($libtpms_cryptolib)
 


### PR DESCRIPTION
Building things like this in-place is really useful when you can't be
bothered to package and install them for your distribution but still
want to use them.  This patch allows building swtpm with libtpms in
place.  Simply specify the location to LDFLAGS and CFLAGS on the
configure line

LIBTPMS_CFLAGS=-I/home/jejb/git/libtpms/include/ LIBTPMS_LDFLAGS=-L/home/jejb/git/libtpms/src/.libs/ ./configure

It will then build a version that can run in-place.

I also think it corrects a bug in the original in that if pkg-config
had specified a non standard library location, the version check
wouldn't have used it.

Signed-off-by: James E.J. Bottomley <jejb@linux.ibm.com>
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>