### PR TITLE
Test cleanups and swtpm_setup clarification

### DIFF
--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -54,6 +54,12 @@ Create an endorsement key (EK).
 
 Create an EK that can sign. This option requires --tpm2.
 
+This option will create a non-standard EK. When re-creating the EK, TPM 2
+tools have to use the EK Template that is witten at an NV index corresponding
+to the created EK (e.g., NV index 0x01c00004 for RS 2048 EK). Otherwise the
+tool-created EK will not correspond to the actual key being used or the
+modulus shown in the EK certificate.
+
 Note that the TCG specification "EK Credential Profile For TPM Family 2.0; Level 0"
 suggests in its section on "EK Usage" that "the Endorsement Key can be a
 created as a decryption or signing key." However, some platforms will

--- a/src/swtpm_setup/py_swtpm_setup/swtpm_setup.py
+++ b/src/swtpm_setup/py_swtpm_setup/swtpm_setup.py
@@ -505,6 +505,7 @@ def usage(prgname):
         "\n"
         "--allow-signing  : Create an EK that can be used for signing;\n"
         "                   this option requires --tpm2.\n"
+        "                   Note: Careful, this option will create a non-standard EK!\n"
         "\n"
         "--decryption     : Create an EK that can be used for key encipherment;\n"
         "                   this is the default unless --allow-signing is given;\n"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -141,7 +141,15 @@ EXTRA_DIST=$(TESTS) \
 	data/tpm2state5/signature.bin \
 	data/tpm2state5/tpm2-00.permall \
 	load_vtpm_proxy \
-	patches/ibmtss2_1.6_rsa2048only.patch \
+	patches/0001-Deactivate-test-cases-accessing-rootcerts.txt.patch \
+	patches/0002-Implement-powerup-for-swtpm.patch \
+	patches/0003-Set-CRYPTOLIBRARY-to-openssl.patch \
+	patches/0004-Store-volatile-state-at-every-step.patch \
+	patches/0005-Disable-tests-related-to-events.patch \
+	patches/0006-Disable-testing-with-RSA-3072.patch \
+	patches/0007-Disable-rev155-test-cases.patch \
+	patches/0008-Disable-x509-test-cases.patch \
+	patches/0009-Disable-getcapability-TPM_CAP_ACT.patch \
 	patches/libtpm.patch \
 	softhsm_setup \
 	test_clientfds.py \

--- a/tests/common
+++ b/tests/common
@@ -7,6 +7,13 @@ SWTPM_SETUP=${SWTPM_SETUP:-${ROOT}/src/swtpm_setup/swtpm_setup}
 SWTPM_CERT=${SWTPM_CERT:-${ROOT}/src/swtpm_cert/swtpm_cert}
 ECHO=$(type -P echo)
 
+case "$(uname -s)" in
+Darwin)
+	CERTTOOL=gnutls-certtool;;
+*)
+	CERTTOOL=certtool;;
+esac
+
 # Note: Do not use file descriptors above 127 due to OpenBSD.
 
 # Kill a process quietly

