### PR TITLE
swtpm: Prefix debug print function with SWTPM rather than TPM

### DIFF
--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -172,15 +172,15 @@ static int ctrlchannel_return_state(ptm_getstate *pgs, int fd)
     iov[0].iov_len = offsetof(ptm_getstate, u.resp.data);
     iovcnt = 1;
 
-    TPM_PrintAll(" Ctrl Rsp:", " ", iov[0].iov_base, iov[0].iov_len);
+    SWTPM_PrintAll(" Ctrl Rsp:", " ", iov[0].iov_base, iov[0].iov_len);
 
     if (res == 0 && return_length) {
         iov[1].iov_base = &blob[offset];
         iov[1].iov_len = return_length;
         iovcnt = 2;
 
-        TPM_PrintAll(" Ctrl Rsp Continued:", " ",
-                     iov[1].iov_base, min(iov[1].iov_len, 1024));
+        SWTPM_PrintAll(" Ctrl Rsp Continued:", " ",
+                       iov[1].iov_base, min(iov[1].iov_len, 1024));
     }
 
     n = writev_full(fd, iov, iovcnt);
@@ -532,7 +532,7 @@ int ctrlchannel_process_fd(int fd,
         goto err_socket;
     }
 
-    TPM_PrintAll(" Ctrl Cmd:", " ", msg.msg_iov->iov_base, min(n, 1024));
+    SWTPM_PrintAll(" Ctrl Cmd:", " ", msg.msg_iov->iov_base, min(n, 1024));
 
     if ((size_t)n < sizeof(input.cmd)) {
         goto err_bad_input;
@@ -867,7 +867,7 @@ int ctrlchannel_process_fd(int fd,
     }
 
 send_resp:
-    TPM_PrintAll(" Ctrl Rsp:", " ", output.body, min(out_len, 1024));
+    SWTPM_PrintAll(" Ctrl Rsp:", " ", output.body, min(out_len, 1024));
 
     n = write_full(fd, output.body, out_len);
     if (n < 0) {

--- a/src/swtpm/swtpm_debug.c
+++ b/src/swtpm/swtpm_debug.c
@@ -50,14 +50,14 @@
 #include "logging.h"
 
 /*
- * TPM_AppendPrintf() print and append to buffer
+ * SWTPM_AppendPrintf() print and append to buffer
  *
  * @buffer: pointer to existing buffer or pointer to NULL to start a new buffer
  * @fmt: typical printf fmt
  * @...: varagr printf parameters
  *
  */
-static int TPM_AppendPrintf(char **buffer, const char *fmt, ...)
+static int SWTPM_AppendPrintf(char **buffer, const char *fmt, ...)
 {
     va_list ap;
     int n, len = 0;
@@ -89,10 +89,10 @@ static int TPM_AppendPrintf(char **buffer, const char *fmt, ...)
     return len + n;
 }
 
-/* TPM_PrintAll() prints 'string', the length, and then the entire byte array
+/* SWTPM_PrintAll() prints 'string', the length, and then the entire byte array
  */
-void TPM_PrintAll(const char *string, const char *indentation,
-                  const unsigned char* buff, uint32_t length)
+void SWTPM_PrintAll(const char *string, const char *indentation,
+                    const unsigned char* buff, uint32_t length)
 {
     uint32_t i;
     int indent;
@@ -105,21 +105,21 @@ void TPM_PrintAll(const char *string, const char *indentation,
     if (buff != NULL) {
         logprintf(STDERR_FILENO, "%s length %u\n", string, length);
 
-        TPM_AppendPrintf(&linebuffer, "%s", indentation);
+        SWTPM_AppendPrintf(&linebuffer, "%s", indentation);
         for (i = 0 ; i < length ; i++) {
             if (i && !( i % 16 )) {
-                TPM_AppendPrintf(&linebuffer, "\n");
+                SWTPM_AppendPrintf(&linebuffer, "\n");
 
                 logprintfA(STDERR_FILENO, 0, linebuffer);
 
                 free(linebuffer);
                 linebuffer = NULL;
-                TPM_AppendPrintf(&linebuffer, "%s", indentation);
+                SWTPM_AppendPrintf(&linebuffer, "%s", indentation);
             }
 
-            TPM_AppendPrintf(&linebuffer, "%.2X ", buff[i]);
+            SWTPM_AppendPrintf(&linebuffer, "%.2X ", buff[i]);
         }
-        TPM_AppendPrintf(&linebuffer, "\n");
+        SWTPM_AppendPrintf(&linebuffer, "\n");
         logprintf(STDERR_FILENO, "%s", linebuffer);
         free(linebuffer);
     }

--- a/src/swtpm/swtpm_debug.h
+++ b/src/swtpm/swtpm_debug.h
@@ -53,8 +53,8 @@
 
 # endif /* DEBUG */
 
-void TPM_PrintAll(const char *string, const char *indent,
-                  const unsigned char* buff, uint32_t length);
+void SWTPM_PrintAll(const char *string, const char *indent,
+                    const unsigned char* buff, uint32_t length);
 
 #endif /* _SWTPM_DEBUG_H_ */
 

--- a/src/swtpm/swtpm_io.c
+++ b/src/swtpm/swtpm_io.c
@@ -114,7 +114,7 @@ TPM_RESULT SWTPM_IO_Read(TPM_CONNECTION_FD *connection_fd,   /* read/write file 
     }
 
     *bufferLength = offset;
-    TPM_PrintAll(" SWTPM_IO_Read:", " ", buffer, *bufferLength);
+    SWTPM_PrintAll(" SWTPM_IO_Read:", " ", buffer, *bufferLength);
 
     return 0;
 }
@@ -212,8 +212,8 @@ TPM_RESULT SWTPM_IO_Write(TPM_CONNECTION_FD *connection_fd,       /* read/write 
     size_t      totlen = 0;
     int         i;
 
-    TPM_PrintAll(" SWTPM_IO_Write:", " ",
-                 iovec[1].iov_base, iovec[1].iov_len);
+    SWTPM_PrintAll(" SWTPM_IO_Write:", " ",
+                   iovec[1].iov_base, iovec[1].iov_len);
 
     /* test that connection is open to write */
     if (connection_fd->fd < 0) {


### PR DESCRIPTION
To avoid clashes with libtpms print functions, prefix the print function
in swtpm with SWTPM_ rather than TPM_. This may matter on older systems
where libtpms could call into swtpm's TPM_PrintAll function due to it
having the same name as libtpms's function.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>