### PR TITLE
samples: Add --password parameter for older GnuTLS versions

### DIFF
--- a/samples/py_swtpm_localca/swtpm_localca.py
+++ b/samples/py_swtpm_localca/swtpm_localca.py
@@ -251,6 +251,7 @@ def create_localca_cert(lockfile, statedir, signkey, signkey_password, issuercer
                 }
                 if swtpm_rootca_password:
                     certtool_env["GNUTLS_PIN"] = swtpm_rootca_password
+                    cmd.extend(["--password", swtpm_rootca_password]) # older GnuTLS
 
                 try:
                     proc = subprocess.Popen(cmd, env=certtool_env,
@@ -311,11 +312,13 @@ def create_localca_cert(lockfile, statedir, signkey, signkey_password, issuercer
                 }
                 if signkey_password and swtpm_rootca_password:
                     certtool_env["GNUTLS_PIN"] = signkey_password
-                    cmd.extend(["--password", swtpm_rootca_password])
+                    cmd.extend(["--password", swtpm_rootca_password]) # older GnutLS
                 elif signkey_password:
                     certtool_env["GNUTLS_PIN"] = signkey_password
+                    cmd.extend(["--password", signkey_password]) # older GnuTLS
                 elif swtpm_rootca_password:
                     certtool_env["GNUTLS_PIN"] = swtpm_rootca_password
+                    cmd.extend(["--password", swtpm_rootca_password]) # older GnuTLS
 
                 try:
                     proc = subprocess.Popen(cmd, env=certtool_env,


### PR DESCRIPTION
Older versions of GnuTLS need --password on the command line while
newer versions require GNUTLS_PIN to be set to pass the password.
So, this patch accomodates older versions of GnuTLS.

Older version of GnuTLS seem to NOT be able to handle a CA private
key needing a password and a signing key needing a password when
creating the intermediate CA. So this case of 2 passwords will
always fail.

The value of the local CA is not so high that passing passwords on
the command line would be an issue. Later on when using the CA the
password are set via environment variables, so not visible to other
users.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>