### PR TITLE
swtpm_setup: Replace OSError with ValueError (Cygwin bugfix)

### DIFF
--- a/src/swtpm_setup/py_swtpm_setup/swtpm.py
+++ b/src/swtpm_setup/py_swtpm_setup/swtpm.py
@@ -67,7 +67,7 @@ class Swtpm:
             s1, s2 = socket.socketpair(self.socket_domain)
             s1.close()
             s2.close()
-        except OSError:
+        except ValueError:  # Cygwin gives a ValueError
             self.socket_domain = socket.AF_INET
 
     def start(self):


### PR DESCRIPTION
A wrong domain to socketpair() causes a ValueError, not an OSError.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>