--- a/tests/patches/0001-Deactivate-test-cases-accessing-rootcerts.txt.patch
+++ b/tests/patches/0001-Deactivate-test-cases-accessing-rootcerts.txt.patch
@@ -1,0 +1,72 @@
+From 850ce946fc5ba79f03d46e8cb7695dcadb5f397d Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.vnet.ibm.com>
+Date: Fri, 26 Feb 2021 18:45:57 -0500
+Subject: [PATCH 1/9] Deactivate test cases accessing rootcerts.txt
+
+rootcerts.txt contains files in a drive we don't have access to
+---
+ utils/regtests/testcredential.sh | 18 +++++++++---------
+ utils/regtests/testunseal.sh     |  4 ++--
+ 2 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/utils/regtests/testcredential.sh b/utils/regtests/testcredential.sh
+index cb9fec0..16fd66a 100755
+--- a/utils/regtests/testcredential.sh
++++ b/utils/regtests/testcredential.sh
+@@ -300,9 +300,9 @@ NVNAME=(
+ 	${PREFIX}createek -high -pwde eee -pwdk kkk ${CALG[i]} -cp -noflush > run.out
+ 	checkSuccess $?
+ 
+-	echo "Validate the ${CALG[i]} EK certificate against the root"
+-	${PREFIX}createek -high ${CALG[i]} -root certificates/rootcerts.txt > run.out
+-	checkSuccess $?
++	#echo "Validate the ${CALG[i]} EK certificate against the root"
++	#${PREFIX}createek -high ${CALG[i]} -root certificates/rootcerts.txt > run.out
++	#checkSuccess $?
+ 
+ 	echo "Create a signing key under the ${CALG[i]} EK using the password"
+ 	${PREFIX}create -hp 80000001 -si -pwdp kkk > run.out
+@@ -402,9 +402,9 @@ NVNAME=(
+ 	${PREFIX}createek -high -pwde eee -pwdk kkk ${CALG[i]} -cp -noflush > run.out
+ 	checkSuccess $?
+ 
+-	echo "Validate the ${CALG[i]} EK certificate against the root"
+-	${PREFIX}createek -high ${CALG[i]} -root certificates/rootcerts.txt > run.out
+-	checkSuccess $?
++	#echo "Validate the ${CALG[i]} EK certificate against the root"
++	#${PREFIX}createek -high ${CALG[i]} -root certificates/rootcerts.txt > run.out
++	#checkSuccess $?
+ 
+ 	echo "Create a signing key under the ${CALG[i]} EK using the password"
+ 	${PREFIX}create -hp 80000001 -si -pwdp kkk > run.out
+@@ -540,9 +540,9 @@ NVNAME=(
+ 	${PREFIX}createek ${ALG} -pwde eee -cp -noflush > run.out
+ 	checkSuccess $?
+ 
+-	echo "Validate the ${ALG} EK certificate against the root"
+-	${PREFIX}createek ${ALG} -root certificates/rootcerts.txt > run.out
+-	checkSuccess $?
++	#echo "Validate the ${ALG} EK certificate against the root"
++	#${PREFIX}createek ${ALG} -root certificates/rootcerts.txt > run.out
++	#checkSuccess $?
+ 
+ 	echo "Start a policy session"
+ 	${PREFIX}startauthsession -se p > run.out
+diff --git a/utils/regtests/testunseal.sh b/utils/regtests/testunseal.sh
+index aae3d4e..1755740 100755
+--- a/utils/regtests/testunseal.sh
++++ b/utils/regtests/testunseal.sh
+@@ -724,8 +724,8 @@ echo ""
+ 
+ echo "PROVISION: Create the EK for the salted session 80000000"
+ if   [ ${CRYPTOLIBRARY} == "openssl" ]; then
+-${PREFIX}createek -rsa 2048 -cp -noflush -root certificates/rootcerts.txt > run.out
+-elif [ ${CRYPTOLIBRARY} == "mbedtls" ]; then
++#${PREFIX}createek -rsa 2048 -cp -noflush -root certificates/rootcerts.txt > run.out
++#elif [ ${CRYPTOLIBRARY} == "mbedtls" ]; then
+ ${PREFIX}createek -rsa 2048 -cp -noflush > run.out
+ fi
+ checkSuccess $?
+-- 
+2.26.2
+

--- a/tests/patches/0002-Implement-powerup-for-swtpm.patch
+++ b/tests/patches/0002-Implement-powerup-for-swtpm.patch
@@ -1,0 +1,148 @@
+From f0f9aec53193b1c81f2de2cc9cc52a0c82afa523 Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.vnet.ibm.com>
+Date: Sun, 28 Feb 2021 16:39:51 -0500
+Subject: [PATCH 2/9] Implement powerup for swtpm
+
+---
+ utils/reg.sh                   | 12 ++++++++++++
+ utils/regtests/inittpm.sh      |  4 ++--
+ utils/regtests/testevent.sh    |  2 +-
+ utils/regtests/testnvpin.sh    |  4 ++--
+ utils/regtests/testpcr.sh      |  2 +-
+ utils/regtests/testshutdown.sh |  6 +++---
+ 6 files changed, 21 insertions(+), 9 deletions(-)
+
+diff --git a/utils/reg.sh b/utils/reg.sh
+index 048863b..61f23d9 100755
+--- a/utils/reg.sh
++++ b/utils/reg.sh
+@@ -1,6 +1,12 @@
+ #!/bin/bash
+ #
+ 
++SWTPM_IOCTL=${SWTPM_IOCTL:-$(type -P swtpm_ioctl)}
++if [ -z "${SWTPM_IOCTL}" ]; then
++	echo "SWTPM_IOCTL not set and could not find swtpm_ioctl in PATH"
++	exit 1
++fi
++
+ #################################################################################
+ #										#
+ #			TPM2 regression test					#
+@@ -244,6 +250,12 @@ initprimary()
+     checkSuccess $?
+ }
+ 
++powerup()
++{
++    ${SWTPM_IOCTL} -i --tcp ${TPM_SERVER_NAME}:${TPM_PLATFORM_PORT}
++    return $?
++}
++export -f powerup
+ 
+ export -f checkSuccess
+ export -f checkWarning
+diff --git a/utils/regtests/inittpm.sh b/utils/regtests/inittpm.sh
+index eaefab4..2c87bb2 100755
+--- a/utils/regtests/inittpm.sh
++++ b/utils/regtests/inittpm.sh
+@@ -46,7 +46,7 @@ echo "Initialize TPM"
+ echo ""
+ 
+ echo "Power cycle"
+-${PREFIX}powerup > run.out
++powerup > run.out
+ checkSuccess $?
+ 
+ echo "Startup"
+@@ -62,7 +62,7 @@ ${PREFIX}pcrallocate +sha1 +sha256 +sha384 +sha512 > run.out
+ checkSuccess $?
+     
+ echo "Power cycle"
+-${PREFIX}powerup > run.out
++powerup > run.out
+ checkSuccess $?
+ 
+ echo "Startup"
+diff --git a/utils/regtests/testevent.sh b/utils/regtests/testevent.sh
+index 6336920..6d78ba5 100755
+--- a/utils/regtests/testevent.sh
++++ b/utils/regtests/testevent.sh
+@@ -66,7 +66,7 @@ do
+     do
+ 
+ 	echo "Power cycle to reset IMA PCR"
+-	${PREFIX}powerup > run.out
++	powerup > run.out
+ 	checkSuccess $?
+ 
+ 	echo "Startup"
+diff --git a/utils/regtests/testnvpin.sh b/utils/regtests/testnvpin.sh
+index 89d14a7..c045af1 100755
+--- a/utils/regtests/testnvpin.sh
++++ b/utils/regtests/testnvpin.sh
+@@ -240,7 +240,7 @@ ${PREFIX}nvwrite -ha 01000000 -hia p -id 0 1 > run.out
+ checkFailure $?
+ 
+ echo "Reboot"
+-${PREFIX}powerup > run.out
++powerup > run.out
+ checkSuccess $?
+ 
+ echo "Startup"
+@@ -448,7 +448,7 @@ ${PREFIX}nvwrite -ha 01000000 -hia p -id 0 1 > run.out
+ checkFailure $?
+ 
+ echo "Reboot"
+-${PREFIX}powerup > run.out
++powerup > run.out
+ checkSuccess $?
+ 
+ echo "Startup"
+diff --git a/utils/regtests/testpcr.sh b/utils/regtests/testpcr.sh
+index ef8fa2c..e2ac737 100755
+--- a/utils/regtests/testpcr.sh
++++ b/utils/regtests/testpcr.sh
+@@ -191,7 +191,7 @@ do
+     checkSuccess $?
+ 
+     echo "powerup"
+-    ${PREFIX}powerup > run.out
++    powerup > run.out
+     checkSuccess $?
+ 
+     echo "startup"
+diff --git a/utils/regtests/testshutdown.sh b/utils/regtests/testshutdown.sh
+index 566471b..7be9f1c 100755
+--- a/utils/regtests/testshutdown.sh
++++ b/utils/regtests/testshutdown.sh
+@@ -147,7 +147,7 @@ ${PREFIX}shutdown -s > run.out
+ checkSuccess $?
+ 
+ echo "Power cycle"
+-${PREFIX}powerup > run.out
++powerup > run.out
+ checkSuccess $?
+ 
+ echo "Startup state"
+@@ -255,7 +255,7 @@ ${PREFIX}shutdown -s > run.out
+ checkSuccess $?
+ 
+ echo "Power cycle"
+-${PREFIX}powerup > run.out
++powerup > run.out
+ checkSuccess $?
+ 
+ echo "Startup clear"
+@@ -331,7 +331,7 @@ ${PREFIX}shutdown -c > run.out
+ checkSuccess $?
+ 
+ echo "Power cycle"
+-${PREFIX}powerup > run.out
++powerup > run.out
+ checkSuccess $?
+ 
+ echo "Startup clear"
+-- 
+2.26.2
+

--- a/tests/patches/0003-Set-CRYPTOLIBRARY-to-openssl.patch
+++ b/tests/patches/0003-Set-CRYPTOLIBRARY-to-openssl.patch
@@ -1,0 +1,25 @@
+From b233462f3fe53d2209a1e2aad7f196979cea00e5 Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.vnet.ibm.com>
+Date: Sun, 28 Feb 2021 16:35:56 -0500
+Subject: [PATCH 3/9] Set CRYPTOLIBRARY to openssl
+
+---
+ utils/reg.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/utils/reg.sh b/utils/reg.sh
+index 61f23d9..33e3299 100755
+--- a/utils/reg.sh
++++ b/utils/reg.sh
+@@ -264,7 +264,7 @@ export WARN
+ export PREFIX
+ export -f initprimary
+ # hack because the mbedtls port is incomplete
+-export CRYPTOLIBRARY=`${PREFIX}getcryptolibrary`
++export CRYPTOLIBRARY=openssl
+ 
+ # example for running scripts with encrypted sessions, see TPM_SESSION_ENCKEY=getrandom below
+ export TPM_SESSION_ENCKEY
+-- 
+2.26.2
+

--- a/tests/patches/0004-Store-volatile-state-at-every-step.patch
+++ b/tests/patches/0004-Store-volatile-state-at-every-step.patch
@@ -1,0 +1,65 @@
+From 223a78820b10fcce8b65d5827d1699dab49e45e1 Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.vnet.ibm.com>
+Date: Sun, 28 Feb 2021 16:42:11 -0500
+Subject: [PATCH 4/9] Store volatile state at every step
+
+---
+ utils/reg.sh | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/utils/reg.sh b/utils/reg.sh
+index 33e3299..de7e181 100755
+--- a/utils/reg.sh
++++ b/utils/reg.sh
+@@ -124,6 +124,13 @@ printUsage ()
+     echo "-51 Events"
+ }
+ 
++storeVolatileState()
++{
++    echo ">>> Storing volatile state <<<"
++    ${SWTPM_IOCTL} -v --tcp ${TPM_SERVER_NAME}:${TPM_PLATFORM_PORT}
++}
++export -f storeVolatileState
++
+ checkSuccess()
+ {
+ if [ $1 -ne 0 ]; then
+@@ -133,7 +140,7 @@ if [ $1 -ne 0 ]; then
+ else
+     echo " INFO:"
+ fi
+-
++storeVolatileState
+ }
+ 
+ # FIXME should not increment past 254
+@@ -146,6 +153,7 @@ if [ $1 -ne 0 ]; then
+ else
+     echo " INFO:"
+ fi
++storeVolatileState
+ }
+ 
+ checkFailure()
+@@ -157,6 +165,7 @@ if [ $1 -eq 0 ]; then
+ else
+     echo " INFO:"
+ fi
++storeVolatileState
+ }
+ 
+ cleanup()
+@@ -252,6 +261,9 @@ initprimary()
+ 
+ powerup()
+ {
++    ${SWTPM_IOCTL} -i --tcp ${TPM_SERVER_NAME}:${TPM_PLATFORM_PORT}
++    # Do it a 2nd time now that the previously store volatile state is gone
++    # Now startup must be sent to the TPM again
+     ${SWTPM_IOCTL} -i --tcp ${TPM_SERVER_NAME}:${TPM_PLATFORM_PORT}
+     return $?
+ }
+-- 
+2.26.2
+

