### PR TITLE
build-sys: leave CFLAGS/LDFLAGS for user to be defined

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -553,6 +553,11 @@ if test "$with_seccomp" != "no"; then
                      [whether to build in seccomp profile (Linux only)])
 fi
 
+AM_CFLAGS="$CFLAGS"
+AM_LDFLAGS="$LDFLAGS"
+AC_SUBST([AM_CFLAGS])
+AC_SUBST([AM_LDFLAGS])
+
 AC_CONFIG_FILES([Makefile                   \
 		debian/swtpm-tools.postinst \
 		dist/swtpm.spec             \
@@ -604,10 +609,10 @@ echo
 echo "Version to build  : $PACKAGE_VERSION"
 echo "Crypto library    : $cryptolib"
 echo
-echo "CFLAGS=$CFLAGS"
+echo "AM_CFLAGS=$AM_CFLAGS"
 echo "HARDENING_CFLAGS=$HARDENING_CFLAGS"
 echo "HARDENING_LDFLAGS=$HARDENING_LDFLAGS"
-echo "LDFLAGS=$LDFLAGS"
+echo "AM_LDFLAGS=$AM_LDFLAGS"
 echo "LIBSECCOMP_LIBS=$LIBSECCOMP_LIBS"
 echo
 echo "TSS_USER=$TSS_USER"

--- a/src/swtpm/Makefile.am
+++ b/src/swtpm/Makefile.am
@@ -4,6 +4,9 @@
 # For the license, see the COPYING file in the root directory.
 #
 
+AM_CFLAGS = @AM_CFLAGS@
+AM_LDFLAGS = @AM_LDFLAGS@
+
 noinst_HEADERS = \
 	capabilities.h \
 	common.h \
@@ -61,11 +64,13 @@ libswtpm_libtpms_la_CFLAGS = \
 	-I$(top_builddir)/include \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/include/swtpm \
+	$(AM_CFLAGS) \
 	$(HARDENING_CFLAGS) \
 	$(GLIB_CFLAGS) \
 	$(LIBSECCOMP_CFLAGS)
 
 libswtpm_libtpms_la_LDFLAGS = \
+	$(AM_LDFLAGS) \
 	$(HARDENING_LDFLAGS)
 
 libswtpm_libtpms_la_LIBADD = \
@@ -95,12 +100,14 @@ swtpm_CFLAGS = \
 	-I$(top_builddir)/include \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/include/swtpm \
+	$(AM_CFLAGS) \
 	$(HARDENING_CFLAGS) \
 	$(GLIB_CFLAGS) \
 	$(LIBFUSE_CFLAGS) \
 	-DHAVE_SWTPM_CUSE_MAIN
 
 swtpm_LDFLAGS = \
+	$(AM_LDFLAGS) \
 	$(HARDENING_LDFLAGS)
 
 swtpm_LDADD = \
@@ -118,11 +125,13 @@ swtpm_cuse_SOURCES = \
 swtpm_cuse_CFLAGS = \
 	-I$(top_builddir)/include \
 	-I$(top_srcdir)/include/swtpm \
+	$(AM_CFLAGS) \
 	$(GLIB_CFLAGS) \
 	$(LIBFUSE_CFLAGS) \
 	$(HARDENING_CFLAGS)
 
 swtpm_cuse_LDFLAGS = \
+	$(AM_LDFLAGS) \
 	$(HARDENING_LDFLAGS)
 
 swtpm_cuse_LDADD = \


### PR DESCRIPTION
This allows user to set specific flags during compilation, without
overriding configure-time cflags necessary for compilation.

See also:
https://www.gnu.org/software/automake/manual/html_node/User-Variables.html
https://www.gnu.org/software/automake/manual/html_node/Flag-Variables-Ordering.html

