### PR TITLE
swtpm_setup: Write EK certificate files into a directory

### DIFF
--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -194,6 +194,7 @@ The output may contain the following:
       "features": [
         "cmdarg-keyfile-fd",
         "cmdarg-pwdfile-fd",
+        "cmdarg-write-ek-cert-files",
         "tpm2-rsa-keysize-2048",
         "tpm2-rsa-keysize-3072",
         "tpm12-not-need-root"
@@ -212,6 +213,10 @@ The I<--keyfile-fd> option is supported.
 
 The I<--pwdfile-fd> option is supported.
 
+=item B<cmdarg-write-ek-cert-files>
+
+The I<--write-ek-cert-files> option is supported
+
 =item B<tpm2-rsa-keysize-2048, ...>
 
 The shown RSA key sizes are supported for a TPM 2's EK key. If none of the
@@ -224,6 +229,18 @@ or the 'tss' user, depending on configuration and availability of this account,
 could do that.
 
 =back
+
+=item B<--write-ek-cert-files <directory>>
+
+This option causes endorsement key (EK) files to be written into the provided
+directory. The files contain the DER-formatted EKs that were written into the
+NVRAM locations of the TPM 1.2 or TPM 2. The EK files have the filename pattern
+of ek-<key type>.crt. Example for filenames are ek-rsa2048.crt, ek-rsa3072.crt,
+and ek-secp384r1.crt.
+
+The keys that are written for a TPM 2 may change over time as the default
+strength of the EK keys changes. This means that one should look for all
+files with the above filename pattern when looking for the EKs.
 
 =item B<--help, -h>
 

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -425,7 +425,7 @@ static int swtpm_tpm2_createprimary_rsa(struct swtpm *self, uint32_t primaryhand
                                         unsigned int rsa_keysize, gboolean havenonce, size_t off,
                                         uint32_t *curr_handle,
                                         unsigned char *ektemplate, size_t *ektemplate_len,
-                                        gchar **ekparam);
+                                        gchar **ekparam, const gchar **key_description);
 
 static int swtpm_tpm2_write_nvram(struct swtpm *self, uint32_t nvindex, uint32_t nvindexattrs,
                                   const unsigned char *data, size_t data_len, gboolean lock_nvram,
@@ -666,7 +666,7 @@ static int swtpm_tpm2_createprimary_ek_rsa(struct swtpm *self, unsigned int rsa_
                                            gboolean allowsigning, gboolean decryption,
                                            uint32_t *curr_handle,
                                            unsigned char *ektemplate, size_t *ektemplate_len,
-                                           gchar **ekparam)
+                                           gchar **ekparam, const gchar **key_description)
 {
     unsigned char authpolicy[48];
     size_t authpolicy_len;
@@ -738,7 +738,7 @@ static int swtpm_tpm2_createprimary_ek_rsa(struct swtpm *self, unsigned int rsa_
                                         symkeydata, symkeydata_len,
                                         authpolicy, authpolicy_len, rsa_keysize,
                                         havenonce, off, curr_handle,
-                                        ektemplate, ektemplate_len, ekparam);
+                                        ektemplate, ektemplate_len, ekparam, key_description);
 }
 
 /* Create an RSA key with the given parameters */
