### PR TITLE
tests: Have tpm2_ptool use store in temporary directory

### DIFF
--- a/tests/test_tpm2_samples_create_tpmca
+++ b/tests/test_tpm2_samples_create_tpmca
@@ -44,6 +44,7 @@ workdir=$(mktemp -d)
 
 SWTPM_LOCALCA_DIR="${workdir}/my localca"
 SWTPM_LOCALCA_CONF="${workdir}/my localca/swtpm-localca.conf"
+export TPM2_PKCS11_STORE="${workdir}"
 
 PID="" # primary object id returned by tpm2_ptool
 


### PR DESCRIPTION
Have the tpm2_ptool use a store in the temporary directory so that
with every test we have a clean environment.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>