### PR TITLE
tests: Adapt test cases' expected PCR result due to libtpms TPM 2 fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,14 +109,14 @@ matrix:
       os: osx
       compiler: clang
       before_script:
-      - brew upgrade gnutls
-      - brew install expect
-      - brew install libtasn
-      - brew install glib
-      - brew install gawk
-      - brew install gmp
-      - brew tap discoteq/discoteq
-      - brew install flock
-      - brew install socat
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade gnutls || true
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install expect
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install libtasn
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install glib
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install gawk
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install gmp
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew tap discoteq/discoteq
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install flock
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install socat
       # To run the pkcs11 test with softhsm we need SUDO (above)
-      - brew install softhsm
+      - HOMEBREW_NO_AUTO_UPDATE=1 brew install softhsm

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@
 #       This file is derived from tpm-tool's configure.in.
 #
 
-AC_INIT(swtpm, 0.1.0)
+AC_INIT(swtpm, 0.1.1)
 AC_PREREQ(2.12)
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_HEADER(config.h)

--- a/dist/swtpm.spec
+++ b/dist/swtpm.spec
@@ -11,7 +11,7 @@
 
 Summary: TPM Emulator
 Name:           swtpm
-Version:        0.1.0
+Version:        0.1.1
 Release:        0.%{gitdate}git%{gitshortcommit}%{?dist}
 License:        BSD
 Url:            http://github.com/stefanberger/swtpm

--- a/tests/_test_tpm2_encrypted_state
+++ b/tests/_test_tpm2_encrypted_state
@@ -100,7 +100,7 @@ fi
 # Read PCR 17
 swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
-exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 19 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
+exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
 if [ "$RES" != "$exp" ]; then
 	echo "Error: (1) Did not get expected result from TPM_PCRRead(17)"
 	echo "expected: $exp"
@@ -192,7 +192,7 @@ fi
 # Read the PCR again ...
 swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
-exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 19 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
+exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
 if [ "$RES" != "$exp" ]; then
 	echo "Error: (2) Did not get expected result from TPM_PCRRead(17)"
 	echo "expected: $exp"
@@ -236,7 +236,7 @@ fi
 # Read the PCR again ...
 swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
-exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 19 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
+exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
 if [ "$RES" != "$exp" ]; then
 	echo "Error: (2) Did not get expected result from TPM_PCRRead(17)"
 	echo "expected: $exp"

--- a/tests/_test_tpm2_hashing3
+++ b/tests/_test_tpm2_hashing3
@@ -93,7 +93,7 @@ swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 # Read PCR 0
 #                                                     length         CC            count       hashalg         sz
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x01\x00\x00')
-exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 15 00 00 00 01 00 0b 03 01 00 00 00 00 00 01 00 20 34 0a 23 3f ac 4c a0 14 98 6e 45 dd 95 ec 77 6a 7a 3f 86 a2 10 74 f4 3a 43 90 c5 b8 c3 ab ea f4'
+exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 14 00 00 00 01 00 0b 03 01 00 00 00 00 00 01 00 20 34 0a 23 3f ac 4c a0 14 98 6e 45 dd 95 ec 77 6a 7a 3f 86 a2 10 74 f4 3a 43 90 c5 b8 c3 ab ea f4'
 if [ "$RES" != "$exp" ]; then
 	echo "Error: (1) Did not get expected result from TPM_PCRRead(0)"
 	echo "expected: $exp"

--- a/tests/_test_tpm2_save_load_encrypted_state
+++ b/tests/_test_tpm2_save_load_encrypted_state
@@ -93,7 +93,7 @@ fi
 # Read PCR 17
 swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
-exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 19 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
+exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
 if [ "$RES" != "$exp" ]; then
 	echo "Error: (1) Did not get expected result from TPM2_PCRRead(17)"
 	echo "expected: $exp"
@@ -191,7 +191,7 @@ fi
 # Read the PCR again ...
 swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
-exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 19 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
+exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
 if [ "$RES" != "$exp" ]; then
 	echo "Error: (2) Did not get expected result from TPM2_PCRRead(17)"
 	echo "expected: $exp"
@@ -234,7 +234,7 @@ fi
 # Read the PCR again ...
 swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
-exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 19 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
+exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
 if [ "$RES" != "$exp" ]; then
 	echo "Error: (2) Did not get expected result from TPM_PCRRead(17)"
 	echo "expected: $exp"

