### PR TITLE
Change swtpm-localca to swtpm_localca in manpages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ Makefile
 /include/swtpm.h
 /man/man3/*.3
 /man/man8/*.8
+!/man/man8/swtpm-localca.8
 /samples/swtpm-create-user-config-files
 /samples/swtpm-localca
 /samples/swtpm-localca.conf

--- a/debian/rules
+++ b/debian/rules
@@ -10,5 +10,8 @@ override_dh_auto_configure:
 override_dh_auto_test:
 	SWTPM_TEST_SECCOMP_OPT="--seccomp action=none" make -j4 check VERBOSE=1
 
+override_dh_clean:
+	dh_clean --exclude=man/man8/swtpm-localca.8
+
 override_dh_makeshlibs:
 	dh_makeshlibs --no-scripts

--- a/debian/swtpm-tools.install
+++ b/debian/swtpm-tools.install
@@ -14,6 +14,7 @@ cat <<_EOF_
 /usr/share/man/man8/swtpm_bios.8*
 /usr/share/man/man8/swtpm_cert.8*
 /usr/share/man/man8/swtpm_ioctl.8*
+/usr/share/man/man8/swtpm_localca.8*
 /usr/share/man/man8/swtpm_setup.8*
 /usr/share/man/man8/swtpm_setup.conf.8*
 /usr/share/swtpm/swtpm-create-tpmca

--- a/man/man8/Makefile.am
+++ b/man/man8/Makefile.am
@@ -11,29 +11,36 @@ man8_PODS = \
 	swtpm_cert.pod \
 	swtpm_cuse.pod \
 	swtpm_ioctl.pod \
+	swtpm_localca.pod \
 	swtpm_setup.pod \
 	swtpm_setup.conf.pod \
 	swtpm-create-tpmca.pod \
-	swtpm-localca.pod \
 	swtpm-localca.options.pod \
 	swtpm-localca.conf.pod
 
-man8_MANS = \
+man8_generated_MANS = \
 	swtpm.8 \
 	swtpm_bios.8 \
 	swtpm_cert.8 \
 	swtpm_ioctl.8 \
+	swtpm_localca.8 \
 	swtpm_setup.8 \
 	swtpm_setup.conf.8 \
 	swtpm-create-tpmca.8 \
-	swtpm-localca.8 \
 	swtpm-localca.options.8 \
 	swtpm-localca.conf.8
 
 if WITH_CUSE
-man8_MANS += \
+man8_generated_MANS += \
 	swtpm_cuse.8
 endif
+
+man8_static_MANS = \
+	swtpm-localca.8
+
+man8_MANS = \
+	$(man8_generated_MANS) \
+	$(man8_static_MANS)
 
 %.8 : %.pod
 	@pod2man -r "swtpm" \
@@ -41,6 +48,6 @@ endif
 		-n $(basename $@) \
 		--section=8 $< > $@
 
-EXTRA_DIST = $(man8_PODS)
+EXTRA_DIST = $(man8_static_MANS) $(man8_PODS)
 
-CLEANFILES = $(man8_MANS)
+CLEANFILES = $(man8_generated_MANS)

--- a/man/man8/swtpm-create-tpmca.pod
+++ b/man/man8/swtpm-create-tpmca.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-swtpm-create-tpmca - Tool to create a local CA for swtpm-localca
+swtpm-create-tpmca - Tool to create a local CA for swtpm_localca
 
 =head1 SYNOPSIS
 
@@ -9,7 +9,7 @@ B<swtpm-create-tpmca [OPTIONS]>
 =head1 DESCRIPTION
 
 B<swtpm-create-tpmca> is a tool to create a TPM 1.2 based CA that
-can be used by B<swtpm-localca> to sign EK and platform certificates.
+can be used by B<swtpm_localca> to sign EK and platform certificates.
 The CA uses a GnuTLS key to sign certificates. To do this,
 GnuTLS talks to the TPM 1.2 using the B<tcsd> (TrouSerS) daemon.
 
@@ -41,7 +41,7 @@ Overwrite the contents of the output directory.
 =item B<--register>
 
 Register the key with TCSD. For the key to be available for signing,
-the same user that created the TPM CA has to run the swtpm-localca
+the same user that created the TPM CA has to run the swtpm_localca tool
 later on. If this option is not passed, the private key is written
 into a file and can be used by others as well.
 
@@ -109,7 +109,7 @@ Display the help screen and exit.
 =head1 EXAMPLE
 
 The following example creates an intermediate TPM CA and writes the keys
-into /var/lib/swtpm-localca and the swtpm-localca configuration to
+into /var/lib/swtpm-localca and the swtpm_localca configuration to
 /etc/swtpm-localca.conf. It can then be used for signing certificates of
 newly created B<swtpm> TPMs.
 
@@ -161,7 +161,7 @@ parameter.
 
 To test either one of the above TPM CAs, run the following command:
 
- #> /usr/share/swtpm/swtpm-localca \
+ #> swtpm_localca \
 	--type ek --ek x=11,y=13 \
 	--dir /tmp --vmid test --tpm2 \
 	--tpm-spec-family 2.0 --tpm-spec-revision 146 --tpm-spec-level 00 \
@@ -185,7 +185,7 @@ certificates since the TPM does not accept authenticated commands.
 
 =head1 SEE ALSO
 
-B<swtpm-localca>, B<swtpm-localca.conf>, B<tcsd>
+B<swtpm_localca>, B<swtpm-localca.conf>, B<tcsd>
 
 =head1 REPORTING BUGS
 

--- a/man/man8/swtpm-localca.8
+++ b/man/man8/swtpm-localca.8
@@ -1,0 +1,1 @@
+.so man8/swtpm_localca.8

--- a/man/man8/swtpm-localca.conf.pod
+++ b/man/man8/swtpm-localca.conf.pod
@@ -1,11 +1,11 @@
 =head1 NAME
 
-swtpm-localca.conf - Configuration file for swtpm-localca
+swtpm-localca.conf - Configuration file for swtpm_localca
 
 =head1 DESCRIPTION
 
 The file I</etc/swtpm-localca.conf> contains configuration variables
-for the I<swtpm-localca> program.
+for the I<swtpm_localca> program.
 
 Entries may contain environment variables that will be resolved. All
 environment variables must be formatted like this: '${varname}'.
@@ -82,7 +82,7 @@ With a PKCS11 URI it may look like this:
 
 =head1 SEE ALSO
 
-B<swtpm-localca>
+B<swtpm_localca>
 
 =head1 REPORTING BUGS
 

--- a/man/man8/swtpm-localca.options.pod
+++ b/man/man8/swtpm-localca.options.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-swtpm-localca.options - Options file for swtpm-localca
+swtpm-localca.options - Options file for swtpm_localca
 
 =head1 DESCRIPTION
 
@@ -23,7 +23,7 @@ An example I<swtpm-localca.options> file may look as follows:
 
 =head1 SEE ALSO
 
-B<swtpm-localca>
+B<swtpm_localca>
 
 =head1 REPORTING BUGS
 

--- a/man/man8/swtpm_localca.pod
+++ b/man/man8/swtpm_localca.pod
@@ -1,14 +1,14 @@
 =head1 NAME
 
-swtpm-localca  - Local CA to create EK and platform certs for swtpm
+swtpm_localca  - Local CA to create EK and platform certs for swtpm
 
 =head1 SYNOPSIS
 
-B<swtpm-localca [OPTIONS]>
+B<swtpm_localca [OPTIONS]>
 
 =head1 DESCRIPTION
 
-B<swtpm-localca> is a tool to create TPM Endorsement Key (EK) and platform
+B<swtpm_localca> is a tool to create TPM Endorsement Key (EK) and platform
 certificates on the host. It uses the I<swtpm_cert> program to create
 the certificates.
 
@@ -18,7 +18,7 @@ a variable needs to be set that points to this program.
 It implements command line options that the I<swtpm_setup>
 program uses to provide the necessary parameters to it.
 
-B<swtpm-localca> will automatically try to create the signing key and
+B<swtpm_localca> will automatically try to create the signing key and
 certificate if the configuration points to a missing signing key.
 Since this certificate must be signed by a CA, a root certificate authority
 will also be created and will sign this certificate. The root CA's

--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -241,7 +241,7 @@ To simulate manufacturing of a TPM, one would typically run the following comman
 Note: since v0.4 TPM 1.2 setup does not require root rights anymore.
 
 Any user can also simulate the manufacturing of a TPM using the
-swtpm-localca plugin. The following example assumes that the user has
+swtpm_localca utility. The following example assumes that the user has
 set the environment variable XDG_CONFIG_HOME as follows (using bash for
 example):
 

--- a/swtpm.spec
+++ b/swtpm.spec
@@ -157,6 +157,7 @@ fi
 %{_mandir}/man8/swtpm-localca.conf.8*
 %{_mandir}/man8/swtpm-localca.options.8*
 %{_mandir}/man8/swtpm-localca.8*
+%{_mandir}/man8/swtpm_localca.8*
 %{_mandir}/man8/swtpm_setup.8*
 %{_mandir}/man8/swtpm_setup.conf.8*
 %config(noreplace) %{_sysconfdir}/swtpm_setup.conf

--- a/swtpm.spec.in
+++ b/swtpm.spec.in
@@ -157,6 +157,7 @@ fi
 %{_mandir}/man8/swtpm-localca.conf.8*
 %{_mandir}/man8/swtpm-localca.options.8*
 %{_mandir}/man8/swtpm-localca.8*
+%{_mandir}/man8/swtpm_localca.8*
 %{_mandir}/man8/swtpm_setup.8*
 %{_mandir}/man8/swtpm_setup.conf.8*
 %config(noreplace) %{_sysconfdir}/swtpm_setup.conf


### PR DESCRIPTION
This pulls request implements **option 1.a** proposed in [this discussion](https://github.com/stefanberger/swtpm/issues/499#issuecomment-885984150) and resolves the [no-manual-page Lintian warning](https://lintian.debian.org/tags/no-manual-page) that's currently being triggered by `swtpm_localca` being installed without a matching manual page.

- Rename `swtpm-localca(8)` manual page to `swtpm_localca(8)` and make `swtpm-localca(8)` an alias for `swtpm_localca(8)`, mirroring the fact that `/usr/bin/swtpm_localca` is the actual program and `/usr/share/swtpm/swtpm-localca` a wrapper for it.
- Change references to `swtpm-localca` in manual pages' content to `swtpm_localca`, reflecting the actual name of the program they are meant to document.

⚠️ **Either** this **or** #506 should be merged; not both.