### PR TITLE
build-sys: Add build targets selinux-install and selinux-uninstall

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,3 +21,9 @@ EXTRA_DIST = \
 	COPYING \
 	README \
 	autogen.sh
+
+if WITH_SELINUX
+selinux-install selinux-uninstall:
+	@cd src/selinux && $(MAKE) $(AM_MAKEFLAGS) $@
+.PHONY: selinux-install selinux-uninstall
+endif

--- a/src/selinux/Makefile.am
+++ b/src/selinux/Makefile.am
@@ -40,9 +40,24 @@ all: $(POLICIES_BZ2)
 clean:
 	$(RM) -r tmp $(POLICIES) $(POLICIES_BZ2)
 
+PRIORITY ?= 400
+selinux-install: $(POLICIES_BZ2)
+	@if test $(shell id -u) != 0; then \
+		echo "You have to be root for this operation"; exit 1; \
+	fi
+	semodule --priority $(PRIORITY) --install $(POLICIES_BZ2)
+
+selinux-uninstall:
+	@if test $(shell id -u) != 0; then \
+		echo "You have to be root for this operation"; exit 1; \
+	fi
+	semodule --priority $(PRIORITY) --remove $(patsubst %.pp.bz2,%,$(POLICIES_BZ2))
+
+.PHONY: selinux-install selinux-uninstall
+
 %.pp.bz2: %.pp
 	@echo Compressing $^ -\> $@
-	bzip2 -f -9 $^
+	bzip2 -k -f -9 $^
 
 .SECONDEXPANSION:
 .NOTPARALLEL:


### PR DESCRIPTION
Add build targets selinux-install and selinux-uninstall to install
and uninstall the SELinux policy rules at a given priority. The
priority defeaults to 400, which works fine on Fedora.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>