### PR TITLE
swtpm_ioctl: Adjust man page and remove unnecessary if statement

### DIFF
--- a/man/man8/swtpm_ioctl.pod
+++ b/man/man8/swtpm_ioctl.pod
@@ -4,7 +4,7 @@ swtpm_ioctl - Utility for sending control commands to swtpm
 
 =head1 SYNOPSIS
 
-B<swtpm_ioctl [COMMAND] E<lt>deviceE<gt>>
+B<swtpm_ioctl [COMMAND] [E<lt>deviceE<gt>>]
 
 =head1 DESCRIPTION
 

--- a/src/swtpm_ioctl/tpm_ioctl.c
+++ b/src/swtpm_ioctl/tpm_ioctl.c
@@ -994,9 +994,7 @@ int main(int argc, char *argv[])
             goto exit;
         }
 
-        if (!tpm_device) {
-            tpm_device = argv[optind];
-        }
+        tpm_device = argv[optind];
     }
 
     is_chardev = (tpm_device != NULL);


### PR DESCRIPTION
This PR adjusts the man page of swtpm_ioctl to reflect that the device parameter is optional.
We also remove an unnecessary if statement in swtpm_ioctl.c.