### PR TITLE
swtpm_setup fixes for distros not using tss:tss for tcsd user/group

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,13 @@
 CHANGES - changes for swtpm
 
-verison 0.3.2:
+version 0.3.3:
+  - swtpm_setup:
+    - openSUSE: Support tcsd configuration where tss user != tss group,
+                such as root/tss; Fedora & Ubuntu for example use tss/tss
+  - build-sys:
+    - Check whether tss user and group are available
+
+version 0.3.2:
   - swtpm:
     - Remove unnecessary #include <seccomp.h> (fixes SuSE build)
     - Make coverity happy by handling default case in case statement

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@
 #       This file is derived from tpm-tool's configure.in.
 #
 
-AC_INIT(swtpm, 0.3.2)
+AC_INIT(swtpm, 0.3.3)
 AC_PREREQ(2.12)
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_HEADER(config.h)

--- a/configure.ac
+++ b/configure.ac
@@ -402,6 +402,24 @@ AC_ARG_WITH([tss-group],
             [TSS_GROUP="$withval"],
             [TSS_GROUP="tss"]
 )
+
+case $have_tcsd in
+yes)
+	AC_MSG_CHECKING([whether TSS_USER $TSS_USER is available])
+	if ! test $(id -u $TSS_USER); then
+		AC_MSG_ERROR(["$TSS_USER is not available"])
+	else
+		AC_MSG_RESULT([yes])
+	fi
+	AC_MSG_CHECKING([whether TSS_GROUP $TSS_GROUP is available])
+	if ! test $(id -g $TSS_GROUP); then
+		AC_MSG_ERROR(["$TSS_GROUP is not available"])
+	else
+		AC_MSG_RESULT([yes])
+	fi
+	;;
+esac
+
 AC_SUBST([TSS_USER])
 AC_SUBST([TSS_GROUP])
 

--- a/dist/swtpm.spec
+++ b/dist/swtpm.spec
@@ -11,7 +11,7 @@
 
 Summary: TPM Emulator
 Name:           swtpm
-Version:        0.3.2
+Version:        0.3.3
 Release:        0.%{gitdate}git%{gitshortcommit}%{?dist}
 License:        BSD
 Url:            http://github.com/stefanberger/swtpm

--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -486,7 +486,7 @@ start_tcsd()
 {
 	local TCSD=$1
 
-	local user group ctr=0 ctr2 tmp tcsd_error_file
+	local user group ctr=0 ctr2 tmp tcsd_error_file tss_uid tss_gid
 
 	user=$(id -u -n)
 	group=$(id -g -n)
@@ -494,6 +494,17 @@ start_tcsd()
 	export TSS_TCSD_PORT
 
 	if check_spaces "$TMPDIR" "TMPDIR environment variable"; then
+		return 1
+	fi
+
+	tss_uid=$(id -u @TSS_USER@ 2>&1)
+	if [ $? -ne 0 ]; then
+		logerr "tcsd's user '@TSS_USER@' must be available: $tss_uid"
+		return 1
+	fi
+	tss_gid=$(id -u @TSS_GROUP@ 2>&1)
+	if [ $? -ne 0 ]; then
+		logerr "tcsd's group '@TSS_GROUP@' must be available: $tss_gid"
 		return 1
 	fi
 
@@ -516,8 +527,13 @@ port = $TSS_TCSD_PORT
 system_ps_file = $TCSD_DATA_FILE
 EOF
 		# tcsd requires @TSS_USER@:@TSS_GROUP@ and 0600 on TCSD_CONFIG
-		# -> only root can start
-		chmod 600 "$TCSD_CONFIG"
+		# 0640 is needed if user != group
+		# -> only root can start (typically)
+		if [ "$tss_uid" = "$tss_gid" ]; then
+			chmod 0600 "$TCSD_CONFIG"
+		else
+			chmod 0640 "$TCSD_CONFIG"
+		fi
 		if [ $(id -u) -eq 0 ]; then
 			chown "@TSS_USER@:@TSS_GROUP@" "$TCSD_CONFIG" 2>/dev/null
 			chown "@TSS_USER@:@TSS_GROUP@" "$TCSD_DATA_DIR" 2>/dev/null

--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -486,7 +486,7 @@ start_tcsd()
 {
 	local TCSD=$1
 
-	local user group ctr=0 ctr2
+	local user group ctr=0 ctr2 tmp tcsd_error_file
 
 	user=$(id -u -n)
 	group=$(id -g -n)
@@ -500,9 +500,10 @@ start_tcsd()
 	TCSD_CONFIG="$(mktemp)"
 	TCSD_DATA_DIR="$(mktemp -d)"
 	TCSD_DATA_FILE="$(TMPDIR=${TCSD_DATA_DIR} mktemp)"
+	tcsd_error_file="$(TMPDIR=${TCSD_DATA_DIR} mktemp)"
 
 	if [ -z "$TCSD_CONFIG" ] || [ -z "$TCSD_DATA_DIR" ] || \
-	   [ -z "$TCSD_DATA_FILE" ]; then
+	   [ -z "$TCSD_DATA_FILE" ] || [ -z "$tcsd_error_file" ]; then
 		logerr "Could not create temporary file; TMPDIR=$TMPDIR"
 		return 1
 	fi
@@ -532,12 +533,12 @@ EOF
 		stop_tcsd 1
 		case "$(id -u)" in
 		0)
-			$TCSD -c "$TCSD_CONFIG" -e -f &>/dev/null &
+			$TCSD -c "$TCSD_CONFIG" -e -f &>"$tcsd_error_file" &
 			TCSD_PID=$!
 			;;
 		*)
 			# for tss user, use the wrapper