--- a/tests/_test_tpm2_savestate
+++ b/tests/_test_tpm2_savestate
@@ -85,7 +85,7 @@ swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 # Read PCR 10
 #                         length         CC            count       hashalg         sz
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x04\x00')
-exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 16 00 00 00 01 00 0b 03 00 04 00 00 00 00 01 00 20 c3 ba a5 62 69 08 26 72 c3 db 3d 11 0a 10 74 a1 a7 a6 ea 43 e8 82 16 1a af 4b ea a6 83 17 e4 b8'
+exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 15 00 00 00 01 00 0b 03 00 04 00 00 00 00 01 00 20 c3 ba a5 62 69 08 26 72 c3 db 3d 11 0a 10 74 a1 a7 a6 ea 43 e8 82 16 1a af 4b ea a6 83 17 e4 b8'
 if [ "$RES" != "$exp" ]; then
 	echo "Error: (1) Did not get expected result from TPM2_PCRRead(10)"
 	echo "expected: $exp"
@@ -126,7 +126,7 @@ swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 # Read PCR 10
 #                                                   length         CC            count       hashalg         sz
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x04\x00')
-exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 1b 00 00 00 01 00 0b 03 00 04 00 00 00 00 01 00 20 c3 ba a5 62 69 08 26 72 c3 db 3d 11 0a 10 74 a1 a7 a6 ea 43 e8 82 16 1a af 4b ea a6 83 17 e4 b8'
+exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 19 00 00 00 01 00 0b 03 00 04 00 00 00 00 01 00 20 c3 ba a5 62 69 08 26 72 c3 db 3d 11 0a 10 74 a1 a7 a6 ea 43 e8 82 16 1a af 4b ea a6 83 17 e4 b8'
 if [ "$RES" != "$exp" ]; then
 	echo "Error: (2) Did not get expected result from TPM2_PCR_Read(10)"
 	echo "expected: $exp"

--- a/tests/_test_tpm2_volatilestate
+++ b/tests/_test_tpm2_volatilestate
@@ -75,7 +75,7 @@ fi
 #                                                  length         CC            count       hashalg         sz
 swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
-exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 19 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
+exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
 if [ "$RES" != "$exp" ]; then
 	echo "Error: (1) Did not get expected result from TPM_PCRRead(17)"
 	echo "expected: $exp"
@@ -142,7 +142,7 @@ swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 
 #                                                      length         CC            count       hashalg         sz
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
-exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 19 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
+exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
 if [ "$RES" != "$exp" ]; then
 	echo "Error: (2) Did not get expected result from TPM_PCRRead(17)"
 	echo "expected: $exp"
@@ -190,7 +190,7 @@ swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 
 #                                                     length         CC            count       hashalg         sz
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
-exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 19 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
+exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
 if [ "$RES" != "$exp" ]; then
 	echo "Error: (3) Did not get expected result from TPM_PCRRead(17)"
 	echo "expected: $exp"

--- a/tests/test_tpm2_ctrlchannel2
+++ b/tests/test_tpm2_ctrlchannel2
@@ -245,7 +245,7 @@ exec 100<>/dev/tcp/localhost/65532
 #                         length         CC            count       hashalg         sz
 echo -en '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02' >&100
 RES=$(cat <&100 | od -t x1 -A n | tr -d "\n")
-exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 19 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 e5 17 e3 9b 10 a3 5b 3b b7 29 95 79 4b c6 4a 07 f8 bc b0 bd e6 bb 31 ad 35 27 fb 6f 64 f8 4c b9'
+exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 e5 17 e3 9b 10 a3 5b 3b b7 29 95 79 4b c6 4a 07 f8 bc b0 bd e6 bb 31 ad 35 27 fb 6f 64 f8 4c b9'
 if [ "$RES" != "$exp" ]; then
 	echo "Error: (1) Did not get expected result from TPM_PCRRead(17)"
 	echo "expected: $exp"

--- a/tests/test_tpm2_vtpm_proxy
+++ b/tests/test_tpm2_vtpm_proxy
@@ -73,7 +73,7 @@ fi
 #                         length         CC            count       hashalg         sz
 echo -en '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02' >&100
 RES=$(od -t x1 -A n -w128 <&100)
-exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 15 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff'
+exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 14 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff'
 if [ "$RES" != "$exp" ]; then
 	echo "Error: Did not get expected result from TPM_PCRRead(17)"
 	echo "expected: $exp"


### PR DESCRIPTION
libtpms version 0.6.3, 0.7.3, and master have a change to the TPM 2 code
that affects the pcrUpdateCounter, which now returns a smaller value than
before.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>