### PR TITLE
tests: Use the IBM TSS2 v1.5.0's test suite

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -144,6 +144,7 @@ EXTRA_DIST=$(TESTS) \
 	data/tpm2state5/signature.bin \
 	data/tpm2state5/tpm2-00.permall \
 	load_vtpm_proxy \
+	patches/ibmtss2_1.5_rsa2048only.patch \
 	patches/libtpm.patch \
 	softhsm_setup \
 	test_clientfds.py \

--- a/tests/patches/ibmtss2_1.5_rsa2048only.patch
+++ b/tests/patches/ibmtss2_1.5_rsa2048only.patch
@@ -1,0 +1,148 @@
+diff --git a/utils/regtests/initkeys.sh b/utils/regtests/initkeys.sh
+index 80c6adb..469b5c9 100755
+--- a/utils/regtests/initkeys.sh
++++ b/utils/regtests/initkeys.sh
+@@ -64,7 +64,7 @@ BITS=(2048 3072)
+ 
+ for ((i = 0 ; i < 2 ; i++))
+ do
+-
++    [ $i -eq 1 ] && continue # skip 3072 bits
+     echo "Create an RSA ${BITS[i]} ${SHALG[i]} storage key under the primary key"
+     ${PREFIX}create -hp 80000000 -rsa ${BITS[i]} -halg ${SHALG[i]} -st -kt f -kt p -pol policies/policycccreate-auth.bin -opr storersa${BITS[i]}priv.bin -opu storersa${BITS[i]}pub.bin -tk storersa${BITS[i]}tk.bin -ch storersa${BITS[i]}ch.bin -pwdp sto -pwdk sto > run.out
+     checkSuccess $?
+diff --git a/utils/regtests/testcredential.sh b/utils/regtests/testcredential.sh
+index 8b678d9..1f6a0f2 100755
+--- a/utils/regtests/testcredential.sh
++++ b/utils/regtests/testcredential.sh
+@@ -289,7 +289,7 @@ NVNAME=(
+ # interate though high range RSA EK certficates
+     for ((i = 0 ; i < 2 ; i++))
+     do
+-
++	[ $i -eq 1 ] && continue # skip 3072 bits
+ 	echo "Create an ${CALG[i]} EK certificate"
+ 	${PREFIX}createekcert -high ${CALG[i]} -cakey cakey.pem -capwd rrrr -pwdp ppp -pwde eee -of tmp.der > run.out
+ 	checkSuccess $?
+diff --git a/utils/regtests/testsalt.sh b/utils/regtests/testsalt.sh
+index 1bdc1a7..57ec69e 100755
+--- a/utils/regtests/testsalt.sh
++++ b/utils/regtests/testsalt.sh
+@@ -57,6 +57,7 @@ fi
+ 
+ for ASY in "${SALTALGS[@]}"
+ do
++    [ "$ASY" = "-rsa 3072" ] && continue # skip 3072 bits
+     for HALG in ${ITERATE_ALGS}
+     do
+ 
+diff --git a/utils/regtests/testx509.sh b/utils/regtests/testx509.sh
+index 813085f..f5737a8 100755
+--- a/utils/regtests/testx509.sh
++++ b/utils/regtests/testx509.sh
+@@ -59,7 +59,7 @@ SKEY=(rsa2048 rsa3072 eccnistp256 eccnistp384)
+ 
+ for ((i = 0 ; i < 4 ; i++))
+ do
+-
++    [ $i -eq 1 ] && continue # skip 3072 bits
+     echo "Load the ${SALG[i]} ${SKEY[i]} issuer key 80000001 under the primary key"
+     ${PREFIX}load -hp 80000000 -ipr sign${SKEY[i]}rpriv.bin -ipu sign${SKEY[i]}rpub.bin -pwdp sto > run.out
+     checkSuccess $?
+diff --git a/utils/regtests/testrsa.sh b/utils/regtests/testrsa.sh
+index 23bf894..d02f748 100755
+--- a/utils/regtests/testrsa.sh
++++ b/utils/regtests/testrsa.sh
+@@ -46,7 +46,7 @@ echo ""
+ echo "Test RSA"
+ echo ""
+ 
+-for BITS in 2048 3072
++for BITS in 2048
+ do
+ 
+     echo "generate the RSA $BITS encryption key with openssl"
+@@ -61,7 +61,7 @@ echo ""
+ echo "RSA decryption key"
+ echo ""
+ 
+-for BITS in 2048 3072
++for BITS in 2048
+ do
+ 
+     echo "Load the RSA $BITS decryption key under the primary key"
+@@ -91,7 +91,7 @@ echo ""
+ echo "RSA decryption key to sign with OID"
+ echo ""
+ 
+-for BITS in 2048 3072
++for BITS in 2048
+ do
+ 
+     echo "Load the RSA $BITS decryption key"
+@@ -133,7 +133,7 @@ echo "Start an HMAC auth session"
+ ${PREFIX}startauthsession -se h > run.out
+ checkSuccess $?
+ 
+-for BITS in 2048 3072
++for BITS in 2048
+ do
+ 
+     for SESS in "" "-se0 02000000 1"
+@@ -180,7 +180,7 @@ echo ""
+ echo "Loadexternal DER encryption key"
+ echo ""
+ 
+-for BITS in 2048 3072
++for BITS in 2048
+ do
+ 
+     echo "Start an HMAC auth session"
+@@ -338,8 +338,8 @@ rm -f tmpdig.bin
+ rm -f tmpsig.bin
+ rm -f tmpkeypairrsa2048.der
+ rm -f tmpkeypairrsa2048.pem
+-rm -f tmpkeypairrsa3072.der
+-rm -f tmpkeypairrsa3072.pem
++rm -f tmpkeypairrsa3072.der &>/dev/null
++rm -f tmpkeypairrsa3072.pem &>/dev/null
+ rm -f tmppubkey.bin
+ rm -f tmppubkey.pem
+ rm -f tmpprivkey.bin
+diff --git a/utils/regtests/testsign.sh b/utils/regtests/testsign.sh
+index 060b374..e6f3fec 100755
+--- a/utils/regtests/testsign.sh
++++ b/utils/regtests/testsign.sh
+@@ -44,7 +44,7 @@ echo ""
+ echo "RSA Signing key"
+ echo ""
+ 
+-for BITS in 2048 3072
++for BITS in 2048
+ do
+ 
+     echo "Create an RSA $BITS key pair in PEM format using openssl"
+@@ -410,8 +410,8 @@ done
+ 
+ rm -f tmpkeypairrsa2048.pem
+ rm -f tmpkeypairrsa2048.der
+-rm -f tmpkeypairrsa3072.pem
+-rm -f tmpkeypairrsa3072.der
++rm -f tmpkeypairrsa3072.pem &>/dev/null
++rm -f tmpkeypairrsa3072.der &>/dev/null
+ rm -f tmpkeypairecc.pem
+ rm -f tmpkeypairecc.der
+ rm -r pssig.bin
+
+index d43767a..59d0bc7 100755
+--- a/utils/reg.sh
++++ b/utils/reg.sh
+@@ -171,7 +171,7 @@ cleanup()
+ 	rm -f khrpub${HALG}.bin
+      done
+ 
+-    for BITS in 2048 3072
++    for BITS in 2048
+     do
+ 	rm -f signrsa${BITS}priv.bin
+ 	rm -f signrsa${BITS}pub.bin

--- a/tests/test_tpm2_ibmtss2
+++ b/tests/test_tpm2_ibmtss2
@@ -6,6 +6,7 @@ fi
 
 ROOT=${abs_top_builddir:-$(pwd)/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ABSTESTDIR=$(cd ${TESTDIR} &>/dev/null;echo ${PWD})
 
 SWTPM_SERVER_PORT=65426
 SWTPM_SERVER_NAME=127.0.0.1
@@ -40,19 +41,21 @@ git clone https://git.code.sf.net/p/ibmtpm20tss/tss ibmtpm20tss-tss
 
 pushd ibmtpm20tss-tss &>/dev/null
 
-git checkout tags/v1.4.0
+git checkout tags/v1.5.0
 if [ $? -ne 0 ]; then
 	echo "'Git checkout' failed."
 	exit 1
 fi
 
-# A v1.4.0 bug work-around:
+# A v1.5.0 bug work-around:
 pushd utils/regtests &>/dev/null
 # We cannot run the EK certificate tests since rootcerts.txt points to
 # files we do not have
-sed -i "133s/./\#\0/" testcredential.sh
-sed -i "134s/./\#\0/" testcredential.sh
-sed -i "135s/./\#\0/" testcredential.sh
+for line in 305 306 307 407 408 409 545 546 547; do
+	sed -i "${line}s/./\#\0/" testcredential.sh
+done
+
+sed -i 's/pass:rrrr 2048/pass:rrrr ${BITS}/' testrsa.sh
 popd &>/dev/null
 
 autoreconf --force --install
@@ -61,6 +64,21 @@ unset CFLAGS LDFLAGS LIBS
 make -j4
 
 pushd utils
+
+rsa3072=$(run_swtpm_ioctl ${SWTPM_INTERFACE} --info 4 |
+          sed -n 's/.*"RSAKeySizes":\[\([0-9,]*\)\].*/\1/p' |
+          grep 3072)
+if [ -z "$rsa3072" ]; then
+	echo "Modifying test cases related to RSA 3072 keys."
+
+	patch -p2 < "${ABSTESTDIR}/patches/ibmtss2_1.5_rsa2048only.patch"
+	if [ $? -ne 0 ]; then
+		echo "Patching of testsuite failed"
+		exit 1
+	fi
+else
+	echo "swptm/libtpms support RSA 3072 bit keys"
+fi
 
 sed -i 's/export CRYPTOLIBRARY.*/export CRYPTOLIBRARY=openssl/' reg.sh
 
@@ -76,26 +94,6 @@ if [ $revision -lt 155 ]; then
 		touch "${t}"
 		chmod 777 "${t}"
 	done
-fi
-
-rsa3072=$(run_swtpm_ioctl ${SWTPM_INTERFACE} --info 4 |
-          sed -n 's/.*"RSAKeySizes":\[\([0-9,]*\)\].*/\1/p' |
-          grep 3072)
-if [ -z "$rsa3072" ]; then
-	pushd regtests &>/dev/null
-
-	echo "Modifying test cases related to RSA 3072 keys."
-	# We do not support 3072 bit RSA keys at this point, so eliminate all 3072
-	# RSA key tests
-	for f in initkeys.sh testrsa.sh testsign.sh; do
-		sed -i "s| 3072||" "${f}"
-	done
-
-	sed -i "s| \"-rsa 3072\"||" testsalt.sh
-
-	popd &>/dev/null
-else
-	echo "swptm/libtpms support RSA 3072 bit keys"
 fi
 
 export TPM_SERVER_NAME=127.0.0.1


### PR DESCRIPTION
Upgrade to use the IBM TSS2 tests from v1.5.0.

Add a patch that eliminates all testing of 3072 bit RSA keys in case
libtpms does not support such keys. This test also passes with libtpms
0.6.0 and 0.7.0.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>