### PR TITLE
build-sys: Error out if libtpms.pc cannot be found and request PKG_CO…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -162,7 +162,12 @@ if test $? -ne 0; then
 fi
 AC_SUBST([LIBTASN1_LIBS])
 
-PKG_CHECK_MODULES([LIBTPMS],[libtpms],,AC_MSG_WARN("no libtpms.pc found, continuing with standard path"))
+PKG_CHECK_MODULES(
+	[LIBTPMS],
+	[libtpms],
+	,
+	AC_MSG_ERROR("no libtpms.pc found; please set PKG_CONFIG_PATH to the directory where libtpms.pc is located")
+)
 LDFLAGS="$LDFLAGS $LIBTPMS_LDFLAGS"
 CFLAGS="$CFLAGS $LIBTPMS_CFLAGS"
 AC_CHECK_LIB(tpms,


### PR DESCRIPTION
…NFIG_PATH be set

Error out if libtpms.pc cannot be found for pkg-config. This now requires that an
in-place libtpms be accessed like this:

PKG_CONFIG_PATH=/home/stefanb/libtpms/ \
	LIBTPMS_CFLAGS=-I/home/stefanb/libtpms/include/ \
	LIBTPMS_LDFLAGS=-L/home/stefanb/libtpms/src/.libs/ \
	./configure --prefix=/usr

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>