### PR TITLE
Fix issues with RSA 3072 bit EK keys

### DIFF
--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -119,8 +119,10 @@ TPMA_NV_WRITEDEFINE=$((0x2000))
 # Use standard EK Cert NVRAM, EK and SRK handles per IWG spec.
 # "TCG TPM v2.0 Provisioning Guide"; Version 1.0, Rev 1.0, March 15, 2017
 # Table 2
-TPM2_NV_INDEX_RSA_EKCert=$((0x01c00002))
-TPM2_NV_INDEX_RSA_EKTemplate=$((0x01c00004))
+TPM2_NV_INDEX_RSA2048_EKCert=$((0x01c00002))
+TPM2_NV_INDEX_RSA2048_EKTemplate=$((0x01c00004))
+TPM2_NV_INDEX_RSA3072_HI_EKCert=$((0x01c0001c))
+TPM2_NV_INDEX_RSA3072_HI_EKTemplate=$((0x01c0001d))
 # For ECC follow "TCG EK Credential Profile For TPM Family 2.0; Level 0"
 # Specification Version 2.1; Revision 13; 10 December 2018
 TPM2_NV_INDEX_PlatformCert=$((0x01c08000))
@@ -1462,7 +1464,10 @@ tpm2_create_ek_and_cert()
 		      "$(printf "0x%08x" ${tpm2_ek_handle})."
 
 		if [ $((flags & SETUP_TPM2_ECC_F)) -eq 0 ]; then
-			nvindex=${TPM2_NV_INDEX_RSA_EKTemplate}
+			case "$rsa_keysize" in
+			2048)	nvindex=${TPM2_NV_INDEX_RSA2048_EKTemplate};;
+			3072)	nvindex=${TPM2_NV_INDEX_RSA3072_HI_EKTemplate};;
+			esac
 		else
 			nvindex=${TPM2_NV_INDEX_ECC_SECP384R1_HI_EKTemplate}
 		fi
@@ -1505,7 +1510,10 @@ tpm2_create_ek_and_cert()
 	   [ -r "${EK_CERT_FILE}" ]; then
 
 		if [ $((flags & SETUP_TPM2_ECC_F)) -eq 0 ]; then
-			nvindex=${TPM2_NV_INDEX_RSA_EKCert}
+			case "$rsa_keysize" in
+			2048)	nvindex=${TPM2_NV_INDEX_RSA2048_EKCert};;
+			3072)	nvindex=${TPM2_NV_INDEX_RSA3072_HI_EKCert};;
+			esac
 		else
 			nvindex=${TPM2_NV_INDEX_ECC_SECP384R1_HI_EKCert}
 		fi

--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -955,7 +955,7 @@ tpm2_createprimary_ek_rsa()
 		addlen=0
 		keyflags=0
 		;;
-	3072)	nonce_size=$NONCE_RSA3072_SIZE
+	3072)	nonce_size=$NONCE_EMPTY_SIZE
 		# authPolicy from: Ek Credential Profile; Spec v 2.3; rev2; p.47
 		authpolicy='\\xB2\\x6E\\x7D\\x28\\xD1\\x1A\\x50\\xBC\\x53\\xD8\\x82\\xBC'
 		authpolicy+='\\xF5\\xFD\\x3A\\x1A\\x07\\x41\\x48\\xBB\\x35\\xD3\\xB4\\xE4'
@@ -1006,7 +1006,7 @@ tpm2_createprimary_ek_rsa()
 	# TPM_RH_ENDORSEMENT
 	tpm2_createprimary_rsa_params '\\x40\\x00\\x00\\x0b' "${keyflags}" \
 	    "${symkeydata}" "${publen}" "${totlen}" "${min_exp}" "${off}" \
-	    "${authpolicy}" "${templatefile}" "${rsa_keysize}"
+	    "${authpolicy}" "${templatefile}" "${rsa_keysize}" "${nonce_size}"
 	return $?
 }
 
@@ -1041,7 +1041,7 @@ tpm2_createprimary_spk_rsa()
 	# TPM_RH_OWNER
 	tpm2_createprimary_rsa_params '\\x40\\x00\\x00\\x01' "${keyflags}" \
 	    "${symkeydata}" "${publen}" "${totlen}" "${min_exp}" "${off}" "" \
-	    "" "${rsa_keysize}"
+	    "" "${rsa_keysize}" "${nonce_size}"
 	return $?
 }
 
@@ -1057,6 +1057,7 @@ function tpm2_createprimary_rsa_params()
 	local authpolicy="$8"
 	local templatefile="$9"
 	local rsa_keysize="${10}"
+	local nonce_size="${11}"
 
 	local req rsp res temp nonce_rsa modulus_len_str key_strlen hashalg
 	local symkeylen
@@ -1068,7 +1069,10 @@ function tpm2_createprimary_rsa_params()
 		hashalg=11
 		symkeylen=128
 		;;
-	3072)	nonce_rsa=${NONCE_RSA3072}
+	3072)	case "$nonce_size" in
+		$NONCE_EMPTY_SIZE)	nonce_rsa=$NONCE_EMPTY;;
+		*)			nonce_rsa=$NONCE_RSA3072;;
+		esac
 		modulus_len_str=" 01 80"
 		hashalg=12
 		symkeylen=256


### PR DESCRIPTION
This PR fixes two issues with 3072 bit EK keys:
-  put them into the correct NVRAM location
-  create the RSA EK key with an empty nonce buffer rather than 384 bytes of zeroes
