### PR TITLE
samples: Replace swtpm_localca with script calling swtpm-localca (iss…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ Makefile
 /man/man3/*.3
 /man/man8/*.8
 /samples/swtpm-create-user-config-files
+/samples/swtpm_localca
 /samples/swtpm-localca
 /samples/swtpm-localca.conf
 /samples/swtpm_localca_conf.h

--- a/configure.ac
+++ b/configure.ac
@@ -125,12 +125,17 @@ fi
 if test "x$prefix" = "xNONE"; then
 	prefix="/usr/local"
 fi
+if test "x$exec_prefix" = "xNONE"; then
+	exec_prefix=$prefix
+fi
 SYSCONFDIR=`eval echo $sysconfdir`
 DATAROOTDIR=`eval echo $datarootdir`
 LOCALSTATEDIR=`eval echo $localstatedir`
+BINDIR=`eval echo $bindir`
 AC_SUBST([SYSCONFDIR])
 AC_SUBST([DATAROOTDIR])
 AC_SUBST([LOCALSTATEDIR])
+AC_SUBST([BINDIR])
 
 cryptolib=openssl
 
@@ -559,6 +564,8 @@ AC_CONFIG_FILES([Makefile                   \
 		tests/Makefile              \
 		tests/test_config           \
 		])
+AC_CONFIG_FILES([samples/swtpm-localca],
+                [chmod 755 samples/swtpm-localca])
 AC_OUTPUT
 
 echo

--- a/debian/swtpm-tools.install
+++ b/debian/swtpm-tools.install
@@ -3,6 +3,7 @@ cat <<_EOF_
 /usr/bin/swtpm_bios
 /usr/bin/swtpm_setup
 /usr/bin/swtpm_ioctl
+/usr/bin/swtpm_localca
 /usr/share/man/man8/swtpm_bios.8*
 /usr/share/man/man8/swtpm_cert.8*
 /usr/share/man/man8/swtpm_ioctl.8*

--- a/samples/Makefile.am
+++ b/samples/Makefile.am
@@ -6,12 +6,11 @@
 
 samplesconfdir = $(datadir)/@PACKAGE@
 samplessysconfdir = $(sysconfdir)
-# swtpm-localca was always installed in /usr/samples/swtpm-localca
-bindir = $(samplesconfdir)
 
 samplesconf_SCRIPTS = \
 	swtpm-create-tpmca \
-	swtpm-create-user-config-files
+	swtpm-create-user-config-files \
+	swtpm-localca
 
 samplessysconf_DATA = \
 	swtpm-localca.conf \
@@ -22,7 +21,7 @@ noinst_HEADERS = \
 	swtpm_localca_utils.h
 
 bin_PROGRAMS = \
-	swtpm-localca
+	swtpm_localca
 
 $(top_builddir)/src/utils/libswtpm_utils.la:
 	$(MAKE) -C$(dir $@)

--- a/samples/swtpm-localca.in
+++ b/samples/swtpm-localca.in
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+swtpm_localca_exe="$(dirname "$0")/swtpm_localca"
+if ! [ -x "$swtpm_localca_exe" ]; then
+  swtpm_localca_exe=@BINDIR@/swtpm_localca
+fi
+
+$swtpm_localca_exe "$@"
+
+exit $?

--- a/swtpm.spec
+++ b/swtpm.spec
@@ -150,6 +150,7 @@ fi
 %endif
 %{_bindir}/swtpm_setup
 %{_bindir}/swtpm_ioctl
+%{_bindir}/swtpm_localca
 %{_mandir}/man8/swtpm_bios.8*
 %{_mandir}/man8/swtpm_cert.8*
 %{_mandir}/man8/swtpm_ioctl.8*

--- a/swtpm.spec.in
+++ b/swtpm.spec.in
@@ -150,6 +150,7 @@ fi
 %endif
 %{_bindir}/swtpm_setup
 %{_bindir}/swtpm_ioctl
+%{_bindir}/swtpm_localca
 %{_mandir}/man8/swtpm_bios.8*
 %{_mandir}/man8/swtpm_cert.8*
 %{_mandir}/man8/swtpm_ioctl.8*


### PR DESCRIPTION
…ue #482)

Replace the binary swtpm_localca with a script that now calls the binary
swtpm-localca, which is to be installed in $bindir.

So that we can use this for script for calling swtpm-localca during testing
(when it is not installed), write the script in such a way that it de-
termines whether there's swtpm-localca in the same directory and if not call
it from ${bindir}/swtpm-localca.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>