### PR TITLE
swtpm: Preserve main loop flags when handling CMD_SET_DATAFD

### DIFF
--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -790,7 +790,7 @@ int ctrlchannel_process_fd(int fd,
             goto err_bad_input;
         }
 
-        mlp->flags = MAIN_LOOP_FLAG_USE_FD | MAIN_LOOP_FLAG_KEEP_CONNECTION |
+        mlp->flags |= MAIN_LOOP_FLAG_USE_FD | MAIN_LOOP_FLAG_KEEP_CONNECTION |
                        MAIN_LOOP_FLAG_END_ON_HUP;
         mlp->fd = *data_fd;
 


### PR DESCRIPTION
The code that handles control channel command `CMD_SET_DATAFD`, introduced in [this commit](https://github.com/stefanberger/swtpm/commit/1fb8bb790f5bd7d81a97be7507d1063aa3bb2c58), overwrites `mlp->flags` instead of `OR`ing new bits onto it. This causes any flags previously set by the command-line argument parsers (in `swtpm::swtpm_main()` and `swtpm_chardev::swtpm_chardev_main()`) to be lost.