-			$TCSD -c "$TCSD_CONFIG" -e -f &>/dev/null &
+			$TCSD -c "$TCSD_CONFIG" -e -f &>"$tcsd_error_file" &
 			#if [ $? -ne  0]; then
 			#	swtpm_tcsd_launcher -c $TCSD_CONFIG -e -f &>/dev/null &
 			#fi
@@ -570,6 +571,11 @@ EOF
 			echo "TSS is listening on TCP port $TSS_TCSD_PORT."
 			return 0
 		done
+
+		tmp="$(cat "$tcsd_error_file")"
+		if [ -n "$tmp" ]; then
+			logerr "tcsd error: $tmp"
+		fi
 
 		ctr=$((ctr + 1))
 	done

--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -534,15 +534,15 @@ EOF
 		else
 			chmod 0640 "$TCSD_CONFIG"
 		fi
-		if [ $(id -u) -eq 0 ]; then
+		if [ $(id -u) -eq 0 ] && \
+		   [ $(id -u) -ne $(id -u @TSS_USER@) -o $(id -g) -ne $(id -g @TSS_GROUP@) ]; then
 			chown "@TSS_USER@:@TSS_GROUP@" "$TCSD_CONFIG" 2>/dev/null
+			if [ $? -ne 0 ]; then
+				logerr "Could not change ownership on $TCSD_CONFIG to ${user}:${group}."
+				return 1
+			fi
 			chown "@TSS_USER@:@TSS_GROUP@" "$TCSD_DATA_DIR" 2>/dev/null
 			chown "@TSS_USER@:@TSS_GROUP@" "$TCSD_DATA_FILE" 2>/dev/null
-		fi
-		if [ $? -ne 0 ]; then
-			logerr "Could not change ownership on $TCSD_CONFIG to ${user}:${group}."
-			ls -l "$TCSD_CONFIG"
-			return 1
 		fi
 
 		# make sure tcsd is gone


### PR DESCRIPTION
This PR fixes a few issues related to requirements of the tcsd on file modes and ownership of the tcsd config file for distros that do NOT use tss:tss as user/group for the tcsd config file but root:tss (openSUSE). Ubuntu and Fedora for example use tss:tss due to the configuration of the tcsd there.

Also:
- build swtpm 0.3.3 now
- update CHANGES file
