### PR TITLE
Remove swtpm.spec from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ Makefile
 /missing
 /stamp-h1
 /swtpm-*.tar.gz
-/swtpm.spec
 /m4/*
 /.pc/*
 /etc/swtpm_setup.conf


### PR DESCRIPTION
Since this file is [meant to be versioned](https://github.com/stefanberger/swtpm/pull/496#issuecomment-884432135), it should not be in `.gitignore`.