### PR TITLE
Allow passing CFLAG and LDFLAGS during configure and build time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -537,6 +537,11 @@ if test "$with_seccomp" != "no"; then
                      [whether to build in seccomp profile (Linux only)])
 fi
 
+AM_CFLAGS="$CFLAGS"
+AM_LDFLAGS="$LDFLAGS"
+AC_SUBST([AM_CFLAGS])
+AC_SUBST([AM_LDFLAGS])
+
 AC_CONFIG_FILES([Makefile                   \
 		debian/swtpm-tools.postinst \
 		swtpm.spec                  \

--- a/configure.ac
+++ b/configure.ac
@@ -579,10 +579,10 @@ echo
 echo "Version to build  : $PACKAGE_VERSION"
 echo "Crypto library    : $cryptolib"
 echo
-echo "           CFLAGS = $CFLAGS"
+echo "        AM_CFLAGS = $AM_CFLAGS"
 echo " HARDENING_CFLAGS = $HARDENING_CFLAGS"
 echo "HARDENING_LDFLAGS = $HARDENING_LDFLAGS"
-echo "          LDFLAGS = $LDFLAGS"
+echo "       AM_LDFLAGS = $AM_LDFLAGS"
 echo "  LIBSECCOMP_LIBS = $LIBSECCOMP_LIBS"
 echo " JSON_GLIB_CFLAGS = $JSON_GLIB_CFLAGS"
 echo "   JSON_GLIB_LIBS = $JSON_GLIB_LIBS"

--- a/configure.ac
+++ b/configure.ac
@@ -537,10 +537,10 @@ if test "$with_seccomp" != "no"; then
                      [whether to build in seccomp profile (Linux only)])
 fi
 
-AM_CFLAGS="$CFLAGS"
-AM_LDFLAGS="$LDFLAGS"
-AC_SUBST([AM_CFLAGS])
-AC_SUBST([AM_LDFLAGS])
+MY_CFLAGS="$CFLAGS"
+MY_LDFLAGS="$LDFLAGS"
+AC_SUBST([MY_CFLAGS])
+AC_SUBST([MY_LDFLAGS])
 
 AC_CONFIG_FILES([Makefile                   \
 		debian/swtpm-tools.postinst \
@@ -584,10 +584,10 @@ echo
 echo "Version to build  : $PACKAGE_VERSION"
 echo "Crypto library    : $cryptolib"
 echo
-echo "        AM_CFLAGS = $AM_CFLAGS"
+echo "        MY_CFLAGS = $MY_CFLAGS"
 echo " HARDENING_CFLAGS = $HARDENING_CFLAGS"
 echo "HARDENING_LDFLAGS = $HARDENING_LDFLAGS"
-echo "       AM_LDFLAGS = $AM_LDFLAGS"
+echo "       MY_LDFLAGS = $MY_LDFLAGS"
 echo "  LIBSECCOMP_LIBS = $LIBSECCOMP_LIBS"
 echo " JSON_GLIB_CFLAGS = $JSON_GLIB_CFLAGS"
 echo "   JSON_GLIB_LIBS = $JSON_GLIB_LIBS"

--- a/src/swtpm/Makefile.am
+++ b/src/swtpm/Makefile.am
@@ -4,6 +4,9 @@
 # For the license, see the COPYING file in the root directory.
 #
 
+AM_CFLAGS = @AM_CFLAGS@
+AM_LDFLAGS = @AM_LDFLAGS@
+
 noinst_HEADERS = \
 	capabilities.h \
 	common.h \
@@ -61,11 +64,13 @@ libswtpm_libtpms_la_CFLAGS = \
 	-I$(top_builddir)/include \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/include/swtpm \
+	$(AM_CFLAGS) \
 	$(HARDENING_CFLAGS) \
 	$(GLIB_CFLAGS) \
 	$(LIBSECCOMP_CFLAGS)
 
 libswtpm_libtpms_la_LDFLAGS = \
+	$(AM_LDFLAGS) \
 	$(HARDENING_LDFLAGS)
 
 libswtpm_libtpms_la_LIBADD = \
@@ -95,12 +100,14 @@ swtpm_CFLAGS = \
 	-I$(top_builddir)/include \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/include/swtpm \
+	$(AM_CFLAGS) \
 	$(HARDENING_CFLAGS) \
 	$(GLIB_CFLAGS) \
 	$(LIBFUSE_CFLAGS) \
 	-DHAVE_SWTPM_CUSE_MAIN
 
 swtpm_LDFLAGS = \
+	$(AM_LDFLAGS) \
 	$(HARDENING_LDFLAGS)
 
 swtpm_LDADD = \
@@ -119,11 +126,13 @@ swtpm_cuse_CFLAGS = \
 	-I$(top_builddir)/include \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/include/swtpm \
+	$(AM_CFLAGS) \
 	$(GLIB_CFLAGS) \
 	$(LIBFUSE_CFLAGS) \
 	$(HARDENING_CFLAGS)
 
 swtpm_cuse_LDFLAGS = \
+	$(AM_LDFLAGS) \
 	$(HARDENING_LDFLAGS)
 
 swtpm_cuse_LDADD = \

--- a/src/swtpm/Makefile.am
+++ b/src/swtpm/Makefile.am
@@ -65,6 +65,7 @@ libswtpm_libtpms_la_CFLAGS = \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/include/swtpm \
 	$(MY_CFLAGS) \
+	$(CFLAGS) \
 	$(HARDENING_CFLAGS) \
 	$(GLIB_CFLAGS) \
 	$(LIBSECCOMP_CFLAGS)

--- a/src/swtpm/Makefile.am
+++ b/src/swtpm/Makefile.am
@@ -4,8 +4,8 @@
 # For the license, see the COPYING file in the root directory.
 #
 
-AM_CFLAGS = @AM_CFLAGS@
-AM_LDFLAGS = @AM_LDFLAGS@
+MY_CFLAGS = @MY_CFLAGS@
+MY_LDFLAGS = @MY_LDFLAGS@
 
 noinst_HEADERS = \
 	capabilities.h \
@@ -64,13 +64,13 @@ libswtpm_libtpms_la_CFLAGS = \
 	-I$(top_builddir)/include \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/include/swtpm \
-	$(AM_CFLAGS) \
+	$(MY_CFLAGS) \
 	$(HARDENING_CFLAGS) \
 	$(GLIB_CFLAGS) \
 	$(LIBSECCOMP_CFLAGS)
 
 libswtpm_libtpms_la_LDFLAGS = \
-	$(AM_LDFLAGS) \
+	$(MY_LDFLAGS) \
 	$(HARDENING_LDFLAGS)
 
 libswtpm_libtpms_la_LIBADD = \
@@ -100,14 +100,14 @@ swtpm_CFLAGS = \
 	-I$(top_builddir)/include \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/include/swtpm \
-	$(AM_CFLAGS) \
+	$(MY_CFLAGS) \
 	$(HARDENING_CFLAGS) \
 	$(GLIB_CFLAGS) \
 	$(LIBFUSE_CFLAGS) \
 	-DHAVE_SWTPM_CUSE_MAIN
 
 swtpm_LDFLAGS = \
-	$(AM_LDFLAGS) \
+	$(MY_LDFLAGS) \
 	$(HARDENING_LDFLAGS)
 
 swtpm_LDADD = \
@@ -126,13 +126,13 @@ swtpm_cuse_CFLAGS = \
 	-I$(top_builddir)/include \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/include/swtpm \
-	$(AM_CFLAGS) \
+	$(MY_CFLAGS) \
 	$(GLIB_CFLAGS) \
 	$(LIBFUSE_CFLAGS) \
 	$(HARDENING_CFLAGS)
 
 swtpm_cuse_LDFLAGS = \
-	$(AM_LDFLAGS) \
+	$(MY_LDFLAGS) \
 	$(HARDENING_LDFLAGS)
 
 swtpm_cuse_LDADD = \

--- a/src/swtpm_bios/Makefile.am
+++ b/src/swtpm_bios/Makefile.am
@@ -4,6 +4,9 @@
 # For the license, see the LICENSE file in the root directory.
 #
 
+MY_CFLAGS = @MY_CFLAGS@
+MY_LDFLAGS = @MY_LDFLAGS@
+
 noinst_HEADERS = \
 	tpm_bios.h
 
@@ -13,9 +16,12 @@ bin_PROGRAMS = \
 swtpm_bios_CFLAGS = \
 	-I$(top_builddir)/include \
 	-I$(top_srcdir)/include \
+	$(MY_CFLAGS) \
+	$(CFLAGS) \
 	$(HARDENING_CFLAGS)
 
 swtpm_bios_LDFLAGS = \
+	$(MY_LDFLAGS) \
 	$(HARDENING_LDFLAGS)
 
 swtpm_bios_SOURCES = tpm_bios.c

--- a/src/swtpm_cert/Makefile.am
+++ b/src/swtpm_cert/Makefile.am
@@ -4,6 +4,9 @@
 # For the license, see the LICENSE file in the root directory.
 #
 
+MY_CFLAGS = @MY_CFLAGS@
+MY_LDFLAGS = @MY_LDFLAGS@
+
 noinst_HEADERS =
 
 bin_PROGRAMS =
@@ -18,7 +21,13 @@ swtpm_cert_SOURCES = \
 
 swtpm_cert_CFLAGS = \
 	-I$(top_builddir)/include \
-	-I$(top_srcdir)/include
+	-I$(top_srcdir)/include \
+	$(MY_CFLAGS) \
+	$(CFLAGS)
+
+swtpm_cert_LDFLAGS = \
+	$(MY_LDFLAGS) \
+	$(HARDENING_LDFLAGS)
 
 ek-cert.o : tpm_asn1.h
 

--- a/src/swtpm_ioctl/Makefile.am
+++ b/src/swtpm_ioctl/Makefile.am
@@ -4,6 +4,9 @@
 # For the license, see the LICENSE file in the root directory.
 #
 
+MY_CFLAGS = @MY_CFLAGS@
+MY_LDFLAGS = @MY_LDFLAGS@
+
 noinst_HEADERS =
 
 bin_PROGRAMS = \
@@ -14,9 +17,12 @@ swtpm_ioctl_SOURCES = tpm_ioctl.c
 swtpm_ioctl_CFLAGS = \
 	-I$(top_builddir)/include \
 	-I$(top_srcdir)/include \
+	$(MY_CFLAGS) \
+	$(CFLAGS) \
 	$(HARDENING_CFLAGS)
 
 swtpm_ioctl_LDFLAGS = \
+	$(MY_LDFLAGS) \
 	$(HARDENING_LDFLAGS)
 
 EXTRA_DIST = \

--- a/src/swtpm_localca/Makefile.am
+++ b/src/swtpm_localca/Makefile.am
@@ -4,6 +4,9 @@
 # For the license, see the LICENSE file in the root directory.
 #
 
+MY_CFLAGS = @MY_CFLAGS@
+MY_LDFLAGS = @MY_LDFLAGS@
+
 bin_PROGRAMS = \
 	swtpm_localca
 
@@ -13,6 +16,8 @@ noinst_HEADERS = \
 
 swtpm_localca_CFLAGS = \
 	-I$(top_srcdir)/src/utils \
+	$(MY_CFLAGS) \
+	$(CFLAGS) \
 	$(GLIB_CFLAGS) \
 	$(HARDENING_CFLAGS)
 
@@ -24,6 +29,7 @@ swtpm_localca_LDADD = \
 
 swtpm_localca_LDFLAGS = \
 	-L$(top_builddir)/src/utils -lswtpm_utils \
+	$(MY_LDFLAGS) \
 	$(GLIB_LIBS) \
 	$(HARDENING_LDFLAGS)
 

--- a/src/swtpm_setup/Makefile.am
+++ b/src/swtpm_setup/Makefile.am
@@ -4,6 +4,9 @@
 # For the license, see the LICENSE file in the root directory.
 #
 
+MY_CFLAGS = @MY_CFLAGS@
+MY_LDFLAGS = @MY_LDFLAGS@
+
 noinst_HEADERS = \
 	swtpm.h \
 	swtpm_setup.h \
@@ -28,6 +31,7 @@ swtpm_setup_LDADD = \
 
 swtpm_setup_LDFLAGS = \
 	-L$(top_builddir)/src/utils -lswtpm_utils \
+	$(MY_LDFLAGS) \
 	$(HARDENING_LDFLAGS) \
 	$(GLIB_LIBS) \
 	$(JSON_GLIB_LIBS) \
@@ -38,6 +42,8 @@ swtpm_setup_CFLAGS = \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/include/swtpm \
 	-I$(top_srcdir)/src/utils \
+	$(MY_CFLAGS) \
+	$(CFLAGS) \
 	$(HARDENING_CFLAGS) \
 	$(GLIB_CFLAGS) \
 	$(JSON_GLIB_CFLAGS)

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -4,6 +4,9 @@
 # For the license, see the COPYING file in the root directory.
 #
 
+MY_CFLAGS = @MY_CFLAGS@
+MY_LDFLAGS = @MY_LDFLAGS@
+
 noinst_HEADERS = \
 	swtpm_utils.h
 
@@ -11,10 +14,13 @@ noinst_LTLIBRARIES = \
 	libswtpm_utils.la
 
 libswtpm_utils_la_CFLAGS = \
+	$(MY_CFLAGS) \
+	$(CFLAGS) \
 	$(HARDENING_CFLAGS) \
 	$(GLIB_CFLAGS)
 
 libswtpm_utils_la_LDFLAGS = \
+	$(MY_LDFLAGS) \
 	$(HARDENING_LDFLAGS)
 
 libswtpm_utils_la_SOURCES = \


### PR DESCRIPTION
This PR enables us to pass CFLAGS and LDFLAGS during configure time. It then also allows us to pass CFLAGS and LDFLAGS (was working already) again during build-time as additional flags like this (using eye-catchers):

configure time:

```
CFLAGS="-Werror -Werror -Werror -Werror" LDFLAGS="-lc -lc -lc -lc" ./configure --prefix=/usr
```

build time:

```
make V=1 CFLAGS="-Wextra -Wextra -Wextra -Wextra" LDFLAGS="-lm -lgnutls-dane" 2>&1 | tee make.log
```