### PR TITLE
swtpm_setup: Accomodate for BSD sed that does not print \n as newline

### DIFF
--- a/src/swtpm_setup/swtpm_setup.sh.in
+++ b/src/swtpm_setup/swtpm_setup.sh.in
@@ -2155,7 +2155,8 @@ get_rsa_keysizes() {
 
 	if [ $((flags & SETUP_TPM2_F)) -ne 0 ]; then
 		$SWTPM --tpm2 --print-capabilities |
-			sed -n 's/rsa\-keysize\-[^"]*"/\n&/gp' |
+			sed -n 's/rsa\-keysize\-[^"]*"/@&/gp' |
+			tr '@' '\n' |
 			sed -n 's/rsa\-keysize\-\([^"]*\)".*/\1/gp'
 	fi
 }


### PR DESCRIPTION
BSD's sed does not print \n as newline, so we have to split the string
into different lines using tr.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>