### PR TITLE
build-sys: Use -Wl,-z,relro and -Wl,-z,now only when linking (clang)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -403,7 +403,7 @@ if test "x$enable_hardening" != "xno"; then
 	AC_MSG_CHECKING([whether linker supports -Wl,-z,relro])
 	AC_LINK_IFELSE(
 		[AC_LANG_SOURCE([[int main() { return 0; }]])],
-		[HARDENING_CFLAGS="$HARDENING_CFLAGS -Wl,-z,relro"
+		[HARDENING_LDFLAGS="$HARDENING_LDFLAGS -Wl,-z,relro"
 		 AC_MSG_RESULT(yes)],
 		[AC_MSG_RESULT(no)]
 	)
@@ -411,12 +411,13 @@ if test "x$enable_hardening" != "xno"; then
 	AC_MSG_CHECKING([whether linker supports -Wl,-z,now])
 	AC_LINK_IFELSE(
 		[AC_LANG_SOURCE([[int main() { return 0; }]])],
-		[HARDENING_CFLAGS="$HARDENING_CFLAGS -Wl,-z,now"
+		[HARDENING_LDFLAGS="$HARDENING_LDFLAGS -Wl,-z,now"
 		 AC_MSG_RESULT(yes)],
 		[AC_MSG_RESULT(no)]
 	)
 	CFLAGS="$save_CFLAGS"
 	AC_SUBST([HARDENING_CFLAGS])
+	AC_SUBST([HARDENING_LDFLAGS])
 fi
 
 AC_ARG_ENABLE([test-coverage],
@@ -585,6 +586,7 @@ echo "Crypto library    : $cryptolib"
 echo
 echo "CFLAGS=$CFLAGS"
 echo "HARDENING_CFLAGS=$HARDENING_CFLAGS"
+echo "HARDENING_LDFLAGS=$HARDENING_LDFLAGS"
 echo "LDFLAGS=$LDFLAGS"
 echo "LIBSECCOMP_LIBS=$LIBSECCOMP_LIBS"
 echo

--- a/src/swtpm/Makefile.am
+++ b/src/swtpm/Makefile.am
@@ -65,6 +65,9 @@ libswtpm_libtpms_la_CFLAGS = \
 	$(GLIB_CFLAGS) \
 	$(LIBSECCOMP_CFLAGS)
 
+libswtpm_libtpms_la_LDFLAGS = \
+	$(HARDENING_LDFLAGS)
+
 libswtpm_libtpms_la_LIBADD = \
 	$(LIBTPMS_LIBS) \
 	$(GLIB_LIBS) \
@@ -97,6 +100,9 @@ swtpm_CFLAGS = \
 	$(LIBFUSE_CFLAGS) \
 	-DHAVE_SWTPM_CUSE_MAIN
 
+swtpm_LDFLAGS = \
+	$(HARDENING_LDFLAGS)
+
 swtpm_LDADD = \
 	-L$(PWD)/.libs -lswtpm_libtpms \
 	$(LIBFUSE_LIBS) \
@@ -115,6 +121,9 @@ swtpm_cuse_CFLAGS = \
 	$(GLIB_CFLAGS) \
 	$(LIBFUSE_CFLAGS) \
 	$(HARDENING_CFLAGS)
+
+swtpm_cuse_LDFLAGS = \
+	$(HARDENING_LDFLAGS)
 
 swtpm_cuse_LDADD = \
 	-L$(PWD)/.libs -lswtpm_libtpms \


### PR DESCRIPTION
Clang complains if eiher one of those linker flags are used during compilation:

clang-9: error: -Wl,-z,relro: 'linker' input unused [-Werror,-Wunused-command-line-argument]
clang-9: error: -Wl,-z,now: 'linker' input unused [-Werror,-Wunused-command-line-argument]

This patch applies those flags only when linking.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>