### PR TITLE
swtpm_setup: Increase timeout from 10s to 30s for slower machines

### DIFF
--- a/src/swtpm_setup/py_swtpm_setup/swtpm_setup.py
+++ b/src/swtpm_setup/py_swtpm_setup/swtpm_setup.py
@@ -223,7 +223,7 @@ def call_create_certs(flags, config_file, certsdir, ekparam, vmid, swtpm):
                     cmd[2] = entry[1]
                     logit(LOGFILE, "  Invoking %s\n" % (" ".join(cmd)))
                     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-                    stdout, _ = proc.communicate(timeout=10)
+                    stdout, _ = proc.communicate(timeout=30)
                     for line in stdout.decode().split("\n"):
                         if len(line) > 0:
                             logit(LOGFILE, "%s: %s\n" % (prgname, line))


### PR DESCRIPTION
Older ARM processors need more time to create the initial CA keys
and then the key for the TPM. So we increase the timeout to 30s.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>