### PR TITLE
Some fixes of minor issues

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -342,6 +342,11 @@ if test "x$SOCAT" = "x"; then
 	AC_MSG_ERROR([socat is required: socat package])
 fi
 
+AC_PATH_PROG([FLOCK], flock)
+if test "x$FLOCK" = "x"; then
+	AC_MSG_ERROR([flock is required: flock package])
+fi
+
 AC_PATH_PROG([PYTHON], python3)
 if test "x$PYTHON" = "x"; then
 	AC_MSG_ERROR([python3 is required])

--- a/tests/test_parameters
+++ b/tests/test_parameters
@@ -131,7 +131,7 @@ for (( i=0; i<${#PARAMETERS[*]}; i++)); do
 	# We expect sequences of 4 0-bytes in unencrypted state
 	# and no such sequences in encrypted state.
 	nullseq="$(cat $TPMDIR/tpm-00.permall | \
-			od -t x1 -A n | tr -d '\n' |
+			od -t x1 -A n | tr -d '\n' | tr -s ' ' |
 			grep "00 00 00 00")"
 	if [[ "${PARAMETERS[$i]}" =~ (keyfile|pwdfile) ]]; then
 		if [ -n "${nullseq}" ]; then


### PR DESCRIPTION
This PR fixes some minor issues such as checking for the flock tool and a fix for BSD where `od` output needs to be 'squeezed.'