### PR TITLE
build-sys: Call autoupdate and fix some resulting issues

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,10 +23,10 @@
 #       This file is derived from tpm-tool's configure.in.
 #
 
-AC_INIT(swtpm, 0.4.3)
-AC_PREREQ(2.12)
+AC_INIT([swtpm],[0.4.3])
+AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR(Makefile.am)
-AC_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS([config.h])
 
 SWTPM_VER_MAJOR=`echo $PACKAGE_VERSION | cut -d "." -f1`
 SWTPM_VER_MINOR=`echo $PACKAGE_VERSION | cut -d "." -f2`
@@ -50,7 +50,7 @@ AM_SILENT_RULES([yes])
 
 DEBUG=""
 AC_MSG_CHECKING([for debug-enabled build])
-AC_ARG_ENABLE(debug, AC_HELP_STRING([--enable-debug], [create a debug build]),
+AC_ARG_ENABLE(debug, AS_HELP_STRING([--enable-debug],[create a debug build]),
   [if test "$enableval" = "yes"; then
      DEBUG="yes"
      AC_MSG_RESULT([yes])
@@ -73,12 +73,10 @@ elif test "$DEBUG" = "yes"; then
 	CFLAGS="$CFLAGS -O0 -g -DDEBUG"
 fi
 
-AC_HEADER_STDC
 AC_C_CONST
 AC_C_INLINE
 
 AC_TYPE_SIZE_T
-AC_TYPE_SIGNAL
 
 AC_PROG_CC
 AC_PROG_INSTALL
@@ -200,8 +198,7 @@ esac
 
 AC_MSG_CHECKING([for whether to build with CUSE interface])
 AC_ARG_WITH([cuse],
-            AC_HELP_STRING([--with-cuse],
-                           [build with CUSE interface]),
+            AS_HELP_STRING([--with-cuse],[build with CUSE interface]),
             [],
             [with_cuse=check]
 )
@@ -265,8 +262,7 @@ AM_CONDITIONAL([WITH_CHARDEV],[test "$with_chardev" = "yes"])
 AC_MSG_RESULT($with_cuse)
 
 AC_ARG_WITH([gnutls],
-            AC_HELP_STRING([--with-gnutls],
-                           [build with gnutls library]),
+            AS_HELP_STRING([--with-gnutls],[build with gnutls library]),
             [],
             [with_gnutls=check]
 )
@@ -428,15 +424,13 @@ if test "x$enable_test_coverage" = "xyes"; then
 fi
 
 AC_ARG_WITH([tss-user],
-            AC_HELP_STRING([--with-tss-user=TSS_USER],
-                           [The tss user to use]),
+            AS_HELP_STRING([--with-tss-user=TSS_USER],[The tss user to use]),
             [TSS_USER="$withval"],
             [TSS_USER="tss"]
 )
 
 AC_ARG_WITH([tss-group],
-            AC_HELP_STRING([--with-tss-group=TSS_GROUP],
-                           [The tss group to use]),
+            AS_HELP_STRING([--with-tss-group=TSS_GROUP],[The tss group to use]),
             [TSS_GROUP="$withval"],
             [TSS_GROUP="tss"]
 )
@@ -515,8 +509,7 @@ esac
 
 AC_MSG_CHECKING([for whether to build with seccomp profile])
 AC_ARG_WITH([seccomp],
-  AC_HELP_STRING([--with-seccomp],
-                 [build with seccomp profile]),
+  AS_HELP_STRING([--with-seccomp],[build with seccomp profile]),
   AC_MSG_RESULT([$with_seccomp]),
   [with_seccomp=$with_seccomp_default]
   AC_MSG_RESULT([$with_seccomp])


### PR DESCRIPTION
autoreconf from autoconf 2.71 emmits a lot of warnings:
```
+ autoreconf -fiv
autoreconf: export WARNINGS=
autoreconf: Entering directory '.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
autoreconf: configure.ac: tracing
autoreconf: running: libtoolize --copy --force
libtoolize: putting auxiliary files in '.'.
libtoolize: copying file './ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
autoreconf: configure.ac: not using Intltool
autoreconf: configure.ac: not using Gtkdoc
autoreconf: running: aclocal --force -I m4
autoreconf: running: /usr/bin/autoconf --force
configure.ac:29: warning: The macro `AC_CONFIG_HEADER' is obsolete.
configure.ac:29: You should run autoupdate.
./lib/autoconf/status.m4:719: AC_CONFIG_HEADER is expanded from...
configure.ac:29: the top level
configure.ac:53: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:53: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
configure.ac:53: the top level
configure.ac:76: warning: The macro `AC_HEADER_STDC' is obsolete.
configure.ac:76: You should run autoupdate.
./lib/autoconf/headers.m4:704: AC_HEADER_STDC is expanded from...
configure.ac:76: the top level
configure.ac:81: warning: The macro `AC_TYPE_SIGNAL' is obsolete.
configure.ac:81: You should run autoupdate.
./lib/autoconf/types.m4:776: AC_TYPE_SIGNAL is expanded from...
configure.ac:81: the top level
configure.ac:202: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:202: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
configure.ac:202: the top level
configure.ac:267: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:267: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
configure.ac:267: the top level
configure.ac:430: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:430: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
configure.ac:430: the top level
configure.ac:437: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:437: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
configure.ac:437: the top level
configure.ac:517: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:517: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
configure.ac:517: the top level
autoreconf: running: /usr/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:40: installing './compile'
configure.ac:48: installing './missing'
Makefile.am:34: warning: .PHONY was already defined in condition WITH_SELINUX, which is included in condition TRUE ...
Makefile.am:28: ... '.PHONY' previously defined here
src/swtpm/Makefile.am: installing './depcomp'
autoreconf: './config.sub' is updated
autoreconf: './config.guess' is updated
autoreconf: Leaving directory '.'
```
Execute autoupdate to apply all those changes.

Signed-off-by: Tomasz Kłoczko <kloczek@github.com>
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>