### PR TITLE
samples: Use ${HOME}/.config if XDG_CONFIG_HOME is not set (RHEL)

### DIFF
--- a/samples/swtpm-create-user-config-files.in
+++ b/samples/swtpm-create-user-config-files.in
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 if [ -z "${XDG_CONFIG_HOME}" ]; then
-	echo "Environment variable XDG_CONFIG_HOME is not set."
-	exit 1
+	echo "Environment variable XDG_CONFIG_HOME is not set. Using \${HOME}/.config."
+	XDG_CONFIG_HOME="${HOME}/.config"
 fi
 
 SWTPM_LOCALCA_DIR="${XDG_CONFIG_HOME}/var/lib/swtpm-localca"


### PR DESCRIPTION
When creating the user config files, fall back to using ${HOME}/.config
if XDG_CONFIG_HOME is not set on a system.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>