### PR TITLE
Travis: Upgrade pip to v20.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_install:
       sudo apt-get -y install trousers
     fi
 script:
-  - sudo pip3 install --upgrade pip
+  - sudo pip3 install --upgrade pip==20.3.3
   - sudo pip3 install --upgrade wheel
   - sudo pip3 install --upgrade cryptography
   - if [ ! -d libtpms ]; then git clone https://github.com/stefanberger/libtpms; fi


### PR DESCRIPTION
Pip 21.0.0 seems to be broken when upgraded to on Xenial. So
let's just only upgrade to 20.3.3.

$ sudo pip3 install --upgrade cryptography
Traceback (most recent call last):
  File "/usr/local/bin/pip3", line 7, in <module>
    from pip._internal.cli.main import main
  File "/usr/local/lib/python3.5/dist-packages/pip/_internal/cli/main.py", line 60
    sys.stderr.write(f"ERROR: {exc}")

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>