### PR TITLE
swtpm_setup fixes for distros not using tss:tss for tcsd user/group

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -407,6 +407,24 @@ AC_ARG_WITH([tss-group],
             [TSS_GROUP="$withval"],
             [TSS_GROUP="tss"]
 )
+
+case $have_tcsd in
+yes)
+	AC_MSG_CHECKING([whether TSS_USER $TSS_USER is available])
+	if ! test $(id -u $TSS_USER); then
+		AC_MSG_ERROR(["$TSS_USER is not available"])
+	else
+		AC_MSG_RESULT([yes])
+	fi
+	AC_MSG_CHECKING([whether TSS_GROUP $TSS_GROUP is available])
+	if ! test $(id -g $TSS_GROUP); then
+		AC_MSG_ERROR(["$TSS_GROUP is not available"])
+	else
+		AC_MSG_RESULT([yes])
+	fi
+	;;
+esac
+
 AC_SUBST([TSS_USER])
 AC_SUBST([TSS_GROUP])
 

--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -502,7 +502,7 @@ start_tcsd()
 {
 	local TCSD=$1
 
-	local user group ctr=0 ctr2 tmp tcsd_error_file
+	local user group ctr=0 ctr2 tmp tcsd_error_file tss_uid tss_gid
 
 	user=$(id -u -n)
 	group=$(id -g -n)
@@ -510,6 +510,17 @@ start_tcsd()
 	export TSS_TCSD_PORT
 
 	if check_spaces "$TMPDIR" "TMPDIR environment variable"; then
+		return 1
+	fi
+
+	tss_uid=$(id -u @TSS_USER@ 2>&1)
+	if [ $? -ne 0 ]; then
+		logerr "tcsd's user '@TSS_USER@' must be available: $tss_uid"
+		return 1
+	fi
+	tss_gid=$(id -u @TSS_GROUP@ 2>&1)
+	if [ $? -ne 0 ]; then
+		logerr "tcsd's group '@TSS_GROUP@' must be available: $tss_gid"
 		return 1
 	fi
 
@@ -532,8 +543,13 @@ port = $TSS_TCSD_PORT
 system_ps_file = $TCSD_DATA_FILE
 EOF
 		# tcsd requires @TSS_USER@:@TSS_GROUP@ and 0600 on TCSD_CONFIG
-		# -> only root can start
-		chmod 600 "$TCSD_CONFIG"
+		# 0640 is needed if user != group
+		# -> only root can start (typically)
+		if [ "$tss_uid" = "$tss_gid" ]; then
+			chmod 0600 "$TCSD_CONFIG"
+		else
+			chmod 0640 "$TCSD_CONFIG"
+		fi
 		if [ $(id -u) -eq 0 ]; then
 			chown "@TSS_USER@:@TSS_GROUP@" "$TCSD_CONFIG" 2>/dev/null
 			chown "@TSS_USER@:@TSS_GROUP@" "$TCSD_DATA_DIR" 2>/dev/null

--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -502,7 +502,7 @@ start_tcsd()
 {
 	local TCSD=$1
 
-	local user group ctr=0 ctr2
+	local user group ctr=0 ctr2 tmp tcsd_error_file
 
 	user=$(id -u -n)
 	group=$(id -g -n)
@@ -516,9 +516,10 @@ start_tcsd()
 	TCSD_CONFIG="$(mktemp)"
 	TCSD_DATA_DIR="$(mktemp -d)"
 	TCSD_DATA_FILE="$(TMPDIR=${TCSD_DATA_DIR} mktemp)"
+	tcsd_error_file="$(TMPDIR=${TCSD_DATA_DIR} mktemp)"
 
 	if [ -z "$TCSD_CONFIG" ] || [ -z "$TCSD_DATA_DIR" ] || \
-	   [ -z "$TCSD_DATA_FILE" ]; then
+	   [ -z "$TCSD_DATA_FILE" ] || [ -z "$tcsd_error_file" ]; then
 		logerr "Could not create temporary file; TMPDIR=$TMPDIR"
 		return 1
 	fi
@@ -547,7 +548,7 @@ EOF
 		# make sure tcsd is gone
 		stop_tcsd 1
 
-		TCSD_TCP_DEVICE_HOSTNAME=127.0.0.1 $TCSD -c "$TCSD_CONFIG" -e -f &>/dev/null &
+		TCSD_TCP_DEVICE_HOSTNAME=127.0.0.1 $TCSD -c "$TCSD_CONFIG" -e -f &>"$tcsd_error_file" &
 		TCSD_PID=$!
 
 		# poll for open port (good) or the process to have
@@ -575,6 +576,11 @@ EOF
 			echo "TSS is listening on TCP port $TSS_TCSD_PORT."
 			return 0
 		done
+
+		tmp="$(cat "$tcsd_error_file")"
+		if [ -n "$tmp" ]; then
+			logerr "tcsd error: $tmp"
+		fi
 
 		ctr=$((ctr + 1))
 	done

--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -550,15 +550,15 @@ EOF
 		else
 			chmod 0640 "$TCSD_CONFIG"
 		fi
-		if [ $(id -u) -eq 0 ]; then
+		if [ $(id -u) -eq 0 ] && \
+		   [ $(id -u) -ne $(id -u @TSS_USER@) -o $(id -g) -ne $(id -g @TSS_GROUP@) ]; then
 			chown "@TSS_USER@:@TSS_GROUP@" "$TCSD_CONFIG" 2>/dev/null
+			if [ $? -ne 0 ]; then
+				logerr "Could not change ownership on $TCSD_CONFIG to ${user}:${group}."
+				return 1
+			fi
 			chown "@TSS_USER@:@TSS_GROUP@" "$TCSD_DATA_DIR" 2>/dev/null
 			chown "@TSS_USER@:@TSS_GROUP@" "$TCSD_DATA_FILE" 2>/dev/null
-		fi
-		if [ $? -ne 0 ]; then
-			logerr "Could not change ownership on $TCSD_CONFIG to ${user}:${group}."
-			ls -l "$TCSD_CONFIG"
-			return 1
 		fi
 
 		# make sure tcsd is gone


### PR DESCRIPTION
This PR fixes a few issues related to requirements of the tcsd on file modes and ownership of the tcsd config file for distros that do NOT use tss:tss as user/group for the tcsd config file but root:tss (openSUSE). Ubuntu and Fedora for example use tss:tss due to the configuration of the tcsd there.
