### PR TITLE
Add --root flag to swtpm-create-user-config-files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@
 #       This file is derived from tpm-tool's configure.in.
 #
 
-AC_INIT(swtpm, 0.5.0)
+AC_INIT(swtpm, 0.6.0)
 AC_PREREQ(2.12)
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_HEADER(config.h)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-swtpm (0.5.0-1) RELEASED; urgency=medium
+swtpm (0.5.0) RELEASED; urgency=medium
 
   * Stable release
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+swtpm (0.6.0~dev1) UNRELEASED; urgency=medium
+
+  * Developer release 1
+
+ -- Stefan Berger <stefanb@linux.ibm.com>  Fri, 09 Oct 2020 14:14:00 -0500
+
 swtpm (0.5.0) RELEASED; urgency=medium
 
   * Stable release

--- a/dist/swtpm.spec
+++ b/dist/swtpm.spec
@@ -11,7 +11,7 @@
 
 Summary: TPM Emulator
 Name:           swtpm
-Version:        0.5.0
+Version:        0.6.0
 Release:        0.%{gitdate}git%{gitshortcommit}%{?dist}
 License:        BSD
 Url:            http://github.com/stefanberger/swtpm

--- a/samples/swtpm-create-user-config-files.in
+++ b/samples/swtpm-create-user-config-files.in
@@ -12,6 +12,7 @@ SWTPM_LOCALCA_CONF="${XDG_CONFIG_HOME}/swtpm-localca.conf"
 SWTPM_LOCALCA_OPTIONS="${XDG_CONFIG_HOME}/swtpm-localca.options"
 
 FLAG_OVERWRITE=1
+FLAG_ROOT=2
 
 function help() {
 	cat <<_EOF_
@@ -19,6 +20,9 @@ Usage: $1 [options]
 
 The following options are supported:
 --overwrite	: Overwrite existing config files
+
+--root          : Allow the installation of the config files under the root account.
+                  This will shadow the default configuration files under @SYSCONFDIR@.
 
 --help|-h|-?	: Display this help screen and exit
 
@@ -31,11 +35,20 @@ function main() {
 	while [ $# -ne 0 ]; do
 		case "$1" in
 		--overwrite) flags=$((flags | FLAG_OVERWRITE));;
+		--root) flags=$((flags | FLAG_ROOT));;
 		--help|-h|-?) help $0; exit 0;;
 		*) echo -e "Unknown option $1\n" >&2; help $0; exit 1;;
 		esac
 		shift
 	done
+
+	if [ "$(id -u)" = "0" ]; then
+		if [[ $((flags & FLAG_ROOT)) -eq 0 ]]; then
+			echo "Requiring the --root flag since the configuration files will shadow"
+			echo "those in @SYSCONFDIR@."
+			exit 1
+		fi
+	fi
 
 	if [[ $((flags & FLAG_OVERWRITE)) -eq 0 ]]; then
 		for f in "${SWTPM_SETUP_CONF}" \


### PR DESCRIPTION
This PR adds a --root flag to swtpm-create-user-config-files and adjusts the package version to 0.6.0.