--- a/tests/patches/0005-Disable-tests-related-to-events.patch
+++ b/tests/patches/0005-Disable-tests-related-to-events.patch
@@ -1,0 +1,23 @@
+From 19ce952c3a7205585bed8cb063dc2b1f23434ba4 Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.vnet.ibm.com>
+Date: Sun, 28 Feb 2021 16:33:02 -0500
+Subject: [PATCH 5/9] Disable tests related to 'events'
+
+---
+ utils/regtests/testevent.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/utils/regtests/testevent.sh b/utils/regtests/testevent.sh
+index 6d78ba5..9252161 100755
+--- a/utils/regtests/testevent.sh
++++ b/utils/regtests/testevent.sh
+@@ -1,5 +1,6 @@
+ #!/bin/bash
+ #
++exit 0
+ 
+ #################################################################################
+ #										#
+-- 
+2.26.2
+

--- a/tests/patches/0006-Disable-testing-with-RSA-3072.patch
+++ b/tests/patches/0006-Disable-testing-with-RSA-3072.patch
@@ -1,8 +1,25 @@
+From ca400b52d26bf4f518964faf2b2353d25a057fce Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.vnet.ibm.com>
+Date: Sun, 28 Feb 2021 16:35:02 -0500
+Subject: [PATCH 6/9] Disable testing with RSA 3072
+
+---
+ utils/reg.sh                       |  2 +-
+ utils/regtests/initkeys.sh         |  2 +-
+ utils/regtests/testcreateloaded.sh |  2 +-
+ utils/regtests/testcredential.sh   |  2 +-
+ utils/regtests/testprimary.sh      |  2 +-
+ utils/regtests/testrsa.sh          | 14 +++++++-------
+ utils/regtests/testsalt.sh         |  1 +
+ utils/regtests/testsign.sh         |  6 +++---
+ utils/regtests/testx509.sh         |  2 +-
+ 9 files changed, 17 insertions(+), 16 deletions(-)
+
 diff --git a/utils/reg.sh b/utils/reg.sh
