### PR TITLE
tests: Wait a bit for pid file content; dump log on failure

### DIFF
--- a/tests/test_samples_create_tpmca
+++ b/tests/test_samples_create_tpmca
@@ -177,6 +177,8 @@ _EOF_
 			exit 1
 		fi
 
+		# wait for PID to be written
+		sleep 0.5
 		TCSD_PID=$(cat "${TCSD_PIDFILE}")
 		kill_quiet -0 "${TCSD_PID}"
 		if [ $? -ne 0 ]; then

--- a/tests/test_tpm2_save_load_state_2
+++ b/tests/test_tpm2_save_load_state_2
@@ -213,6 +213,11 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
+if wait_process_gone ${PID} 4; then
+	echo "Error: swtpm did not shut down"
+	exit 1
+fi
+
 echo "============================" >> $LOGFILE
 
 echo "TPM was shut down"
@@ -246,6 +251,7 @@ PID="$(cat $PID_FILE)"
 act=$($SWTPM_IOCTL --unix $SOCK_PATH -i 2>&1)
 if [ $? -ne 0 ]; then
 	echo "Error: $SWTPM_IOCTL CMD_INIT failed: $act"
+	cat $LOGFILE
 	exit 1
 fi
 


### PR DESCRIPTION
test_samples_create_tpmca needs to wait longer for the pid file content
to be there not just until the file is available.

test_tpm2_save_load_state_2 needs to dump the TPM log file on failure.
Failures occurred rarely because the previous instance of swtpm had
not shut down yet and released the lock file while the new instance
wanted to lock the lockfile. So we have to wait a bit until the
previous instance is gone.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>