### PR TITLE
build-sys: Bump up version to 0.5.0 at beginning of dev cycle

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@
 #       This file is derived from tpm-tool's configure.in.
 #
 
-AC_INIT(swtpm, 0.4.0)
+AC_INIT(swtpm, 0.5.0)
 AC_PREREQ(2.12)
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_HEADER(config.h)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+swtpm (0.5.0~dev1) UNRELEASED; urgency=medium
+
+  * Developer release 1
+
+ -- Stefan Berger <stefanb@linux.ibm.com>  Tue, 08 Sep 2020 09:00:00 -0500
+
 swtpm (0.4.0-1) RELEASED; urgency=medium
 
   * Stable release

--- a/dist/swtpm.spec
+++ b/dist/swtpm.spec
@@ -11,7 +11,7 @@
 
 Summary: TPM Emulator
 Name:           swtpm
-Version:        0.4.0
+Version:        0.5.0
 Release:        0.%{gitdate}git%{gitshortcommit}%{?dist}
 License:        BSD
 Url:            http://github.com/stefanberger/swtpm


### PR DESCRIPTION
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>