-index 048863b..3aff350 100755
+index de7e181..9de1eaa 100755
 --- a/utils/reg.sh
 +++ b/utils/reg.sh
-@@ -171,7 +171,7 @@ cleanup()
+@@ -186,7 +186,7 @@ cleanup()
  	rm -f khrpub${HALG}.bin
      done
  
@@ -38,7 +55,7 @@ index d3e3eb8..76fb859 100755
  
  	echo "CreateLoaded primary key, parent ${HIER} ${ALG}"
 diff --git a/utils/regtests/testcredential.sh b/utils/regtests/testcredential.sh
-index cb9fec0..ca9d512 100755
+index 16fd66a..a68960d 100755
 --- a/utils/regtests/testcredential.sh
 +++ b/utils/regtests/testcredential.sh
 @@ -287,7 +287,7 @@ NVNAME=(
@@ -179,3 +196,6 @@ index 813085f..f5737a8 100755
      echo "Load the ${SALG[i]} ${SKEY[i]} issuer key 80000001 under the primary key"
      ${PREFIX}load -hp 80000000 -ipr sign${SKEY[i]}rpriv.bin -ipu sign${SKEY[i]}rpub.bin -pwdp sto > run.out
      checkSuccess $?
+-- 
+2.26.2
+

--- a/tests/patches/0007-Disable-rev155-test-cases.patch
+++ b/tests/patches/0007-Disable-rev155-test-cases.patch
@@ -1,0 +1,23 @@
+From 7a6fe0d006ef5f2c6c960aa324b3e0ca4e0afcc9 Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.vnet.ibm.com>
+Date: Sun, 28 Feb 2021 16:36:53 -0500
+Subject: [PATCH 7/9] Disable rev155 test cases
+
+---
+ utils/regtests/testattest155.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/utils/regtests/testattest155.sh b/utils/regtests/testattest155.sh
+index 0bf88aa..554a40e 100755
+--- a/utils/regtests/testattest155.sh
++++ b/utils/regtests/testattest155.sh
+@@ -1,5 +1,6 @@
+ #!/bin/bash
+ #
++exit 0
+ 
+ #################################################################################
+ #										#
+-- 
+2.26.2
+

--- a/tests/patches/0008-Disable-x509-test-cases.patch
+++ b/tests/patches/0008-Disable-x509-test-cases.patch
@@ -1,0 +1,23 @@
+From 3dbd97928bd833f5b79e8a1f5147c7b23d4c989d Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.vnet.ibm.com>
+Date: Sun, 28 Feb 2021 16:37:27 -0500
+Subject: [PATCH 8/9] Disable x509 test cases
+
+---
+ utils/regtests/testx509.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/utils/regtests/testx509.sh b/utils/regtests/testx509.sh
+index f5737a8..acd2c3c 100755
+--- a/utils/regtests/testx509.sh
++++ b/utils/regtests/testx509.sh
+@@ -1,5 +1,6 @@
+ #!/bin/bash
+ #
++exit 0
+ 
+ #################################################################################
+ #										#
+-- 
+2.26.2
+

--- a/tests/patches/0009-Disable-getcapability-TPM_CAP_ACT.patch
+++ b/tests/patches/0009-Disable-getcapability-TPM_CAP_ACT.patch
@@ -1,0 +1,28 @@
+From 0e64682da7e1da7b8ffdf1103b99546d31a599da Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.vnet.ibm.com>
+Date: Sun, 28 Feb 2021 16:38:10 -0500
+Subject: [PATCH 9/9] Disable getcapability TPM_CAP_ACT
+
+---
+ utils/regtests/testgetcap.sh | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/utils/regtests/testgetcap.sh b/utils/regtests/testgetcap.sh
+index 4e370cf..cd6607d 100755
+--- a/utils/regtests/testgetcap.sh
++++ b/utils/regtests/testgetcap.sh
+@@ -120,8 +120,8 @@ echo "Get Capability TPM_CAP_AUTH_POLICIES"
+ ${PREFIX}getcapability -cap 9 -pr 40000000 > run.out
+ checkSuccess $?
+ 
+-echo "Get Capability TPM_CAP_ACT"
+-${PREFIX}getcapability -cap a -pr 40000110 > run.out
+-checkSuccess $?
++#echo "Get Capability TPM_CAP_ACT"
++#${PREFIX}getcapability -cap a -pr 40000110 > run.out
++#checkSuccess $?
+ 
+ 
+-- 
+2.26.2
+

--- a/tests/test_samples_create_tpmca
+++ b/tests/test_samples_create_tpmca
@@ -76,13 +76,6 @@ function cleanup()
 trap "cleanup" SIGTERM EXIT
 source ${TESTDIR}/common
 
-case "$(uname -s)" in
-Darwin)
-	CERTTOOL=gnutls-certtool;;
-*)
-	CERTTOOL=certtool;;
-esac
-
 PATH=${ROOT}/src/swtpm_bios:${ROOT}/src/swtpm_cert:${PATH}
 
 # run the test with the given owner and SRK passwords

