### PR TITLE
swtpm: Unconditionally close fd if writing of pidfile fails (coverity)

### DIFF
--- a/src/swtpm/pidfile.c
+++ b/src/swtpm/pidfile.c
@@ -91,6 +91,8 @@ int pidfile_write(pid_t pid)
         g_pidfile = fd_to_filename(pidfilefd);
         if (!g_pidfile)
             goto error;
+
+        pidfile_set_fd(-1); /* will be closed */
     } else {
         return 0;
     }
@@ -118,8 +120,7 @@ int pidfile_write(pid_t pid)
     return 0;
 
 error_close:
-    if (fd != pidfilefd)
-        close(fd);
+    close(fd);
 
 error:
     return -1;


### PR DESCRIPTION
Do not bother trying to keep pidfilefd open in case fd = pidfilefd,
but close it unconditionally. If writing the pidfile fails, the process
terminates anyway, besides that we only ever need to write to the
pidfile once, which is happening in this function.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>