### PR TITLE
Debian packaging improvements

### DIFF
--- a/debian/clean
+++ b/debian/clean
@@ -1,0 +1,3 @@
+include/swtpm/*.gch
+man/*/*.3
+man/*/*.8

--- a/debian/control
+++ b/debian/control
@@ -2,50 +2,35 @@ Source: swtpm
 Maintainer: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Section: misc
 Priority: optional
-Build-Depends: automake,
-	       autoconf,
-	       libtool,
-	       debhelper (>= 9),
-	       libtpms-dev,
-	       libfuse-dev,
-	       libglib2.0-dev,
-	       libjson-glib-dev,
-	       libgmp-dev,
-	       expect,
-	       libtasn1-dev,
-	       socat,
-	       python3-twisted,
-	       gnutls-dev,
-	       gnutls-bin,
-	       libssl-dev,
-	       net-tools,
-	       gawk,
-	       softhsm2,
-	       libseccomp-dev
-# linux-image-extra
+Standards-Version: 4.5.1
+Rules-Requires-Root: no
+Build-Depends: debhelper (>= 10),
+               expect,
+               gawk,
+               gnutls-bin,
+               gnutls-dev,
+               libfuse-dev,
+               libglib2.0-dev,
+               libgmp-dev,
+               libjson-glib-dev,
+               libseccomp-dev,
+               libssl-dev,
+               libtasn1-dev,
+               libtool,
+               libtpms-dev,
+               net-tools,
+               python3-twisted,
+               socat,
+               softhsm2
 
 Package: swtpm
 Architecture: any
 Depends: swtpm-libs (= ${binary:Version}),
-	 ${shlibs:Depends},
-	 ${misc:Depends}
-# linux-image-extra
+         ${misc:Depends},
+         ${shlibs:Depends}
 Description: Libtpms-based TPM emulator
  The swtpm package provides TPM emulators that listen for TPM commands
  on sockets, character devices, or CUSE devices.
-
-Package: swtpm-libs
-Architecture: any
-Multi-Arch: same
-Depends: openssl,
-	 libtpms0,
-	 libglib2.0-0,
-	 ${shlibs:Depends},
-	 ${misc:Pre-Depends},
-	 ${misc:Depends}
-Description: Common libraries for TPM emulators
- The swtpm-libs package provides the shared libraries for the swtpm
- and swtpm-cuse packages.
 
 Package: swtpm-dev
 Architecture: any
@@ -53,6 +38,19 @@ Depends: ${misc:Depends}
 Description: Include files for the TPM emulator's CUSE interface
  The swtpm-dev package provides include files for developing clients
  controlling the CUSE TPM through ioctls.
+
+Package: swtpm-libs
+Architecture: any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends: libglib2.0-0,
+         libtpms0,
+         openssl,
+         ${misc:Depends},
+         ${shlibs:Depends}
+Description: Common libraries for TPM emulators
+ The swtpm-libs package provides the shared libraries for the swtpm
+ and swtpm-cuse packages.
 
 Package: swtpm-tools
 Architecture: any
@@ -64,8 +62,8 @@ Description: Tools for the TPM emulator
       tool basically simulates TPM manufacturing where certificates are
       written into the NVRAM of the TPM
   - swtpm_cert: Creation of certificates for the TPM (x509)
-Depends: swtpm (= ${binary:Version}),
-	 trousers (>= 0.3.9),
-	 ${shlibs:Depends},
-	 ${misc:Depends},
-	 gnutls-bin
+Depends: gnutls-bin,
+         swtpm (= ${binary:Version}),
+         trousers (>= 0.3.9),
+         ${misc:Depends},
+         ${shlibs:Depends}

--- a/debian/not-installed
+++ b/debian/not-installed
@@ -1,0 +1,1 @@
+/usr/lib/*/swtpm/*.la

--- a/debian/rules
+++ b/debian/rules
@@ -1,13 +1,14 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --parallel
+	dh $@
 
 override_dh_auto_configure:
 	NOCONFIGURE=1 ./autogen.sh
 	dh_auto_configure -- --with-openssl --with-gnutls --without-cuse
 
-override_dh_usrlocal:
-
 override_dh_auto_test:
 	SWTPM_TEST_SECCOMP_OPT="--seccomp action=none" make -j4 check VERBOSE=1
+
+override_dh_makeshlibs:
+	dh_makeshlibs --no-scripts

--- a/debian/swtpm-dev.install
+++ b/debian/swtpm-dev.install
@@ -1,3 +1,4 @@
-/usr/lib/*/swtpm/*.so
 /usr/include/swtpm/tpm_ioctl.h
+/usr/lib/*/swtpm/*.a
+/usr/lib/*/swtpm/*.so
 /usr/share/man/man3/swtpm_ioctls.3

--- a/debian/swtpm-libs.install
+++ b/debian/swtpm-libs.install
@@ -1,2 +1,1 @@
-#! /usr/bin/dh-exec
 /usr/lib/*/swtpm/*.so.*

--- a/debian/swtpm-tools.install
+++ b/debian/swtpm-tools.install
@@ -1,22 +1,24 @@
 #!/bin/sh
 cat <<_EOF_
-/usr/bin/swtpm_bios
-/usr/bin/swtpm_setup
-/usr/bin/swtpm_ioctl
-/usr/bin/swtpm_localca
-/usr/share/man/man8/swtpm_bios.8*
-/usr/share/man/man8/swtpm_cert.8*
-/usr/share/man/man8/swtpm_ioctl.8*
-/usr/share/man/man8/swtpm-localca.conf.8*
-/usr/share/man/man8/swtpm-localca.options.8*
-/usr/share/man/man8/swtpm-localca.8*
-/usr/share/man/man8/swtpm_setup.8*
-/usr/share/man/man8/swtpm_setup.conf.8*
-/usr/share/swtpm/swtpm-localca
-/usr/share/swtpm/swtpm-create-user-config-files
 /etc/swtpm-localca.conf
 /etc/swtpm-localca.options
 /etc/swtpm_setup.conf
+/usr/bin/swtpm_bios
+/usr/bin/swtpm_ioctl
+/usr/bin/swtpm_localca
+/usr/bin/swtpm_setup
+/usr/share/man/man8/swtpm-create-tpmca.8*
+/usr/share/man/man8/swtpm-localca.8*
+/usr/share/man/man8/swtpm-localca.conf.8*
+/usr/share/man/man8/swtpm-localca.options.8*
+/usr/share/man/man8/swtpm_bios.8*
+/usr/share/man/man8/swtpm_cert.8*
+/usr/share/man/man8/swtpm_ioctl.8*
+/usr/share/man/man8/swtpm_setup.8*
+/usr/share/man/man8/swtpm_setup.conf.8*
+/usr/share/swtpm/swtpm-create-tpmca
+/usr/share/swtpm/swtpm-create-user-config-files
+/usr/share/swtpm/swtpm-localca
 _EOF_
 if test -n "$(find $(dirname "$0")/tmp -name swtpm_cert)"; then
 echo "/usr/bin/swtpm_cert"

--- a/debian/swtpm-tools.postinst.in
+++ b/debian/swtpm-tools.postinst.in
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 SWTPM_LOCALCA_DIR=@LOCALSTATEDIR@/lib/swtpm-localca
 
 if ! [ -d $SWTPM_LOCALCA_DIR ]; then

--- a/debian/swtpm.install
+++ b/debian/swtpm.install
@@ -1,3 +1,2 @@
-#! /usr/bin/dh-exec
 /usr/bin/swtpm
 /usr/share/man/man8/swtpm.8*


### PR DESCRIPTION
- debian/clean: Add files that were not being automatically cleaned
  up by dh(1)'s `clean` target.
- debian/control:
  - Add new recommended/required fields and bump Standards-Version.
  - Remove redundant build dependencies that are implied transitively.
  - Bump debhelper dependency version to match debian/compat.
  - Move swtpm-libs's ${misc:Pre-Depends} dependency to `Pre-Depends`.
    Resolves `depends-on-misc-pre-depends` Lintian warning.
  - Sort packages and dependency lists alphabetically as per
    wrap-and-sort(1).
- debian/not-installed: List deliberately non-installed files to
  avoid dh_missing(1) warnings.
- debian/rules:
  - Pass --no-scripts to dh_makeshlibs(1) in order to keep a
    ldconfig(8) trigger from being implicitly added, which for
    this package was redundant and triggered Lintian warning
    `package-has-unnecessary-activation-of-ldconfig-trigger`.
  - Remove redundant --parallel dh flag.
  - Remove redundant dh_usrlocal override.
- debian/*.install:
  - Add swtpm-create-tpmca(8) and its manpage, which were missing.
  - Remove redundant `#! /usr/bin/dh-exec` lines.
  - Sort entries alphabetically as per wrap-and-sort(1).
- debian/swtpm-tools.postinst.in: Add `set -e` to fail in case of
  error. Fixes `maintainer-script-ignores-errors` Lintian warning.

Signed-off-by: Nick Chevsky <nchevsky@users.noreply.github.com>