### PR TITLE
Use open() call rather than fopen() and avoid following symlinks

### DIFF
--- a/src/swtpm/swtpm_nvfile.c
+++ b/src/swtpm/swtpm_nvfile.c
@@ -210,7 +210,7 @@ static TPM_RESULT SWTPM_NVRAM_Lock_Lockfile(const char *directory,
         return TPM_FAIL;
     }
 
-    *fd = open(lockfile, O_WRONLY|O_CREAT|O_TRUNC, 0660);
+    *fd = open(lockfile, O_WRONLY|O_CREAT|O_TRUNC|O_NOFOLLOW, 0660);
     if (*fd < 0) {
         logprintf(STDERR_FILENO,
                   "SWTPM_NVRAM_Lock_Lockfile: Could not open lockfile: %s\n",


### PR DESCRIPTION
This PR gets rid of the fopen() call and switches over to the open() call. Along with this we are now using O_NOFOLLOW whenever we open a file for writing to avoid symlink attacks.