### PR TITLE
build-sys: Use AC_LINK_IFELSE to check whether support for hardening …

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -401,7 +401,7 @@ if test "x$enable_hardening" != "xno"; then
 	save_CFLAGS="$CFLAGS"
 	CFLAGS="-Wl,-z,relro -Werror"
 	AC_MSG_CHECKING([whether linker supports -Wl,-z,relro])
-	AC_COMPILE_IFELSE(
+	AC_LINK_IFELSE(
 		[AC_LANG_SOURCE([[int main() { return 0; }]])],
 		[HARDENING_CFLAGS="$HARDENING_CFLAGS -Wl,-z,relro"
 		 AC_MSG_RESULT(yes)],
@@ -409,7 +409,7 @@ if test "x$enable_hardening" != "xno"; then
 	)
 	CFLAGS="-Wl,-z,now -Werror"
 	AC_MSG_CHECKING([whether linker supports -Wl,-z,now])
-	AC_COMPILE_IFELSE(
+	AC_LINK_IFELSE(
 		[AC_LANG_SOURCE([[int main() { return 0; }]])],
 		[HARDENING_CFLAGS="$HARDENING_CFLAGS -Wl,-z,now"
 		 AC_MSG_RESULT(yes)],


### PR DESCRIPTION
…flags

Cygwin's linker does not support -Wl,-z,relro and -Wl,-z,now and
AC_COMPILE_IFELSE did only compile but not link, so it wouldn't detect
whether these flags are supported. So, use AC_LINK_IFELSE to detect
support for these flags.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>