### PR TITLE
debian: Address some issues raised by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -22,7 +22,7 @@ swtpm (0.2.0~dev1) UNRELEASED; urgency=medium
 
  -- Stefan Berger <stefanb@linux.ibm.com>  Mon, 04 Feb 2019 14:30:08 -0500
 
-swtpm (0.1.0-1) RELEASED; urgency medium
+swtpm (0.1.0-1) RELEASED; urgency=medium
 
   * Initial public release
 

--- a/debian/swtpm-cuse.install
+++ b/debian/swtpm-cuse.install
@@ -1,3 +1,0 @@
-#! /usr/bin/dh-exec
-/usr/bin/swtpm_cuse
-/usr/share/man/man8/swtpm_cuse.8*

--- a/debian/swtpm-tools.postinst.in
+++ b/debian/swtpm-tools.postinst.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 
 SWTPM_LOCALCA_DIR=@LOCALSTATEDIR@/lib/swtpm-localca
 


### PR DESCRIPTION
Remove swtpm_cuse related install script since not needed anymore.

Also address the following issues:

E: swtpm-tools: unknown-control-interpreter control/postinst #!/usr/bin/env
W: swtpm: syntax-error-in-debian-changelog line 25 "bad key-value after `;': `urgency medium'"

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>