### PR TITLE
Use open() call rather than fopen() and avoid following symlinks

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,11 @@
 CHANGES - changes for swtpm
 
+version 0.5.1:
+  - swtpm
+    - Addressed potential symlink attack issue (CVS-2020-28407)
+  - build-sys:
+    - Fix configure python cryptography error message
+
 version 0.5.0:
   - swtpm:
     - Write files atomically using a temp file and then renaming

--- a/configure.ac
+++ b/configure.ac
@@ -372,7 +372,7 @@ AC_MSG_CHECKING([for python cryptography package])
 $PYTHON -c "import cryptography"
 AS_IF([ test $? = 0 ],
        [AC_MSG_RESULT([yes])],
-       [AC_MSG_ERROR([python setuptools is required])])
+       [AC_MSG_ERROR([python cryptography is required])])
 
 AC_ARG_ENABLE([python-installation],
   AS_HELP_STRING([--disable-python-installation], [Disable running setup.py install for swtpm_setup]))

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+swtpm (0.5.1) RELEASED; urgency=medium
+
+  * Addressed potential symlink attack issue (CVE-2020-28407)
+
+ -- Stefan Berger <stefanb@linux.ibm.com>  Fri, 13 Nov 2020 09:52:00 -0500
+
 swtpm (0.5.0) RELEASED; urgency=medium
 
   * Stable release

--- a/dist/swtpm.spec
+++ b/dist/swtpm.spec
@@ -1,6 +1,6 @@
 %bcond_without gnutls
 
-%global gitdate     20201007
+%global gitdate     20201113
 %global gitcommit   enter_commit_here
 %global gitshortcommit  %(c=%{gitcommit}; echo ${c:0:7})
 
@@ -183,6 +183,9 @@ fi
 %{_datadir}/swtpm/swtpm-create-tpmca
 
 %changelog
+* Fri Nov 13 2020 Stefan Berger <stefanb@linux.ibm.com> - 0.5.1-0.20201113git-------
+- v0.5.1 release: Addressed potential symlink attack issue (CVE-2020-28407)
+
 * Wed Oct 7 2020 Stefan Berger <stefanb@linux.ibm.com> - 0.5.0-0.20201007git-------
 - v0.5.0 release
 

--- a/dist/swtpm.spec.in
+++ b/dist/swtpm.spec.in
@@ -1,6 +1,6 @@
 %bcond_without gnutls
 
-%global gitdate     20201007
+%global gitdate     20201113
 %global gitcommit   enter_commit_here
 %global gitshortcommit  %(c=%{gitcommit}; echo ${c:0:7})
 
@@ -183,6 +183,9 @@ fi
 %{_datadir}/swtpm/swtpm-create-tpmca
 
 %changelog
+* Fri Nov 13 2020 Stefan Berger <stefanb@linux.ibm.com> - 0.5.1-0.20201113git-------
+- v0.5.1 release: Addressed potential symlink attack issue (CVE-2020-28407)
+
 * Wed Oct 7 2020 Stefan Berger <stefanb@linux.ibm.com> - 0.5.0-0.20201007git-------
 - v0.5.0 release
 

--- a/src/swtpm/swtpm_nvfile.c
+++ b/src/swtpm/swtpm_nvfile.c
@@ -210,7 +210,7 @@ static TPM_RESULT SWTPM_NVRAM_Lock_Lockfile(const char *directory,
         return TPM_FAIL;
     }
 
-    *fd = open(lockfile, O_WRONLY|O_CREAT|O_TRUNC, 0660);
+    *fd = open(lockfile, O_WRONLY|O_CREAT|O_TRUNC|O_NOFOLLOW, 0660);
     if (*fd < 0) {
         logprintf(STDERR_FILENO,
                   "SWTPM_NVRAM_Lock_Lockfile: Could not open lockfile: %s\n",


### PR DESCRIPTION
This PR prepares for the 0.5.1 release and addresses a potential symlink attack issue (CVE-2020-28407)