### PR TITLE
Rename swtpm_localca binary to swtpm-localca

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ Makefile
 /src/swtpm_bios/swtpm_bios
 /src/swtpm_cert/swtpm_cert
 /src/swtpm_ioctl/swtpm_ioctl
-/src/swtpm_localca/swtpm_localca
+/src/swtpm_localca/swtpm-localca
 /src/swtpm_localca/swtpm_localca_conf.h
 src/swtpm_setup/swtpm_setup
 src/swtpm_setup/swtpm_setup_conf.h

--- a/debian/swtpm-tools.install
+++ b/debian/swtpm-tools.install
@@ -3,9 +3,9 @@ cat <<_EOF_
 /etc/swtpm-localca.conf
 /etc/swtpm-localca.options
 /etc/swtpm_setup.conf
+/usr/bin/swtpm-localca
 /usr/bin/swtpm_bios
 /usr/bin/swtpm_ioctl
-/usr/bin/swtpm_localca
 /usr/bin/swtpm_setup
 /usr/share/man/man8/swtpm-create-tpmca.8*
 /usr/share/man/man8/swtpm-localca.8*

--- a/samples/swtpm-localca.in
+++ b/samples/swtpm-localca.in
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 
-@BINDIR@/swtpm_localca "$@"
+@BINDIR@/swtpm-localca "$@"
 
 exit $?

--- a/src/swtpm_localca/Makefile.am
+++ b/src/swtpm_localca/Makefile.am
@@ -5,7 +5,7 @@
 #
 
 bin_PROGRAMS = \
-	swtpm_localca
+	swtpm-localca
 
 noinst_HEADERS = \
 	swtpm_localca.h \

--- a/swtpm.spec
+++ b/swtpm.spec
@@ -148,9 +148,9 @@ fi
 %if %{with gnutls}
 %{_bindir}/swtpm_cert
 %endif
+%{_bindir}/swtpm-localca
 %{_bindir}/swtpm_setup
 %{_bindir}/swtpm_ioctl
-%{_bindir}/swtpm_localca
 %{_mandir}/man8/swtpm_bios.8*
 %{_mandir}/man8/swtpm_cert.8*
 %{_mandir}/man8/swtpm_ioctl.8*

--- a/swtpm.spec.in
+++ b/swtpm.spec.in
@@ -148,9 +148,9 @@ fi
 %if %{with gnutls}
 %{_bindir}/swtpm_cert
 %endif
+%{_bindir}/swtpm-localca
 %{_bindir}/swtpm_setup
 %{_bindir}/swtpm_ioctl
-%{_bindir}/swtpm_localca
 %{_mandir}/man8/swtpm_bios.8*
 %{_mandir}/man8/swtpm_cert.8*
 %{_mandir}/man8/swtpm_ioctl.8*

--- a/tests/test_samples_create_tpmca
+++ b/tests/test_samples_create_tpmca
@@ -24,7 +24,7 @@ source ${abs_top_builddir:-$(dirname "$0")/..}/tests/test_config
 
 SWTPM_SETUP=${ROOT}/src/swtpm_setup/swtpm_setup
 SWTPM_CREATE_TPMCA=${SRCDIR}/samples/swtpm-create-tpmca
-SWTPM_LOCALCA=${ROOT}/src/swtpm_localca/swtpm_localca
+SWTPM_LOCALCA=${ROOT}/src/swtpm_localca/swtpm-localca
 SWTPM=${ROOT}/src/swtpm/swtpm
 SWTPM_IOCTL=${ROOT}/src/swtpm_ioctl/swtpm_ioctl
 

--- a/tests/test_swtpm_setup_create_cert
+++ b/tests/test_swtpm_setup_create_cert
@@ -8,7 +8,7 @@ SRCDIR=${abs_top_srcdir:-$(dirname "$0")/..}
 
 source ${TESTDIR}/common
 
-SWTPM_LOCALCA=${ROOT}/src/swtpm_localca/swtpm_localca
+SWTPM_LOCALCA=${ROOT}/src/swtpm_localca/swtpm-localca
 
 workdir=$(mktemp -d)
 

--- a/tests/test_tpm2_samples_create_tpmca
+++ b/tests/test_tpm2_samples_create_tpmca
@@ -42,7 +42,7 @@ SRCDIR=${abs_top_srcdir:-$(dirname "$0")/..}
 
 SWTPM_SETUP=${ROOT}/src/swtpm_setup/swtpm_setup
 SWTPM_CREATE_TPMCA=${SRCDIR}/samples/swtpm-create-tpmca
-SWTPM_LOCALCA=${ROOT}/src/swtpm_localca/swtpm_localca
+SWTPM_LOCALCA=${ROOT}/src/swtpm_localca/swtpm-localca
 SWTPM=${ROOT}/src/swtpm/swtpm
 SWTPM_IOCTL=${ROOT}/src/swtpm_ioctl/swtpm_ioctl
 

--- a/tests/test_tpm2_swtpm_localca
+++ b/tests/test_tpm2_swtpm_localca
@@ -7,7 +7,7 @@ TOPBUILD=${abs_top_builddir:-$(dirname "$0")/..}
 TOPSRC=${abs_top_srcdir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
-SWTPM_LOCALCA=${TOPBUILD}/src/swtpm_localca/swtpm_localca
+SWTPM_LOCALCA=${TOPBUILD}/src/swtpm_localca/swtpm-localca
 
 workdir=$(mktemp -d "/tmp/path with spaces.XXXXXX")
 

--- a/tests/test_tpm2_swtpm_localca_pkcs11
+++ b/tests/test_tpm2_swtpm_localca_pkcs11
@@ -7,7 +7,7 @@ TOPBUILD=${abs_top_builddir:-$(dirname "$0")/..}
 TOPSRC=${abs_top_srcdir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
-SWTPM_LOCALCA=${TOPBUILD}/src/swtpm_localca/swtpm_localca
+SWTPM_LOCALCA=${TOPBUILD}/src/swtpm_localca/swtpm-localca
 
 workdir=$(mktemp -d)
 if [ $? -ne 0 ]; then

--- a/tests/test_tpm2_swtpm_setup_create_cert
+++ b/tests/test_tpm2_swtpm_setup_create_cert
@@ -9,7 +9,7 @@ TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
 source ${TESTDIR}/common
 
-SWTPM_LOCALCA=${TOPBUILD}/src/swtpm_localca/swtpm_localca
+SWTPM_LOCALCA=${TOPBUILD}/src/swtpm_localca/swtpm-localca
 
 workdir=$(mktemp -d "/tmp/path with spaces.XXXXXX")
 


### PR DESCRIPTION
This pulls request implements **option 3** proposed in [this discussion](https://github.com/stefanberger/swtpm/issues/499#issuecomment-885996153) and resolves the [no-manual-page Lintian warning](https://lintian.debian.org/tags/no-manual-page) that's currently being triggered by `swtpm_localca` being installed without a matching manual page.

- Change the name of the `/usr/bin`-installed binary from `swtpm_localca` to `swtpm-localca` for consistency with the `swtpm-localca(8)` manpage and the `/usr/share/swtpm/swtpm-localca` wrapper script.

⚠️ **Either** this **or** #505 should be merged; not both.