### PR TITLE
tests: Try with tcsd.conf ownership of root:tss if tss:tss did not work

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@
 #       This file is derived from tpm-tool's configure.in.
 #
 
-AC_INIT(swtpm, 0.5.0)
+AC_INIT(swtpm, 0.5.1)
 AC_PREREQ(2.12)
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_HEADER(config.h)

--- a/dist/swtpm.spec
+++ b/dist/swtpm.spec
@@ -11,7 +11,7 @@
 
 Summary: TPM Emulator
 Name:           swtpm
-Version:        0.5.0
+Version:        0.5.1
 Release:        0.%{gitdate}git%{gitshortcommit}%{?dist}
 License:        BSD
 Url:            http://github.com/stefanberger/swtpm

--- a/tests/test_samples_create_tpmca
+++ b/tests/test_samples_create_tpmca
@@ -155,27 +155,41 @@ port = ${TCSD_LISTEN_PORT}
 system_ps_file = ${TCSD_SYSTEM_PS_FILE}
 _EOF_
 
-	chown ${TSS_USER}:${TSS_GROUP} "${TCSD_CONF}"
-	if [ "${TSS_USER}" == "${TSS_GROUP}" ]; then
-		chmod 0600 "${TCSD_CONF}"
-	else
-		chmod 0640 "${TCSD_CONF}"
-	fi
+	# Due to recent changes in tcsd we have to try with TSS_USER=tss and TSS_USER=root
+	# Before the following worked:
+	#   - tss:tss  0600   for  TSS_USER=tss and TSS_GROUP=tss
+	#   - root:tss 0640   for  TSS_USER=root and TSS_GROUP=tss
+	# After the changes:
+	#   - root:tss 0640   for  TSS_USER=tss and TSS_GROUP=tss
+	while :; do
+		chown ${TSS_USER}:${TSS_GROUP} "${TCSD_CONF}"
+		if [ "${TSS_USER}" == "${TSS_GROUP}" ]; then
+			chmod 0600 "${TCSD_CONF}"
+		else
+			chmod 0640 "${TCSD_CONF}"
+		fi
 
-	bash -c "TCSD_USE_TCP_DEVICE=1 TCSD_TCP_DEVICE_PORT=${SWTPM_SERVER_PORT} tcsd -c "${TCSD_CONF}" -e -f &>/dev/null & echo \$! > "${TCSD_PIDFILE}"; wait" &
-	BASH_PID=$!
+		bash -c "TCSD_USE_TCP_DEVICE=1 TCSD_TCP_DEVICE_PORT=${SWTPM_SERVER_PORT} tcsd -c "${TCSD_CONF}" -e -f &>/dev/null & echo \$! > "${TCSD_PIDFILE}"; wait" &
+		BASH_PID=$!
 
-	if wait_for_file "${TCSD_PIDFILE}" 3; then
-		echo "Error: Could not get TCSD's PID file"
-		exit 1
-	fi
+		if wait_for_file "${TCSD_PIDFILE}" 3; then
+			echo "Error: Could not get TCSD's PID file"
+			exit 1
+		fi
 
-	TCSD_PID=$(cat "${TCSD_PIDFILE}")
-	kill_quiet -0 "${TCSD_PID}"
-	if [ $? -ne 0 ]; then
-		echo "Error: TCSD with pid ${TCSD_PID} must have terminated"
-		exit 1
-	fi
+		TCSD_PID=$(cat "${TCSD_PIDFILE}")
+		kill_quiet -0 "${TCSD_PID}"
+		if [ $? -ne 0 ]; then
+			# Try again with root unless we already tried
+			if [ "$TSS_USER" != "root" ]; then
+				TSS_USER="root"
+				continue
+			fi
+			echo "Error: TCSD with pid ${TCSD_PID} must have terminated"
+			exit 1
+		fi
+		break
+	done
 
 	${SWTPM_CREATE_TPMCA} \
 		--dir "${SWTPM_LOCALCA_DIR}" \


### PR DESCRIPTION
Due to recent changes in tcsd, it doesn't accept 'tss:tss 0600' anymore
for the tcsd config file but we need to use 'root:tss 0640' for it.
So far only Fedora seems to be affected. It now depends on whether tcsd
has been patched what ownership is required. So we try first the old
configuration and then the new one.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>