### PR TITLE
samples: Use different script for local testing than install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ Makefile
 /samples/swtpm-create-user-config-files
 /samples/swtpm_localca
 /samples/swtpm-localca
+/samples/swtpm-localca.2inst
 /samples/swtpm-localca.conf
 /samples/swtpm_localca_conf.h
 /src/selinux/*.pp.bz2

--- a/configure.ac
+++ b/configure.ac
@@ -543,6 +543,7 @@ AC_CONFIG_FILES([Makefile                   \
 		etc/Makefile                \
 		etc/swtpm_setup.conf        \
 		samples/Makefile            \
+		samples/swtpm-localca.2inst \
 		samples/swtpm-localca.conf  \
 		samples/swtpm-create-user-config-files \
 		samples/swtpm_localca_conf.h \

--- a/samples/Makefile.am
+++ b/samples/Makefile.am
@@ -9,8 +9,7 @@ samplessysconfdir = $(sysconfdir)
 
 samplesconf_SCRIPTS = \
 	swtpm-create-tpmca \
-	swtpm-create-user-config-files \
-	swtpm-localca
+	swtpm-create-user-config-files
 
 samplessysconf_DATA = \
 	swtpm-localca.conf \
@@ -52,6 +51,13 @@ install-data-local:
 		chown -R @TSS_USER@:root $(DESTDIR)$(localstatedir)/lib/swtpm-localca || true; \
 		chmod 0750 $(DESTDIR)$(localstatedir)/lib/swtpm-localca || true; \
 	fi
+
+install-exec-local:
+	$(MKDIR_P) $(DESTDIR)$(samplesconfdir)
+	$(INSTALL_SCRIPT) swtpm-localca.2inst $(DESTDIR)$(samplesconfdir)/swtpm-localca
+
+uninstall-local:
+	rm -f $(DESTDIR)$(samplesconfdir)/swtpm-localca
 
 EXTRA_DIST= \
 	swtpm-create-tpmca \

--- a/samples/swtpm-localca.2inst.in
+++ b/samples/swtpm-localca.2inst.in
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+@BINDIR@/swtpm_localca "$@"
+
+exit $?


### PR DESCRIPTION
Use a different script for local testing that what is installed into
/usr/share/swtpm/swtpm-localca.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>