### PR TITLE
build-sys: Add python-install and python-uninstall targets

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,3 +27,8 @@ selinux-install selinux-uninstall:
 	@cd src/selinux && $(MAKE) $(AM_MAKEFLAGS) $@
 .PHONY: selinux-install selinux-uninstall
 endif
+
+python-install python-uninstall:
+	@cd samples && $(MAKE) $(AM_MAKEFLAGS) $@
+	@cd src/swtpm_setup && $(MAKE) $(AM_MAKEFLAGS) $@
+.PHONY: python-install python-uninstall

--- a/samples/Makefile.am
+++ b/samples/Makefile.am
@@ -29,22 +29,28 @@ $(PY_PACKAGE): $(PY_SWTPM_LOCALCA_FILES)
 
 all-local: $(PY_PACKAGE)
 
+python-install: $(PY_PACKAGE)
+	echo "Installing python to DESTDIR '/$(DESTDIR)'"
+	./setup.py install --prefix=$(prefix) --root "/$(DESTDIR)" --install-layout deb 2>/dev/null || \
+		./setup.py install --prefix=$(prefix) --root "/$(DESTDIR)" 2>/dev/null
+
+python-uninstall:
+	echo "Local pip3 uninstall"
+	$(PIP3) uninstall -y $(PY_PACKAGE_NAME)
+
 if PYTHON_INSTALLATION
 install-exec-local: $(PY_PACKAGE)
 	@if ! test $(findstring /usr, "$(DESTDIR)$(bindir)"); then \
 		echo "Warning: Not installing python package to $(DESTDIR)$(bindir)"; \
 	else \
-		echo "Installing python to DESTDIR '/$(DESTDIR)'"; \
-		./setup.py install --prefix=$(prefix) --root "/$(DESTDIR)" --install-layout deb 2>/dev/null || \
-		./setup.py install --prefix=$(prefix) --root "/$(DESTDIR)" 2>/dev/null ; \
+		$(MAKE) python-install; \
 	fi
 
 uninstall-local:
 	@if ! test $(findstring /usr, "$(DESTDIR)$(bindir)"); then \
 		echo "Cleanup for distcheck build not implemented" ; \
 	else \
-		echo "Local pip3 uninstall"; \
-		$(PIP3) uninstall -y $(PY_PACKAGE_NAME); \
+		$(MAKE) python-uninstall; \
 	fi
 endif
 

--- a/src/swtpm_setup/Makefile.am
+++ b/src/swtpm_setup/Makefile.am
@@ -19,22 +19,28 @@ $(PY_PACKAGE): $(PY_SWTPM_SETUP_FILES)
 
 all-local: $(PY_PACKAGE)
 
+python-install: $(PY_PACKAGE)
+	echo "Installing python to DESTDIR '/$(DESTDIR)'"
+	./setup.py install --prefix=$(prefix) --root "/$(DESTDIR)" --install-layout deb 2>/dev/null || \
+		./setup.py install --prefix=$(prefix) --root "/$(DESTDIR)" 2>/dev/null
+
+python-uninstall:
+	echo "Local pip3 uninstall"
+	$(PIP3) uninstall -y $(PY_PACKAGE_NAME)
+
 if PYTHON_INSTALLATION
 install-exec-local: $(PY_PACKAGE)
 	@if ! test $(findstring /usr, "$(DESTDIR)$(bindir)"); then \
 		echo "Warning: Not installing python package to $(DESTDIR)$(bindir)"; \
 	else \
-		echo "Installing python to DESTDIR '/$(DESTDIR)'"; \
-		./setup.py install --prefix=$(prefix) --root "/$(DESTDIR)" --install-layout deb 2>/dev/null || \
-		./setup.py install --prefix=$(prefix) --root "/$(DESTDIR)" 2>/dev/null ; \
+		$(MAKE) python-install; \
 	fi
 
 uninstall-local:
 	@if ! test $(findstring /usr, "$(DESTDIR)$(bindir)"); then \
 		echo "Cleanup for distcheck build not implemented" ; \
 	else \
-		echo "Local pip3 uninstall"; \
-		$(PIP3) uninstall -y $(PY_PACKAGE_NAME); \
+		$(MAKE) python-uninstall; \
 	fi
 endif
 


### PR DESCRIPTION
To force the installation of the python programs add a python-install
target. This solves an installation issue with non-standard prefix,
like not using /usr or /usr/local, as may be the case on OS X (Apple)
when using homebrew. It leaves the 'make distcheck' working, which also
uses a non-standard prefix and where we don't want to install the tools
due to issues with removing them afterwards where pip3 cannot be used.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>