### PR TITLE
Prevent following a log file symlink

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,8 @@
 CHANGES - changes for swtpm
 
 version 0.5.1:
-  - swtpm
-    - Addressed potential symlink attack issue (CVS-2020-28407)
+  - swtpm & swtpm_setup:
+    - Addressed potential symlink attack issue (CVE-2020-28407)
   - build-sys:
     - Fix configure python cryptography error message
 

--- a/samples/py_swtpm_localca/swtpm_localca.py
+++ b/samples/py_swtpm_localca/swtpm_localca.py
@@ -574,6 +574,9 @@ def main():
             sys.exit(0)
 
     if len(LOGFILE) > 0:
+        if os.path.islink(LOGFILE):
+            sys.stderr.write("Logfile must not be a symlink.\n")
+            sys.exit(1)
         try:
             fobj = open(LOGFILE, "a") # do not truncate
             fobj.close()

--- a/samples/py_swtpm_localca/swtpm_utils.py
+++ b/samples/py_swtpm_localca/swtpm_utils.py
@@ -3,17 +3,24 @@
 
 # pylint: disable=W0703
 
+import os
 import sys
 
 
 def append_to_file(filename, string):
     """" Append a string to a file """
     try:
-        fobj = open(filename, 'a')
-        fobj.write(string)
-        fobj.close()
-    except Exception:
+        filedesc = os.open(filename, os.O_WRONLY|os.O_APPEND|os.O_CREAT|os.O_NOFOLLOW, 0o640)
+        os.write(filedesc, string.encode('utf-8'))
+        os.close(filedesc)
+    except Exception as ex:
+        sys.stdout.write("Error: %s\n" % ex)
         sys.stdout.write(string)
+        try:
+            if filedesc > 0:
+                os.close(filedesc)
+        except Exception:
+            pass
 
 
 def logit(logfile, string):

--- a/src/swtpm_setup/py_swtpm_setup/swtpm_setup.py
+++ b/src/swtpm_setup/py_swtpm_setup/swtpm_setup.py
@@ -896,6 +896,9 @@ def main():
         srkpass = DEFAULT_SRK_PASSWORD
 
     if len(LOGFILE) > 0:
+        if os.path.islink(LOGFILE):
+            sys.stderr.write("Logfile must not be a symlink.\n")
+            sys.exit(1)
         try:
             fobj = open(LOGFILE, "a") # do not truncate
             fobj.close()

--- a/src/swtpm_setup/py_swtpm_setup/swtpm_utils.py
+++ b/src/swtpm_setup/py_swtpm_setup/swtpm_utils.py
@@ -3,6 +3,7 @@
 
 # pylint: disable=W0703
 
+import os
 import sys
 
 from cryptography.hazmat.backends import default_backend
@@ -12,11 +13,17 @@ from cryptography.hazmat.primitives import hashes
 def append_to_file(filename, string):
     """" Append a string to a file """
     try:
-        fobj = open(filename, 'a')
-        fobj.write(string)
-        fobj.close()
-    except Exception:
+        filedesc = os.open(filename, os.O_WRONLY|os.O_APPEND|os.O_CREAT|os.O_NOFOLLOW, 0o640)
+        os.write(filedesc, string.encode('utf-8'))
+        os.close(filedesc)
+    except Exception as ex:
+        sys.stdout.write("Error: %s\n" % ex)
         sys.stdout.write(string)
+        try:
+            if filedesc > 0:
+                os.close(filedesc)
+        except Exception:
+            pass
 
 
 def logit(logfile, string):


### PR DESCRIPTION
This PR changes swtpm, swtpm_setup, and swtpm_localca from following symlinks when accessing the log file.