### PR TITLE
tests: Fix path to swtpm-localca

### DIFF
--- a/tests/test_samples_create_tpmca
+++ b/tests/test_samples_create_tpmca
@@ -24,7 +24,7 @@ source ${abs_top_builddir:-$(dirname "$0")/..}/tests/test_config
 
 SWTPM_SETUP=${ROOT}/src/swtpm_setup/swtpm_setup
 SWTPM_CREATE_TPMCA=${SRCDIR}/samples/swtpm-create-tpmca
-SWTPM_LOCALCA=${SRCDIR}/samples/swtpm-localca
+SWTPM_LOCALCA=${ROOT}/samples/swtpm-localca
 SWTPM=${ROOT}/src/swtpm/swtpm
 SWTPM_IOCTL=${ROOT}/src/swtpm_ioctl/swtpm_ioctl
 


### PR DESCRIPTION
This patch fixes the path to swtpm-localca to avoid this type of
error because of swtpm_localca_conf having been created in another
directory. This error occurred whan running

sudo bash -c "make -j32 distcheck"

Traceback (most recent call last):
  File "/home/stefanb/tmp/swtpm/swtpm-0.5.0/samples/swtpm-localca", line 5, in <
    from py_swtpm_localca.swtpm_localca import main
  File "/home/stefanb/tmp/swtpm/swtpm-0.5.0/samples/py_swtpm_localca/swtpm_local
    from py_swtpm_localca.swtpm_localca_conf import SYSCONFDIR
ModuleNotFoundError: No module named 'py_swtpm_localca.swtpm_localca_conf'

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>