### PR TITLE
swtpm: Change include of sys/fcntl.h to fcntl.h

### DIFF
--- a/src/swtpm/logging.c
+++ b/src/swtpm/logging.c
@@ -42,7 +42,7 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>