### PR TITLE
swtpm_setup: Initialize Gerror and free it

### DIFF
--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -58,7 +58,7 @@ static int swtpm_start(struct swtpm *self)
     g_autofree gchar **argv = NULL;
     struct stat statbuf;
     gboolean success;
-    GError *error;
+    GError *error = NULL;
     unsigned ctr;
 
     self->pidfile = g_strjoin(G_DIR_SEPARATOR_S,

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -834,6 +834,7 @@ static int get_rsa_keysizes(unsigned long flags, gchar **swtpm_prg_l,
                                &standard_output, NULL, &exit_status, &error);
         if (!success) {
             logerr(gl_LOGFILE, "Could not start swtpm '%s': %s\n", swtpm_prg_l[0], error->message);
+            g_error_free(error);
             goto error;
         }
 


### PR DESCRIPTION
Gerror was not initialized to NULL in one place. In the other it wasn't
freed.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>