### PR TITLE
build-sys: Label swtpm and swtpm_cuse with SELinux label

### DIFF
--- a/src/selinux/Makefile.am
+++ b/src/selinux/Makefile.am
@@ -46,6 +46,10 @@ selinux-install: $(POLICIES_BZ2)
 		echo "You have to be root for this operation"; exit 1; \
 	fi
 	semodule --priority $(PRIORITY) --install $(POLICIES_BZ2)
+	restorecon -i "$(prefix)/bin/swtpm"
+if WITH_CUSE
+	restorecon -i "$(prefix)/bin/swtpm_cuse"
+endif
 
 selinux-uninstall:
 	@if test $(shell id -u) != 0; then \


### PR DESCRIPTION
When running the selinux-install target also label swptm and swtpm_cuse.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>