### PR TITLE
tests: Squeeze spaces in case od print two space between hexbytes (Op…

### DIFF
--- a/tests/test_tpm2_parameters
+++ b/tests/test_tpm2_parameters
@@ -115,7 +115,7 @@ for (( i=0; i<${#PARAMETERS[*]}; i++)); do
 	# We expect sequences of 4 0-bytes in unencrypted state
 	# and no such sequences in encrypted state.
 	nullseq="$(cat $TPMDIR/tpm2-00.permall | \
-			od -t x1 -A n | tr -d '\n' |
+			od -t x1 -A n | tr -d '\n' | tr -s ' ' |
 			grep "00 00 00 00")"
 	if [[ "${PARAMETERS[$i]}" =~ (keyfile|pwdfile) ]]; then
 		if [ -n "${nullseq}" ]; then


### PR DESCRIPTION
…enBSD)

The OpenBSD implementation of 'od -tx1' prints two spaces between
hexbytes, thus the grep fails and we report an invalid result. This
patch fixes this by squeezing the two consecutive spaces.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>