### PR TITLE
Add missing title to swtpm-create-tpmca(8) manual page

### DIFF
--- a/man/man8/swtpm-create-tpmca.pod
+++ b/man/man8/swtpm-create-tpmca.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-swtpm-create-tpmca
+swtpm-create-tpmca - Tool to create a local CA for swtpm-localca
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
Fixes [bad-whatis-entry](https://lintian.debian.org/tags/bad-whatis-entry) Lintian warning.