### PR TITLE
tests: Allow volatile state file >= 9000 bytes in test_tpm2_migration…

### DIFF
--- a/tests/_test_tpm2_migration_key
+++ b/tests/_test_tpm2_migration_key
@@ -108,7 +108,7 @@ if [ ! -r $volatilestatefile ]; then
 fi
 
 size=$(get_filesize $volatilestatefile)
-expsize="^([568][0-9]{3})$"
+expsize="^([5689][0-9]{3})$"
 if ! [[ $size =~ $expsize ]]; then
 	echo "Error: Unexpected size of volatile state file."
 	echo "       Expected file with size of $expsize, found $size bytes."


### PR DESCRIPTION
…_key

Changes to libtpms will require that the volatile state files
during this test may be larger than 9000 bytes.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>