--- a/tests/test_tpm2_ibmtss2
+++ b/tests/test_tpm2_ibmtss2
@@ -8,6 +8,8 @@ ROOT=${abs_top_builddir:-$(pwd)/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 ABSTESTDIR=$(cd ${TESTDIR} &>/dev/null;echo ${PWD})
 
+PATCHESDIR=${ABSTESTDIR}/patches
+
 SWTPM_SERVER_PORT=65426
 SWTPM_SERVER_NAME=127.0.0.1
 SWTPM_CTRL_PORT=65427
@@ -48,18 +50,42 @@ if [ $? -ne 0 ]; then
 fi
 
 # A v1.6.0 bug work-around:
-pushd utils/regtests &>/dev/null
 # We cannot run the EK certificate tests since rootcerts.txt points to
 # files we do not have
-for line in 303 304 305 405 406 407 543 544 545; do
-	sed -i "${line}s/./\#\0/" testcredential.sh
-done
-for line in 727 728;do
-	sed -i "${line}s/./\#\0/" testunseal.sh
-done
-# We do not run the UEFI tests
-sed -i '2 i exit 0' testevent.sh
-popd &>/dev/null
+git am < ${PATCHESDIR}/0001-Deactivate-test-cases-accessing-rootcerts.txt.patch
+
+# Implement 'powerup' for swtpm
+git am < ${PATCHESDIR}/0002-Implement-powerup-for-swtpm.patch
+
+# set CRYPTOLIBRARY=openssl
+git am < ${PATCHESDIR}/0003-Set-CRYPTOLIBRARY-to-openssl.patch
+
+# Store volatile state at every step
+git am < ${PATCHESDIR}/0004-Store-volatile-state-at-every-step.patch
+
+# Disable 'Events' test
+git am < ${PATCHESDIR}/0005-Disable-tests-related-to-events.patch
+
+rsa3072=$(run_swtpm_ioctl ${SWTPM_INTERFACE} --info 4 |
+          sed -n 's/.*"RSAKeySizes":\[\([0-9,]*\)\].*/\1/p' |
+          grep 3072)
+if [ -z "$rsa3072" ]; then
+	echo "Modifying test cases related to RSA 3072 keys."
+	git am < ${PATCHESDIR}/0006-Disable-testing-with-RSA-3072.patch
+else
+	echo "swtpm/libtpms support RSA 3072 bit keys"
+fi
+
+# Adjust test suite to TPM 2.0 revision libtpms is implementing
+revision=$(run_swtpm_ioctl ${SWTPM_INTERFACE} --info 1 |
+           sed 's/.*,"revision":\([^\}]*\).*/\1/')
+echo "Libtpms implements TPM 2.0 revision ${revision}."
+if [ $revision -lt 155 ]; then
+	echo "Removing revision 155 and later test cases."
+	git am < ${PATCHESDIR}/0007-Disable-rev155-test-cases.patch
+	git am < ${PATCHESDIR}/0008-Disable-x509-test-cases.patch
+	git am < ${PATCHESDIR}/0009-Disable-getcapability-TPM_CAP_ACT.patch
+fi
 
 autoreconf --force --install
 unset CFLAGS LDFLAGS LIBS
@@ -68,54 +94,12 @@ make -j4
 
 pushd utils
 
-rsa3072=$(run_swtpm_ioctl ${SWTPM_INTERFACE} --info 4 |
-          sed -n 's/.*"RSAKeySizes":\[\([0-9,]*\)\].*/\1/p' |
-          grep 3072)
-if [ -z "$rsa3072" ]; then
-	echo "Modifying test cases related to RSA 3072 keys."
-
-	patch -p2 < "${ABSTESTDIR}/patches/ibmtss2_1.6_rsa2048only.patch"
-	if [ $? -ne 0 ]; then
-		echo "Patching of testsuite failed"
-		exit 1
-	fi
-else
-	echo "swtpm/libtpms support RSA 3072 bit keys"
-fi
-
-sed -i 's/export CRYPTOLIBRARY.*/export CRYPTOLIBRARY=openssl/' reg.sh
-
-# Adjust test suite to TPM 2.0 revision libtpms is implementing
-revision=$(run_swtpm_ioctl ${SWTPM_INTERFACE} --info 1 |
-           sed 's/.*,"revision":\([^\}]*\).*/\1/')
-echo "Libtpms implements TPM 2.0 revision ${revision}."
-if [ $revision -lt 155 ]; then
-	echo "Removing revision 155 test cases."
-	for t in regtests/testattest155.sh regtests/testx509.sh
-	do
-		rm "${t}"
-		touch "${t}"
-		chmod 777 "${t}"
-	done
-	# CAP_ACT was introduced later than 155
-	for line in 123 124 125; do
-		sed -i "${line}s/./\#\0/" regtests/testgetcap.sh
-	done
-fi
-
 export TPM_SERVER_NAME=127.0.0.1
 export TPM_INTERFACE_TYPE=socsim
 export TPM_COMMAND_PORT=${SWTPM_SERVER_PORT}
 export TPM_PLATFORM_PORT=${SWTPM_CTRL_PORT}
 
 export SWTPM_IOCTL
-
-cat <<_EOF_ > powerup
-#!/usr/bin/env bash
-\${SWTPM_IOCTL} -i --tcp \${TPM_SERVER_NAME}:\${TPM_PLATFORM_PORT}
-exit \$?
-_EOF_
-chmod 755 powerup
 
 ./startup
 if [ $? -ne 0 ]; then

--- a/tests/test_tpm2_samples_create_tpmca
+++ b/tests/test_tpm2_samples_create_tpmca
@@ -85,13 +85,6 @@ function cleanup()
 trap "cleanup" SIGTERM EXIT
 source ${TESTDIR}/common
 
-case "$(uname -s)" in
-Darwin)
-	CERTTOOL=gnutls-certtool;;
-*)
-	CERTTOOL=certtool;;
-esac
-
 PATH=${ROOT}/src/swtpm_bios:${ROOT}/src/swtpm_cert:${PATH}
 
 # Run the tests

