### PR TITLE
samples: swtpm-localca: Pass password via template file when possible

### DIFF
--- a/man/man8/swtpm-localca.pod
+++ b/man/man8/swtpm-localca.pod
@@ -28,6 +28,12 @@ swtpm-localca-rootca-cert.pem respectively. The environment variable
 SWTPM_ROOTCA_PASSWORD can be set for the password of the root CA's
 private key.
 
+Note: Due to limitations of 'certtool', the possible passwords used for
+securing the root CA's private key and the intermedia CA's private
+key have to be passed over the command line and therefore will be visible
+to others on the system. If you are concerned about this, you should create
+the CAs elsewhere and copy them onto the target system.
+
 The following options are supported:
 
 =over 4


### PR DESCRIPTION
Pass the CA's private key password via the template file. Remove recently
added old GnuTLS support. Extend man page with a paragraph about short-
comings of certtool that doesn't seem to allow private key password being
passed either as environment variable or template file.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>