### PR TITLE
build-sys: add configure option to disable installation of Python module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -380,6 +380,10 @@ AS_IF([ test $? = 0 ],
        [AC_MSG_RESULT([yes])],
        [AC_MSG_ERROR([python setuptools is required])])
 
+AC_ARG_ENABLE([python-installation],
+  AS_HELP_STRING([--disable-python-installation], [Disable running setup.py install for swtpm_setup]))
+AM_CONDITIONAL([PYTHON_INSTALLATION], [test "x$enable_python_installation" != "xno"])
+
 AC_ARG_ENABLE([hardening],
   AS_HELP_STRING([--disable-hardening], [Disable hardening flags]))
 

--- a/src/swtpm_setup/Makefile.am
+++ b/src/swtpm_setup/Makefile.am
@@ -19,6 +19,7 @@ $(PY_PACKAGE): $(PY_SWTPM_SETUP_FILES)
 
 all-local: $(PY_PACKAGE)
 
+if PYTHON_INSTALLATION
 install-exec-local: $(PY_PACKAGE)
 	@if ! test $(findstring /usr, "$(DESTDIR)$(bindir)"); then \
 		echo "Warning: Not installing python package to $(DESTDIR)$(bindir)"; \
@@ -35,6 +36,7 @@ uninstall-local:
 		echo "Local pip3 uninstall"; \
 		$(PIP3) uninstall -y $(PY_PACKAGE_NAME); \
 	fi
+endif
 
 # for out-of-tree builds we need to clean up
 clean-local:


### PR DESCRIPTION
Distributions often have their own guidelines regarding installation of Python modules (e.g. Arch Linux [mandates using `--optimize=1`](https://wiki.archlinux.org/index.php/Python_package_guidelines#distutils) for `setup.py install`, which the Makefile in this project [does not do](https://github.com/stefanberger/swtpm/blob/0c238a2c93cdeea4283c6e9a7b8430a9b2df2b3e/src/swtpm_setup/Makefile.am#L39)). Add an option `--disable-python-installation` (disabled by default) to allow skipping the Python installation process entirely so that distributions can take care of this process manually in their preferred way.