@@ -748,7 +748,7 @@ static int swtpm_tpm2_createprimary_rsa(struct swtpm *self, uint32_t primaryhand
                                         unsigned int rsa_keysize, gboolean havenonce, size_t off,
                                         uint32_t *curr_handle,
                                         unsigned char *ektemplate, size_t *ektemplate_len,
-                                        gchar **ekparam)
+                                        gchar **ekparam, const gchar **key_description)
 {
     const unsigned char *nonce;
     size_t nonce_len;
@@ -768,6 +768,8 @@ static int swtpm_tpm2_createprimary_rsa(struct swtpm *self, uint32_t primaryhand
         nonce = NONCE_RSA2048;
         nonce_len = sizeof(NONCE_RSA2048);
         hashalg = TPM2_ALG_SHA256;
+        if (key_description)
+            *key_description = "rsa2048";
     } else if (rsa_keysize == 3072) {
         if (!havenonce) {
            nonce = NONCE_EMPTY;
@@ -777,6 +779,8 @@ static int swtpm_tpm2_createprimary_rsa(struct swtpm *self, uint32_t primaryhand
            nonce_len = sizeof(NONCE_RSA3072);
         }
         hashalg = TPM2_ALG_SHA384;
+        if (key_description)
+            *key_description = "rsa3072";
     } else {
         logerr(self->logfile, "Internal error in %s: unsupported RSA keysize %d.\n",
                __func__, rsa_keysize);
@@ -867,7 +871,7 @@ static int swtpm_tpm2_createprimary_ecc(struct swtpm *self, uint32_t primaryhand
                                         const unsigned char *nonce, size_t nonce_len,
                                         size_t off, uint32_t *curr_handle,
                                         unsigned char *ektemplate, size_t *ektemplate_len,
-                                        gchar **ekparam)
+                                        gchar **ekparam, const gchar **key_description)
 {
     struct tpm_req_header hdr = TPM_REQ_HEADER_INITIALIZER(TPM2_ST_SESSIONS, 0, TPM2_CC_CREATEPRIMARY);
     struct tpm2_authblock authblock = TPM2_AUTHBLOCK_INITIALIZER(TPM2_RS_PW, 0, 0, 0);
@@ -936,6 +940,8 @@ static int swtpm_tpm2_createprimary_ecc(struct swtpm *self, uint32_t primaryhand
     if (curveid == TPM2_ECC_NIST_P384) {
         exp_ksize = 48;
         cid = "secp384r1";
+        if (key_description)
+            *key_description = cid;
     } else {
         logerr(self->logfile, "Unknown curveid 0x%x\n", curveid);
         return 1;
@@ -988,7 +994,7 @@ static int swtpm_tpm2_createprimary_spk_ecc_nist_p384(struct swtpm *self,
     return swtpm_tpm2_createprimary_ecc(self, TPM2_RH_OWNER, keyflags, symkeydata, symkeydata_len,
                                         authpolicy, authpolicy_len, TPM2_ECC_NIST_P384, TPM2_ALG_SHA384,
                                         NONCE_ECC_384, sizeof(NONCE_ECC_384), off, curr_handle,
-                                        NULL, 0, NULL);
+                                        NULL, 0, NULL, NULL);
 }
 
 static int swtpm_tpm2_createprimary_spk_rsa(struct swtpm *self, unsigned int rsa_keysize,
@@ -1015,7 +1021,7 @@ static int swtpm_tpm2_createprimary_spk_rsa(struct swtpm *self, unsigned int rsa
     return swtpm_tpm2_createprimary_rsa(self, TPM2_RH_OWNER, keyflags,
                                         symkeydata, symkeydata_len,
                                         authpolicy, authpolicy_len, rsa_keysize, TRUE,
-                                        off, curr_handle, NULL, 0, NULL);
+                                        off, curr_handle, NULL, 0, NULL, NULL);
 }
 
 /* Create either an ECC or RSA storage primary key */
@@ -1044,7 +1050,7 @@ static int swtpm_tpm2_create_spk(struct swtpm *self, gboolean isecc, unsigned in
 static int swtpm_tpm2_createprimary_ek_ecc_nist_p384(struct swtpm *self, gboolean allowsigning,
                                                      gboolean decryption, uint32_t *curr_handle,
                                                      unsigned char *ektemplate, size_t *ektemplate_len,
-                                                     gchar **ekparam)
+                                                     gchar **ekparam, const char **key_description)
 {
     unsigned char authpolicy[48]= {
         0xB2, 0x6E, 0x7D, 0x28, 0xD1, 0x1A, 0x50, 0xBC, 0x53, 0xD8, 0x82, 0xBC,
@@ -1090,7 +1096,7 @@ static int swtpm_tpm2_createprimary_ek_ecc_nist_p384(struct swtpm *self, gboolea
     ret = swtpm_tpm2_createprimary_ecc(self, TPM2_RH_ENDORSEMENT, keyflags, symkeydata, symkeydata_len,
                                        authpolicy, authpolicy_len, TPM2_ECC_NIST_P384, TPM2_ALG_SHA384,
                                        NONCE_EMPTY, sizeof(NONCE_EMPTY), off, curr_handle,
-                                       ektemplate, ektemplate_len, ekparam);
+                                       ektemplate, ektemplate_len, ekparam, key_description);
     if (ret != 0)
        logerr(self->logfile, "%s failed\n", __func__);
 
@@ -1100,7 +1106,7 @@ static int swtpm_tpm2_createprimary_ek_ecc_nist_p384(struct swtpm *self, gboolea
 /* Create an ECC or RSA EK */
 static int swtpm_tpm2_create_ek(struct swtpm *self, gboolean isecc, unsigned int rsa_keysize,
                                 gboolean allowsigning, gboolean decryption, gboolean lock_nvram,
-                                gchar **ekparam)
+                                gchar **ekparam, const  gchar **key_description)
 {
     uint32_t tpm2_ek_handle, nvindex, curr_handle;
     const char *keytype;
@@ -1128,10 +1134,11 @@ static int swtpm_tpm2_create_ek(struct swtpm *self, gboolean isecc, unsigned int
     }
     if (isecc)
         ret = swtpm_tpm2_createprimary_ek_ecc_nist_p384(self, allowsigning, decryption, &curr_handle,
-                                                        ektemplate, &ektemplate_len, ekparam);
+                                                        ektemplate, &ektemplate_len, ekparam,
+                                                        key_description);
     else
         ret = swtpm_tpm2_createprimary_ek_rsa(self, rsa_keysize, allowsigning, decryption, &curr_handle,
-                                              ektemplate, &ektemplate_len, ekparam);
+                                              ektemplate, &ektemplate_len, ekparam, key_description);
 
     if (ret == 0)
         ret = swtpm_tpm2_evictcontrol(self, curr_handle, tpm2_ek_handle);

--- a/src/swtpm_setup/swtpm.h
+++ b/src/swtpm_setup/swtpm.h
@@ -48,7 +48,7 @@ struct swtpm2_ops {
     int (*create_spk)(struct swtpm *self, gboolean isecc, unsigned int rsa_keysize);
     int (*create_ek)(struct swtpm *self, gboolean isecc, unsigned int rsa_keysize,
                      gboolean allowsigning, gboolean decryption, gboolean lock_nvram,
-                     gchar **ekparam);
+                     gchar **ekparam, const gchar **key_description);
     int (*get_all_pcr_banks)(struct swtpm *self, gchar ***all_pcr_banks);
     int (*set_active_pcr_banks)(struct swtpm *self, gchar **pcr_banks_l, gchar **all_pcr_banks,
                                 gchar ***active);

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -315,7 +315,7 @@ static int tpm2_create_ek_and_cert(unsigned long flags, const gchar *config_file
                                      !!(flags & SETUP_ALLOW_SIGNING_F),
                                      !!(flags & SETUP_DECRYPTION_F),
                                      !!(flags & SETUP_LOCK_NVRAM_F),
-                                     &ekparam);
+                                     &ekparam, NULL);
         if (ret != 0)
             return 1;
     }

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -1294,22 +1294,8 @@ int main(int argc, char *argv[])
         logerr(gl_LOGFILE, "--tpm-state must be provided\n");
         goto error;
     }
-    if (stat(tpm_state_path, &statbuf) != 0 || (statbuf.st_mode & S_IFMT) != S_IFDIR) {
-        logerr(gl_LOGFILE,
-               "User %s cannot access directory %s. Make sure it exists and is a directory.\n",
-               curr_user ? curr_user->pw_name : "<unknown>", tpm_state_path);
+    if (check_directory_access(tpm_state_path, R_OK|W_OK, curr_user) != 0)
         goto error;
-    }
-    if (access(tpm_state_path, R_OK) != 0) {
-        logerr(gl_LOGFILE, "Need read rights on directory %s for user %s.\n",
-               tpm_state_path, curr_user ? curr_user->pw_name : "<unknown>");
-        goto error;
-    }
-    if (access(tpm_state_path, W_OK) != 0) {
-        logerr(gl_LOGFILE, "Need write rights on directory %s for user %s.\n",
-               tpm_state_path, curr_user ? curr_user->pw_name : "<unknown>");
-        goto error;
-    }
 
     if (flags & SETUP_TPM2_F) {
         if (flags & SETUP_TAKEOWN_F) {

--- a/src/utils/swtpm_utils.c
+++ b/src/utils/swtpm_utils.c
@@ -417,3 +417,26 @@ gchar *str_replace(const char *in, const char *torep, const char *rep)
 
     return res;
 }
+
+int check_directory_access(const gchar *directory, int mode, const struct passwd *curr_user)
+{
+    struct stat statbuf;
+
+    if (stat(directory, &statbuf) != 0 || (statbuf.st_mode & S_IFMT) != S_IFDIR) {
+        logerr(gl_LOGFILE,
+               "User %s cannot access directory %s. Make sure it exists and is a directory.\n",
+               curr_user ? curr_user->pw_name : "<unknown>", directory);
+        return 1;
+    }
+    if ((mode & R_OK) && access(directory, R_OK) != 0) {
+        logerr(gl_LOGFILE, "Need read rights on directory %s for user %s.\n",
+               directory, curr_user ? curr_user->pw_name : "<unknown>");
+        return 1;
+    }
+    if ((mode & W_OK) && access(directory, W_OK) != 0) {
+        logerr(gl_LOGFILE, "Need write rights on directory %s for user %s.\n",
+               directory, curr_user ? curr_user->pw_name : "<unknown>");
+        return 1;
+    }
+    return 0;
+}

--- a/src/utils/swtpm_utils.h
+++ b/src/utils/swtpm_utils.h
@@ -10,6 +10,8 @@
 #ifndef SWTPM_UTILS_H
 #define SWTPM_UTILS_H
 
+#include <pwd.h>
+
 #include <glib.h>
 
 #define min(X,Y) (X) < (Y) ? (X) : (Y)
@@ -37,5 +39,7 @@ int write_file(const gchar *filename, const unsigned char *data, size_t data_len
 int write_to_tempfile(gchar **filename, const unsigned char *data, size_t data_len);
 
 gchar *str_replace(const char *in, const char *torep, const char *rep);
+
+int check_directory_access(const gchar *directory, int mode, const struct passwd *curr_user);
 
 #endif /* SWTPM_UTILS_H */

--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -43,7 +43,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # The are some variable parameters at the end, use regex
-exp='\{ "type": "swtpm_setup", "features": \[ "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", "tpm12-not-need-root"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")? \] \}'
+exp='\{ "type": "swtpm_setup", "features": \[ "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", "tpm12-not-need-root", "cmdarg-write-ek-cert-files"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")? \] \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_SETUP} to --print-capabilities:"
 	echo "Actual   : ${msg}"

--- a/tests/_test_tpm2_print_capabilities
+++ b/tests/_test_tpm2_print_capabilities
@@ -44,7 +44,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # The are some variable parameters at the end, use regex
-exp='\{ "type": "swtpm_setup", "features": \[ "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", "tpm12-not-need-root"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")? \] \}'
+exp='\{ "type": "swtpm_setup", "features": \[ "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", "tpm12-not-need-root", "cmdarg-write-ek-cert-files"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")? \] \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_SETUP} to --print-capabilities:"
 	echo "Actual   : ${msg}"

--- a/tests/test_swtpm_setup_create_cert
+++ b/tests/test_swtpm_setup_create_cert
@@ -63,7 +63,8 @@ $SWTPM_SETUP \
 	--create-ek-cert \
 	--config ${workdir}/swtpm_setup.conf \
 	--logfile ${workdir}/logfile \
-	--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}"
+	--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}" \
+	--write-ek-cert-files "${workdir}"
 
 if [ $? -ne 0 ]; then
 	echo "Error: Could not run $SWTPM_SETUP."
@@ -96,6 +97,19 @@ fi
 if [ -z "$(grep "ENCRYPTED PRIVATE KEY" ${workdir}/swtpm-localca-rootca-privkey.pem)" ]; then
 	echo "Error: Root CA's private key should be encrypted"
 	cat ${workdir}/swtpm-localca-rootca-privkey.pem
+	exit 1
+fi
+
+certfile="${workdir}/ek-rsa2048.crt"
+if [ ! -f "${certfile}" ]; then
+	echo "Error: EK file '${certfile}' was not written."
+	ls -l "${workdir}"
+	exit 1
+fi
+
+if [ -z "$($CERTTOOL --inder --infile "${certfile}" -i | grep "2048 bits")" ]; then
+	echo "Error: EK file '${certfile}' is not an RSA 2048 bit key."
+	$CERTTOOL --inder --infile "${certfile}" -i
 	exit 1
 fi
 

--- a/tests/test_tpm2_swtpm_setup_create_cert
+++ b/tests/test_tpm2_swtpm_setup_create_cert
@@ -16,6 +16,8 @@ workdir=$(mktemp -d "/tmp/path with spaces.XXXXXX")
 SIGNINGKEY=${workdir}/signingkey.pem
 ISSUERCERT=${workdir}/issuercert.pem
 CERTSERIAL=${workdir}/certserial
+USER_CERTSDIR=${workdir}/mycerts
+mkdir -p "${USER_CERTSDIR}"
 
 PATH=${TOPBUILD}/src/swtpm_bios:$PATH
 
@@ -76,7 +78,8 @@ for keysize in $(echo $keysizes); do
 		--logfile "${workdir}/logfile" \
 		--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}" \
 		--rsa-keysize ${keysize} \
-		--overwrite
+		--overwrite \
+		--write-ek-cert-files "${USER_CERTSDIR}"
 
 	if [ $? -ne 0 ]; then
 		echo "Error: Could not run $SWTPM_SETUP."
@@ -100,7 +103,20 @@ for keysize in $(echo $keysizes); do
 		exit 1
 	fi
 
-	rm -rf ${SIGNINGKEY} ${ISSUERCERT} ${CERTSERIAL}
+	certfile="${USER_CERTSDIR}/ek-rsa${keysize}.crt"
+	if [ ! -f "${certfile}" ]; then
+		echo "Error: EK file '${certfile}' was not written."
+		ls -l "${USER_CERTSDIR}"
+		exit 1
+	fi
+
+	if [ -z "$($CERTTOOL --inder --infile "${certfile}" -i | grep "${keysize} bits")" ]; then
+		echo "Error: EK file '${certfile}' is not an RSA ${keysize} bit key."
+		$CERTTOOL --inder --infile "${certfile}" -i
+		exit 1
+	fi
+
+	rm -rf "${SIGNINGKEY}" "${ISSUERCERT}" "${CERTSERIAL}" ${USER_CERTSDIR}/ek-*.crt
 done
 
 echo "Test 1: OK"
@@ -115,7 +131,8 @@ $SWTPM_SETUP \
 	--config "${workdir}/swtpm_setup.conf" \
 	--logfile "${workdir}/logfile" \
 	--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}" \
-	--overwrite
+	--overwrite \
+	--write-ek-cert-files "${workdir}"
 
 if [ $? -ne 0 ]; then
 	echo "Error: Could not run $SWTPM_SETUP."
@@ -136,6 +153,19 @@ fi
 
 if [ ! -r "${CERTSERIAL}" ]; then
 	echo "Error: Cert serial number file ${CERTSERIAL} was not created."
+	exit 1
+fi
+
+certfile="${workdir}/ek-secp384r1.crt"
+if [ ! -f "${certfile}" ]; then
+	echo "Error: EK file '${certfile}' was not written."
+	ls -l "${workdir}"
+	exit 1
+fi
+
+if [ -z "$($CERTTOOL --inder --infile "${certfile}" -i | grep "384 bits")" ]; then
+	echo "Error: EK file '${certfile}' is not an ECC 384 bit key."
+	$CERTTOOL --inder --infile "${certfile}" -i
 	exit 1
 fi
 


### PR DESCRIPTION
This PR implements an option for swptm_setup to write the created EK certificates into a directory. It addresses issue #455.