--- a/tests/test_tpm2_samples_swtpm_localca
+++ b/tests/test_tpm2_samples_swtpm_localca
@@ -22,19 +22,14 @@ CERTSERIAL=${workdir}/certserial
 
 PATH=${TOPBUILD}/src/swtpm_cert:$PATH
 
+source ${TESTDIR}/common
+
 trap "cleanup" SIGTERM EXIT
 
 function cleanup()
 {
 	rm -rf "${workdir}"
 }
-
-case "$(uname -s)" in
-Darwin)
-	CERTTOOL=gnutls-certtool;;
-*)
-	CERTTOOL=certtool;;
-esac
 
 cat <<_EOF_ > "${workdir}/swtpm-localca.conf"
 statedir=${workdir}

--- a/tests/test_tpm2_samples_swtpm_localca_pkcs11
+++ b/tests/test_tpm2_samples_swtpm_localca_pkcs11
@@ -33,6 +33,8 @@ CERTSERIAL=${workdir}/certserial
 
 PATH=${TOPBUILD}/src/swtpm_cert:$PATH
 
+source ${TESTDIR}/common
+
 trap "cleanup" SIGTERM EXIT
 
 function cleanup()
@@ -40,13 +42,6 @@ function cleanup()
 	rm -rf ${workdir}
 	${TESTDIR}/softhsm_setup teardown
 }
-
-case "$(uname -s)" in
-Darwin)
-	CERTTOOL=gnutls-certtool;;
-*)
-	CERTTOOL=certtool;;
-esac
 
 unset GNUTLS_PIN
 export PIN="abcdef"

--- a/tests/test_tpm2_save_load_state_3
+++ b/tests/test_tpm2_save_load_state_3
@@ -49,13 +49,6 @@ source ${TESTDIR}/common
 
 trap "cleanup" SIGTERM EXIT
 
-case "$(uname -s)" in
-Darwin)
-	CERTTOOL=gnutls-certtool;;
-*)
-	CERTTOOL=certtool;;
-esac
-
 function cleanup()
 {
 	rm -rf $TPMDIR


### PR DESCRIPTION
This PR
- adds a note to the usage of --allow-signing to swtpm_setup that usage of this option creates a non-standard EK
- Applies patches to the IBM TSS2 test suite in test_ibmtss2 and stores the volatile state at every stop on the way to ensure that the volatile state doesn't run into a pAssert as was the case with libtpms issue 195
- Consolidates the setting of CERTTOOL into common.sh