### PR TITLE
swtpm: Fix --print-capabilities for 'swtpm chardev'

### DIFF
--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -458,17 +458,6 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
     }
 #endif
 
-    if (mlp.fd < 0) {
-        logprintf(STDERR_FILENO,
-                  "Error: Missing character device or file descriptor\n");
-        exit(EXIT_FAILURE);
-    } else if (mlp.fd < 3) {
-        /* no std{in,out,err} */
-        logprintf(STDERR_FILENO,
-            "Error: Cannot accept file descriptors with values 0, 1, or 2\n");
-        exit(EXIT_FAILURE);
-    }
-
     /*
      * choose the TPM version early so that getting/setting
      * buffer size works.
@@ -485,6 +474,17 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
     }
 
     SWTPM_NVRAM_Set_TPMVersion(mlp.tpmversion);
+
+    if (mlp.fd < 0) {
+        logprintf(STDERR_FILENO,
+                  "Error: Missing character device or file descriptor\n");
+        exit(EXIT_FAILURE);
+    } else if (mlp.fd < 3) {
+        /* no std{in,out,err} */
+        logprintf(STDERR_FILENO,
+            "Error: Cannot accept file descriptors with values 0, 1, or 2\n");
+        exit(EXIT_FAILURE);
+    }
 
     if (handle_ctrlchannel_options(ctrlchdata, &mlp.cc) < 0) {
         goto exit_failure;

--- a/tests/test_tpm2_ctrlchannel2
+++ b/tests/test_tpm2_ctrlchannel2
@@ -35,6 +35,14 @@ if [ $(id -u) -eq 0 ]; then
 	FILEOWNER="$(id -u nobody) $(id -G nobody | cut -d" " -f1)"
 fi
 
+# make sure --print-capabiities exits with '0'
+msg=$($SWTPM_EXE chardev --print-capabilities 2>&1)
+if [ $? -ne 0 ]; then
+	echo "Error: swtpm chardev --print-capabilities failed"
+	echo "$msg"
+	exit 1
+fi
+
 FILEMODE=621
 # use a pseudo terminal
 exec 100<>/dev/ptmx


### PR DESCRIPTION
This patch fixes the following issue:

$ ./src/swtpm/swtpm chardev --print-capabilities --tpm2
swtpm: Error: Missing character device or file descriptor

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>