### PR TITLE
Improvements to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 *.la
 *.lo
 *.o
-*.patch
 *~
 .deps
 .libs
@@ -67,6 +66,7 @@ tests/*.trs
 tests/test_config
 /debian/*debhelper*
 /debian/*substvars
+/debian/autoreconf.*
 /debian/files
 /debian/swtpm
 /debian/swtpm-cuse


### PR DESCRIPTION
- Add auto-generated files `debian/autoreconf.*`
- Remove `*.patch` (Quilt requires these under `debian/patches/`)

Avoids the following untracked files after a build:
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        debian/autoreconf.after
        debian/autoreconf.before
```