### PR TITLE
swtpm: Set pidfilefd to -1 when used

### DIFF
--- a/src/swtpm/pidfile.c
+++ b/src/swtpm/pidfile.c
@@ -91,6 +91,8 @@ int pidfile_write(pid_t pid)
         g_pidfile = fd_to_filename(pidfilefd);
         if (!g_pidfile)
             goto error;
+
+        pidfile_set_fd(-1); /* will be closed */
     } else {
         return 0;
     }


### PR DESCRIPTION
Since the pidfilefd will be closed, set it to -1 if it's being
used.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>