### PR TITLE
Fix build system issues for clang

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -357,13 +357,25 @@ if test "x$enable_hardening" != "xno"; then
 	if test -z "$TMP1" && test -n "$TPM2"; then
 		HARDENING_CFLAGS="$HARDENING_CFLAGS -D_FORTIFY_SOURCE=2 "
 	fi
-	dnl Check ld for 'relro' and 'now'
-	if $LD --help 2>&1 | $GREP '\-z relro ' > /dev/null; then
-		HARDENING_CFLAGS="$HARDENING_CFLAGS -Wl,-z,relro "
-	fi
-	if $LD --help 2>&1 | $GREP '\-z now ' > /dev/null; then
-		HARDENING_CFLAGS="$HARDENING_CFLAGS -Wl,-z,now "
-	fi
+	dnl Check linker for 'relro' and 'now'
+	save_CFLAGS="$CFLAGS"
+	CFLAGS="-Wl,-z,relro -Werror"
+	AC_MSG_CHECKING([whether linker supports -Wl,-z,relro])
+	AC_COMPILE_IFELSE(
+		[AC_LANG_SOURCE([[int main() { return 0; }]])],
+		[HARDENING_CFLAGS="$HARDENING_CFLAGS -Wl,-z,relro"
+		 AC_MSG_RESULT(yes)],
+		[AC_MSG_RESULT(no)]
+	)
+	CFLAGS="-Wl,-z,now -Werror"
+	AC_MSG_CHECKING([whether linker supports -Wl,-z,now])
+	AC_COMPILE_IFELSE(
+		[AC_LANG_SOURCE([[int main() { return 0; }]])],
+		[HARDENING_CFLAGS="$HARDENING_CFLAGS -Wl,-z,now"
+		 AC_MSG_RESULT(yes)],
+		[AC_MSG_RESULT(no)]
+	)
+	CFLAGS="$save_CFLAGS"
 	AC_SUBST([HARDENING_CFLAGS])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -150,6 +150,8 @@ openssl)
 	AC_CHECK_HEADERS([openssl/aes.h],[],
 			 AC_MSG_ERROR(Is openssl-devel/libssl-dev installed?))
 	AC_MSG_RESULT([Building with openssl crypto library])
+	LIBCRYPTO_LIBS=$(pkg-config --libs libcrypto)
+	AC_SUBST([LIBCRYPTO_LIBS])
 	;;
 esac
 

--- a/src/swtpm/Makefile.am
+++ b/src/swtpm/Makefile.am
@@ -69,7 +69,8 @@ libswtpm_libtpms_la_LIBADD = \
 	$(LIBTPMS_LIBS) \
 	$(GLIB_LIBS) \
 	$(LIBRT_LIBS) \
-	$(LIBSECCOMP_LIBS)
+	$(LIBSECCOMP_LIBS) \
+	$(LIBCRYPTO_LIBS)
 
 bin_PROGRAMS = swtpm
 if WITH_CUSE


### PR DESCRIPTION
This PR fixes 2 build system issues when clang is used and compilation is done on Gentoo:
- testing for unused linker flags that lead to compilation errors when -Werror is usded
- explicitly link libswtpm_libtpms.so with -lcrypto to avoid unresolved issues
