### PR TITLE
tests: Fix tests for slow/busy system by taking time again (DA timeou…

### DIFF
--- a/tests/_test_tpm2_save_load_state_da_timeout
+++ b/tests/_test_tpm2_save_load_state_da_timeout
@@ -142,6 +142,7 @@ while :; do
 	RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} ${NVWRITE_GOOD})
 	exp=' 80 01 00 00 00 0a 00 00 09 21'
 	# busy systems may run the above at >= $timeout and get an unexpected result; check time again
+	timenow=$(date +%s)
 	if [ "$RES" != "$exp" ] && [ $timenow -lt $timeout ]; then
 		echo "Error: Did not get expected failure from TPM2_NV_Write() with good password. Lockout should be enabled."
 		echo "expected: $exp"
@@ -284,6 +285,7 @@ while :; do
 	RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} ${NVWRITE_GOOD})
 	exp=' 80 01 00 00 00 0a 00 00 09 21'
 	# busy systems may run the above at >= $timeout and get an unexpected result; check time again
+	timenow=$(date +%s)
 	if [ "$RES" != "$exp" ] && [ $timenow -lt $timeout ]; then
 		echo "Error: Did not get expected failure from TPM2_NV_Write() with good password. Lockout should be enabled."
 		echo "expected: $exp"


### PR DESCRIPTION
…t test)

Slow systems, like Cygwin, need so much time from taking the time to sending
the command that we need to take the current time again to check whether the
success is valid. Previously the test may have failed since the old time that
was taken did not allow the success to be valid.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>