### PR TITLE
tests: Modify sample key to be 2048 bit rather than 2033 bit

### DIFF
--- a/tests/test_tpm2_samples_swtpm_localca
+++ b/tests/test_tpm2_samples_swtpm_localca
@@ -11,8 +11,8 @@ SWTPM_LOCALCA=${TOPSRC}/samples/swtpm-localca
 
 workdir=$(mktemp -d "/tmp/path with spaces.XXXXXX")
 
-ek=""
-for ((i = 0; i < 256; i++)); do
+ek="80" # 2048 bit key must have highest bit set
+for ((i = 1; i < 256; i++)); do
   ek="${ek}$(printf "%02x" $i)"
 done
 

--- a/tests/test_tpm2_samples_swtpm_localca_pkcs11
+++ b/tests/test_tpm2_samples_swtpm_localca_pkcs11
@@ -11,8 +11,8 @@ SWTPM_LOCALCA=${TOPSRC}/samples/swtpm-localca
 
 workdir=$(mktemp -d)
 
-ek=""
-for ((i = 0; i < 256; i++)); do
+ek="80" # 2048 bit key must have highest bit set
+for ((i = 1; i < 256; i++)); do
   ek="${ek}$(printf "%02x" $i)"
 done
 


### PR DESCRIPTION
The generated sample keys started with 00010203, thus leaving the
upper 15 bits of the key as '0', which in turn causes gnutls to think
that the key is only 2033 bit long, thus rejecting certificate
verification once the min-verification-profile is set to 'medium'
in /etc/crypto-policies/back-ends/gnutls.config.

This fixes test errors on Fedora Rawhide due to the change in
the min-verification-profile setting in gnutls.config.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>