### PR TITLE
build-sys: fix test for netstat if tcsd is not available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,7 +193,7 @@ dnl If we have the tcsd package, we can build swtpm_setup, but need netstat also
 AC_PATH_PROG([NETSTAT], [netstat])
 case $host_os in
 linux-*)
-    if test "x$NETSTAT" = "x" && test "have_tcsd" != "no"; then
+    if test "x$NETSTAT" = "x" && test "$have_tcsd" != "no"; then
         AC_MSG_ERROR([netstat tool is missing for tests: net-tools package])
     fi
     ;;


### PR DESCRIPTION
A typo in the condition meant that `netstat` was always required regardless of whether `tcsd` is available or not.