### PR TITLE
swtpm: Adjust size of message buffer to be of size ptm_hdata

### DIFF
--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -482,7 +482,7 @@ int ctrlchannel_process_fd(int fd,
 {
     struct input input = {0, };
     struct output {
-        uint8_t body[4096];
+        uint8_t body[sizeof(struct ptm_hdata)]; /* ptm_hdata is largest */
     } output;
     ssize_t n;
     struct iovec iov = {


### PR DESCRIPTION
This patch fixes the following compilation issue/bug:

ctrlchannel.c: In function ‘ctrlchannel_process_fd’:
ctrlchannel.c:694:13: error: array subscript ‘ptm_hdata[0]’ is partly outside array bounds of ‘struct output[1]’ [-Werror=array-bounds]
  694 |         data->u.resp.tpm_result = htobe32(res);
      |             ^~
ctrlchannel.c:486:7: note: while referencing ‘output’
  486 |     } output;
      |       ^~~~~~

Sending hashes to the TPM is not currently used in any major
application, so this bug should not affect much.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>