### PR TITLE
Use open() call rather than fopen() and avoid following symlinks

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 CHANGES - changes for swtpm
 
+version 0.4.2:
+  - swtpm:
+    - Addressed potential symlink attack issue (CVS-2020-28407)
+
 version 0.4.1:
   - swtpm_setup:
     - Do not hardcode '/etc' but use SYSCONFDIR

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+swtpm (0.4.2) RELEASED; urgency=medium
+
+  * Addressed potential symlink attack issue (CVE-2020-28407)
+
+ -- Stefan Berger <stefanb@linux.ibm.com>  Fri, 13 Nov 2020 09:52:00 -0500
+
 swtpm (0.4.1-1) RELEASED; urgency=medium
 
   * Stable release

--- a/dist/swtpm.spec
+++ b/dist/swtpm.spec
@@ -1,6 +1,6 @@
 %bcond_without gnutls
 
-%global gitdate     20200925
+%global gitdate     20201113
 %global gitcommit   enter_commit_here
 %global gitshortcommit  %(c=%{gitcommit}; echo ${c:0:7})
 
@@ -170,6 +170,9 @@ fi
 %attr( 750, tss, root) %{_localstatedir}/lib/swtpm-localca
 
 %changelog
+* Fri Nov 13 2020 Stefan Berger <stefanb@linux.ibm.com> - 0.4.2-0.20201113git-------
+- v0.4.2 release: Addressed potential symlink attack issue (CVE-2020-28407)
+
 * Fri Sep 25 2020 Stefan Berger <stefanb@linux.ibm.com> - 0.4.1-20200925git-------
 - v0.4.1 release
 

--- a/dist/swtpm.spec.in
+++ b/dist/swtpm.spec.in
@@ -1,6 +1,6 @@
 %bcond_without gnutls
 
-%global gitdate     20200925
+%global gitdate     20201113
 %global gitcommit   enter_commit_here
 %global gitshortcommit  %(c=%{gitcommit}; echo ${c:0:7})
 
@@ -170,6 +170,9 @@ fi
 %attr( 750, @TSS_USER@, root) %{_localstatedir}/lib/swtpm-localca
 
 %changelog
+* Fri Nov 13 2020 Stefan Berger <stefanb@linux.ibm.com> - 0.4.2-0.20201113git-------
+- v0.4.2 release: Addressed potential symlink attack issue (CVE-2020-28407)
+
 * Fri Sep 25 2020 Stefan Berger <stefanb@linux.ibm.com> - 0.4.1-20200925git-------
 - v0.4.1 release
 

--- a/src/swtpm/swtpm_nvfile.c
+++ b/src/swtpm/swtpm_nvfile.c
@@ -210,7 +210,7 @@ static TPM_RESULT SWTPM_NVRAM_Lock_Lockfile(const char *directory,
         return TPM_FAIL;
     }
 
-    *fd = open(lockfile, O_WRONLY|O_CREAT|O_TRUNC, 0660);
+    *fd = open(lockfile, O_WRONLY|O_CREAT|O_TRUNC|O_NOFOLLOW, 0660);
     if (*fd < 0) {
         logprintf(STDERR_FILENO,
                   "SWTPM_NVRAM_Lock_Lockfile: Could not open lockfile: %s\n",


### PR DESCRIPTION
This PR prepares for the 0.4.2 release and addresses a potential symlink attack issue (CVE-2020-28407).