### PR TITLE
swtpm: Remove unused file_ops_lock from threadpool.c (asan)

### DIFF
--- a/src/swtpm/cuse_tpm.c
+++ b/src/swtpm/cuse_tpm.c
@@ -109,12 +109,12 @@ static struct fuse_session *ptm_fuse_session;
 #if GLIB_MAJOR_VERSION >= 2
 # if GLIB_MINOR_VERSION >= 32
 
-GMutex file_ops_lock;
+static GMutex file_ops_lock;
 #  define FILE_OPS_LOCK &file_ops_lock
 
 # else
 
-GMutex *file_ops_lock;
+static GMutex *file_ops_lock;
 #  define FILE_OPS_LOCK file_ops_lock
 
 # endif

--- a/src/swtpm/threadpool.c
+++ b/src/swtpm/threadpool.c
@@ -52,19 +52,15 @@ GThreadPool *pool;
 
 GCond thread_busy_signal;
 GMutex thread_busy_lock;
-GMutex file_ops_lock;
 #  define THREAD_BUSY_SIGNAL &thread_busy_signal
 #  define THREAD_BUSY_LOCK &thread_busy_lock
-#  define FILE_OPS_LOCK &file_ops_lock
 
 # else
 
 GCond *thread_busy_signal;
 GMutex *thread_busy_lock;
-GMutex *file_ops_lock;
 #  define THREAD_BUSY_SIGNAL thread_busy_signal
 #  define THREAD_BUSY_LOCK thread_busy_lock
-#  define FILE_OPS_LOCK file_ops_lock
 
 # endif
 #else


### PR DESCRIPTION
Asan reports this error for the CUSE TPM. The file_ops_lock was accidentally
duplicated in a code move of threadpool related code out of cuse_tpm.c
This patch removes the unused file_ops_lock from threadpool.c to resolve
the ASAN issue.

=================================================================
==545493==ERROR: AddressSanitizer: odr-violation (0x000000419340):
  [1] size=8 'file_ops_lock' cuse_tpm.c:112:8
  [2] size=8 'file_ops_lock' threadpool.c:55:8
These globals were registered at these points:
  [1]:
    #0 0x14f6c27f3cc8  (/lib64/libasan.so.6+0x37cc8)
    #1 0x40c2c3 in _sub_I_00099_1 (/home/stefanb/tmp/swtpm/src/swtpm/.libs/lt-swtpm+0x40c2c3)
    #2 0x40c31c in __libc_csu_init (/home/stefanb/tmp/swtpm/src/swtpm/.libs/lt-swtpm+0x40c31c)

  [2]:
    #0 0x14f6c27f3cc8  (/lib64/libasan.so.6+0x37cc8)
    #1 0x14f6c27aad1a in _sub_I_00099_1 (/home/stefanb/tmp/swtpm/src/swtpm/.libs/libswtpm_libtpms.so.0+0x25d1a)
    #2 0x14f6c31dc7b1 in call_init.part.0 (/lib64/ld-linux-x86-64.so.2+0x117b1)

==545493==HINT: if you don't care about these errors you may set ASAN_OPTIONS=detect_odr_violation=0
SUMMARY: AddressSanitizer: odr-violation: global 'file_ops_lock' at cuse_tpm.c:112:8
==545493==ABORTING

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>