### PR TITLE
Fix support for the short options -h and -? in swtpm-localca and swtpm_setup

### DIFF
--- a/samples/py_swtpm_localca/swtpm_localca.py
+++ b/samples/py_swtpm_localca/swtpm_localca.py
@@ -512,7 +512,7 @@ def main():
     global LOGFILE # pylint: disable=W0603
 
     try:
-        opts, _ = getopt.getopt(sys.argv[1:], "",
+        opts, _ = getopt.getopt(sys.argv[1:], "h?",
                                 ["type=",
                                  "ek=",
                                  "dir=",
@@ -529,7 +529,7 @@ def main():
                                  "tpm2",
                                  "allow-signing",
                                  "decryption",
-                                 "help", "h", "-?"])
+                                 "help"])
     except getopt.GetoptError as err:
         print(err)
         usage(sys.argv[0])

--- a/src/swtpm_setup/py_swtpm_setup/swtpm_setup.py
+++ b/src/swtpm_setup/py_swtpm_setup/swtpm_setup.py
@@ -699,7 +699,7 @@ def main():
         swtpm_prg += " socket"
 
     try:
-        opts, _ = getopt.getopt(sys.argv[1:], "",
+        opts, _ = getopt.getopt(sys.argv[1:], "h?",
                                 ["tpm-state=", "tpmstate=",
                                  "tpm=",
                                  "swtpm_ioctl=",
@@ -734,7 +734,7 @@ def main():
                                  "tcsd-system-ps-file",
                                  "version",
                                  "print-capabilities",
-                                 "help", "h"])
+                                 "help"])
     except getopt.GetoptError as err:
         print(err)
         usage(sys.argv[0])


### PR DESCRIPTION
This PR fixes support for the short options -h and -? in swtpm-localca and swtpm_setup.