### PR TITLE
swtpm_setup: Replace '\\s' in regex with [[:space:]] to fix cygwin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@
 #       This file is derived from tpm-tool's configure.in.
 #
 
-AC_INIT(swtpm, 0.6.0)
+AC_INIT(swtpm, 0.7.0)
 AC_PREREQ(2.12)
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_HEADER(config.h)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+swtpm (0.7.0~dev1) UNRELEASED; urgency=medium
+
+  * Developer release 1
+
+ -- Stefan Berger <stefanb@linux.ibm.com>  Fri, 11 Jun 2021 09:14:00 -0500
+
 swtpm (0.6.0) RELEASED; urgency=medium
 
   * Stable release

--- a/src/swtpm_setup/swtpm_setup_utils.c
+++ b/src/swtpm_setup/swtpm_setup_utils.c
@@ -19,7 +19,8 @@
 /* Get a configuration value given its name */
 gchar *get_config_value(gchar **config_file_lines, const gchar *configname)
 {
-    g_autofree gchar *regex = g_strdup_printf("^%s\\s*=\\s*([^#\n]*).*", configname);
+    g_autofree gchar *regex = g_strdup_printf("^%s[[:space:]]*=[[:space:]]*([^#\n]*).*",
+                                              configname);
     gchar *result = NULL;
     regmatch_t pmatch[2];
     regex_t preg;

--- a/swtpm.spec
+++ b/swtpm.spec
@@ -7,7 +7,7 @@
 
 Summary: TPM Emulator
 Name:           swtpm
-Version:        0.6.0
+Version:        0.7.0
 Release:        1%{?dist}
 License:        BSD
 Url:            https://github.com/stefanberger/swtpm


### PR DESCRIPTION
Cygwin's regex implementation doesn't seem to understande \\s
but needs [[:space:]] instead to properly skip over spaces.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>