### PR TITLE
tests: Allow 'ss' as an alternative to 'netstat'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -188,15 +188,14 @@ else
 fi
 AM_CONDITIONAL([HAVE_TCSD], test "$have_tcsd" != "no")
 
-dnl If we have the tcsd package, we can build swtpm_setup, but need netstat also
+dnl We either need netstat (more common across systems) or 'ss' for test cases
 AC_PATH_PROG([NETSTAT], [netstat])
-case $host_os in
-linux-*)
-    if test "x$NETSTAT" = "x" && test "$have_tcsd" != "no"; then
-        AC_MSG_ERROR([netstat tool is missing for tests: net-tools package])
-    fi
-    ;;
-esac
+if test "x$NETSTAT" = "x"; then
+	AC_PATH_PROG([SS], [ss])
+	if test "x$SS" = "x"; then
+		AC_MSG_ERROR(['netstat' and 'ss' tools are missing for tests: net-tools OR iproute/iproute2 package])
+	fi
+fi
 
 AC_MSG_CHECKING([for whether to build with CUSE interface])
 AC_ARG_WITH([cuse],

--- a/tests/common
+++ b/tests/common
@@ -202,13 +202,22 @@ function wait_port_open()
 	local timeout=$3
 
 	local loops=$((timeout * 10)) loop
+	local NETSTAT=$(type -P netstat)
 
 	for ((loop = 0; loop < loops; loop++)); do
-		if [ -n "$(netstat -naptl 2>/dev/null |
-			   grep "LISTEN" |
-			   grep " $pid/" |
-			   grep ":$port ")" ]; then
-			return 1
+		if [ -n "$NETSTAT" ]; then
+			if [ -n "$(netstat -naptl 2>/dev/null |
+				   grep "LISTEN" |
+				   grep " $pid/" |
+				   grep ":$port ")" ]; then
+				return 1
+			fi
+		else
+			if [ -n "$(ss -nptl |
+				   grep ",pid=${pid}," |
+				   grep ":$port ")" ]; then
+				return 1
+			fi
 		fi
 		sleep 0.1
 	done
@@ -226,13 +235,22 @@ function wait_port_closed()
 	local timeout=$3
 
 	local loops=$((timeout * 10)) loop
+	local NETSTAT=$(type -P netstat)
 
 	for ((loop = 0; loop < loops; loop++)); do
-		if [ -z "$(netstat -naptl 2>/dev/null |
-			   grep "LISTEN" |
-			   grep " $pid/" |
-			   grep ":$port ")" ]; then
-			return 1
+		if [ -n "$NETSTAT" ]; then
+			if [ -z "$(netstat -naptl 2>/dev/null |
+				   grep "LISTEN" |
+				   grep " $pid/" |
+				   grep ":$port ")" ]; then
+				return 1
+			fi
+		else
+			if [ -z "$(ss -nptl |
+				   grep ",pid=${pid}," |
+				   grep ":$port ")" ]; then
+				return 1
+			fi
 		fi
 		sleep 0.1
 	done


### PR DESCRIPTION
Some distros (openSUSE) have deprecated the 'net-tools' package,
so we allow for 'ss' as an alternative tool from the
iproute/iproute2 package. This is only relevant for test cases.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>