### PR TITLE
debian: drop revision from version, illegal for native-format packages

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-swtpm (0.5.0-1) RELEASED; urgency=medium
+swtpm (0.5.0) RELEASED; urgency=medium
 
   * Stable release
 


### PR DESCRIPTION
Confer:
```
$ dpkg-buildpackage -us -uc
dpkg-buildpackage: info: source package swtpm
dpkg-buildpackage: info: source version 0.5.0-1
dpkg-buildpackage: info: source distribution RELEASED
dpkg-buildpackage: info: source changed by Stefan Berger <stefanb@linux.ibm.com>
dpkg-source: error: can't build with source format '3.0 (native)': native package version may not have a revision
```