### PR TITLE
swtpm: Remove global unused variable input (issue #395)

### DIFF
--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -287,7 +287,7 @@ struct input {
     uint32_t cmd;
     /* ptm_hdata is the largest buffer to receive */
     uint8_t body[sizeof(ptm_hdata)];
-} input;
+};
 
 /*
  * ctrlchannel_recv_cmd: Receive a command on the control channel

--- a/src/swtpm/key.c
+++ b/src/swtpm/key.c
@@ -309,11 +309,14 @@ key_from_pwdfile_fd(int fd, unsigned char *key, size_t *keylen,
     }
 
     while (true) {
-        filebuffer = realloc(filebuffer, filelen);
+        unsigned char *tmp = filebuffer;
+
+        filebuffer = realloc(tmp, filelen);
         if (!filebuffer) {
             logprintf(STDERR_FILENO,
                       "Could not allocate %zu bytes for filebuffer\n",
                       filelen);
+            free(tmp);
             goto exit;
         }
 


### PR DESCRIPTION
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>