### PR TITLE
samples: Fix usage of passwords for private keys

### DIFF
--- a/samples/swtpm-localca.in
+++ b/samples/swtpm-localca.in
@@ -290,6 +290,8 @@ create_cert() {
 			swtpm_cert \
 			--subject "$subj" \
 			$options \
+			${SIGNKEY_PASSWORD:+--signkey-pwd file:<(echo -en "$SIGNKEY_PASSWORD")} \
+			${PARENTKEY_PASSWORD:+--parentkey-pwd file:<(echo -en "$PARENTKEY_PASSWORD")} \
 			$tpm_attr_params \
 			--type platform \
 			--signkey "${SIGNKEY}" \

--- a/samples/swtpm-localca.in
+++ b/samples/swtpm-localca.in
@@ -333,7 +333,7 @@ create_localca_cert() {
 			local dir=$(dirname "${SIGNKEY}")
 			local cakey=${dir}/swtpm-localca-rootca-privkey.pem
 			local cacert=${dir}/swtpm-localca-rootca-cert.pem
-			local msg
+			local msg password
 
 			# create a CA first
 			msg=$("${CERTTOOL}" \
@@ -368,12 +368,9 @@ create_localca_cert() {
 			}
 
 			# now our signing CA
-			if [ -n "${SIGNKEY_PASSWORD}" ]; then
-				export GNUTLS_PIN=${SIGNKEY_PASSWORD}
-			fi
-
 			msg=$("${CERTTOOL}" \
 				--generate-privkey \
+				${SIGNKEY_PASSWORD:+--password "${SIGNKEY_PASSWORD}"} \
 				--outfile "${SIGNKEY}" \
 				2>&1)
 			[ $? -ne 0 ] && {
@@ -389,11 +386,21 @@ create_localca_cert() {
 			echo "cert_signing_key" >> "${tmp}"
 			echo "expiration_days = 3650" >> "${tmp}"
 
-			msg=$(GNUTLS_PIN="${SWTPM_ROOTCA_PASSWORD}" "${CERTTOOL}" \
+			if [ -n "${SIGNKEY_PASSWORD}" ] && [ -n "${SWTPM_ROOTCA_PASSWORD}" ]; then
+				GNUTLS_PIN="${SIGNKEY_PASSWORD}"
+				password="${SWTPM_ROOTCA_PASSWORD}"
+			elif [ -n "${SIGNKEY_PASSWORD}" ]; then
+				GNUTLS_PIN="${SIGNKEY_PASSWORD}"
+			else
+				GNUTLS_PIN="${SWTPM_ROOTCA_PASSWORD}"
+			fi
+
+			msg=$(GNUTLS_PIN="${GNUTLS_PIN}" "${CERTTOOL}" \
 				--generate-certificate \
 				--template "${tmp}" \
 				--outfile "${ISSUERCERT}" \
 				--load-privkey "${SIGNKEY}" \
+				${password:+--password "${password}"} \
 				--load-ca-privkey "${cakey}" \
 				--load-ca-certificate "${cacert}" \
 				2>&1)

--- a/tests/test_tpm2_samples_swtpm_localca
+++ b/tests/test_tpm2_samples_swtpm_localca
@@ -41,6 +41,7 @@ statedir=${workdir}
 signingkey = ${SIGNINGKEY}
 issuercert = ${ISSUERCERT}
 certserial = ${CERTSERIAL}
+signingkey_password = password
 _EOF_
 
 cat <<_EOF_ > "${workdir}/swtpm-localca.options"
@@ -76,6 +77,27 @@ do
   if [ $? -ne 0 ]; then
     echo "Error: Test with parameters '$params' failed."
     exit 1
+  fi
+
+  # Signing key should always be password protected
+  if [ -z "$(grep "ENCRYPTED PRIVATE KEY" "${SIGNINGKEY}")" ]; then
+    echo "Error: Signing key is not password protected."
+    exit 1
+  fi
+
+  # For the root CA's key we flip the password protection
+  if [ -n "${SWTPM_ROOTCA_PASSWORD}" ] ;then
+     if [ -z "$(grep "ENCRYPTED PRIVATE KEY" "${workdir}/swtpm-localca-rootca-privkey.pem")" ]; then
+       echo "Error: Root CA's private key is not password protected."
+       exit 1
+     fi
+     unset SWTPM_ROOTCA_PASSWORD
+  else
+     if [ -n "$(grep "ENCRYPTED PRIVATE KEY" "${workdir}/swtpm-localca-rootca-privkey.pem")" ]; then
+       echo "Error: Root CA's private key is password protected but should not be."
+       exit 1
+     fi
+     export SWTPM_ROOTCA_PASSWORD=xyz
   fi
 
   if [ ! -r "${workdir}/ek.cert" ]; then
@@ -114,6 +136,9 @@ do
     echo "Error: Could not verify certificate chain."
     exit 1
   fi
+
+  # Delete all keys to have CA re-created
+  rm -rf "${workdir}"/*.pem
 done
 
 echo "Test 1: OK"


### PR DESCRIPTION
This PR fixes some usage aspects for passwords for the private keys of the localca. The create signing key was not properly protected with the password and when creating the platform certificate the password for the signing key was not used.