### PR TITLE
Correct old reference to swtpm_setup.sh in manpage

### DIFF
--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -17,7 +17,7 @@ The following options are supported:
 
 =item B<--runas <userid>>
 
-Use this userid to run swtpm_setup.sh as. Only 'root' can use this option.
+Use this userid to run swtpm_setup as. Only 'root' can use this option.
 
 =item B<--config <file>>
 


### PR DESCRIPTION
`swtpm_setup.sh(8)` was replaced by `swtpm_setup(8)` in v0.5.0.