### PR TITLE
swtpm: add "linear" nvram store backend (for single-file storage and block devices)

### DIFF
--- a/man/man8/swtpm.pod
+++ b/man/man8/swtpm.pod
@@ -159,10 +159,13 @@ the given file I<mode> bits. This value must be given as an octal number startin
 The default value is 0640.
 
 If I<backend-uri> is specified, the TPM state data will be stored to the URI.
-Currently I<backend-uri=dir://<path_to_dir>> is the only one available. In this case,
-URI should specify the path to the directory where files are stored. If I<path_to_dir>
-starts with a '/' then the path is interpreted as an absolute path, otherwise it is
-a path relative to the current directory.
+Currently I<backend-uri=dir://<path_to_dir>> and I<backend-uri=file://<path_to_dir>>
+are available. For 'dir://', the URI should specify the path to the directory where
+files are stored. If I<path_to_dir> starts with a '/' then the path is interpreted
+as an absolute path, otherwise it is a path relative to the current directory.
+For 'file://', the URI should specify a single file or block device where TPM state
+will be stored. A blockdevice must exist already and be big enough to store all
+state.
 
 =item B<--tpm2>
 
@@ -345,7 +348,8 @@ The I<--key> option supports the I<pwdfd=> parameter.
 
 =item B<nvram-backend-dir>
 
-The I<--tpmstate> option supports the I<backend-uri=dir://...> parameter.
+The I<--tpmstate> option supports the I<backend-uri=dir://...> and
+I<backend-uri=file://...> parameters.
 
 =item B<tpm-send-command-header>
 

--- a/man/man8/swtpm.pod
+++ b/man/man8/swtpm.pod
@@ -305,6 +305,7 @@ may contain the following:
         "cmdarg-key-fd",
         "cmdarg-pwd-fd",
         "nvram-backend-dir",
+        "nvram-backend-file",
         "tpm-send-command-header",
         "flags-opt-startup",
         "rsa-keysize-1024",

--- a/src/swtpm/Makefile.am
+++ b/src/swtpm/Makefile.am
@@ -25,6 +25,7 @@ noinst_HEADERS = \
 	swtpm_debug.h \
 	swtpm_io.h \
 	swtpm_nvstore.h \
+	swtpm_nvstore_linear.h \
 	threadpool.h \
 	tlv.h \
 	tpmlib.h \
@@ -51,6 +52,8 @@ libswtpm_libtpms_la_SOURCES = \
 	swtpm_io.c \
 	swtpm_nvstore.c \
 	swtpm_nvstore_dir.c \
+	swtpm_nvstore_linear.c \
+	swtpm_nvstore_linear_file.c \
 	tlv.c \
 	tpmlib.c \
 	tpmstate.c \

--- a/src/swtpm/capabilities.c
+++ b/src/swtpm/capabilities.c
@@ -127,7 +127,8 @@ int capabilities_print_json(bool cusetpm)
     const char *with_tpm1 = "";
     const char *with_tpm2 = "";
     char *keysizecaps = NULL;
-    const char *nvram_backend_dir = "\"nvram-backend-dir\"";
+    const char *nvram_backend_dir = "\"nvram-backend-dir\", ";
+    const char *nvram_backend_file = "\"nvram-backend-file\"";
 
     ret = get_rsa_keysize_caps(&keysizecaps);
     if (ret < 0)
@@ -142,7 +143,7 @@ int capabilities_print_json(bool cusetpm)
          "{ "
          "\"type\": \"swtpm\", "
          "\"features\": [ "
-             "%s%s%s%s%s%s%s%s%s"
+             "%s%s%s%s%s%s%s%s%s%s"
           " ], "
          "\"version\": \"" VERSION "\" "
          "}",
@@ -154,6 +155,7 @@ int capabilities_print_json(bool cusetpm)
          true         ? "\"cmdarg-key-fd\", "          : "",
          true         ? "\"cmdarg-pwd-fd\", "          : "",
          nvram_backend_dir,
+         nvram_backend_file,
          keysizecaps  ? keysizecaps                    : ""
     );
 

--- a/src/swtpm/common.c
+++ b/src/swtpm/common.c
@@ -723,7 +723,8 @@ handle_tpmstate_options(char *options)
             ret = -1;
             goto error;
         }
-        if (strncmp(tpmbackend_uri, "dir://", 6) == 0 &&
+        if ((strncmp(tpmbackend_uri, "dir://", 6) == 0 ||
+            strncmp(tpmbackend_uri, "file://", 7)) &&
             tpmstate_set_mode(mode) < 0) {
             ret = -1;
             goto error;

--- a/src/swtpm/swtpm_nvstore.c
+++ b/src/swtpm/swtpm_nvstore.c
@@ -180,6 +180,8 @@ TPM_RESULT SWTPM_NVRAM_Init(void)
     backend_uri = tpmstate_get_backend_uri();
     if (strncmp(backend_uri, "dir://", 6) == 0) {
         g_nvram_backend_ops = &nvram_dir_ops;
+    } else if (strncmp(backend_uri, "file://", 7) == 0) {
+        g_nvram_backend_ops = &nvram_linear_ops;
     } else {
         logprintf(STDERR_FILENO,
                   "SWTPM_NVRAM_Init: Unsupported backend.\n");

--- a/src/swtpm/swtpm_nvstore.h
+++ b/src/swtpm/swtpm_nvstore.h
@@ -129,6 +129,7 @@ struct nvram_backend_ops {
 
 /* backend interfaces */
 extern struct nvram_backend_ops nvram_dir_ops;
+extern struct nvram_backend_ops nvram_linear_ops;
 
 
 int SWTPM_NVRAM_PrintJson(void);

--- a/src/swtpm/swtpm_nvstore_linear.c
+++ b/src/swtpm/swtpm_nvstore_linear.c
@@ -1,0 +1,479 @@
+#include "config.h"
+
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <string.h>
+#include <endian.h>
+
+#include <libtpms/tpm_error.h>
+#include <libtpms/tpm_nvfilename.h>
+
+#include "swtpm.h"
+#include "swtpm_debug.h"
+#include "swtpm_nvstore.h"
+#include "swtpm_nvstore_linear.h"
+#include "logging.h"
+#include "utils.h"
+
+static struct {
+    TPM_BOOL      initialized;
+    char          *loaded_uri;
+    struct nvram_linear_store_ops *ops;
+
+    unsigned char *data;
+    uint32_t      length;
+    struct nvram_linear_hdr *hdr; /* points into *data */
+} state;
+
+/*
+    Attempts to flush the header of the linear state, if required by the store.
+*/
+static TPM_RESULT
+SWTPM_NVRAM_Linear_FlushHeader(const char* uri)
+{
+    if (state.ops->flush) {
+        return state.ops->flush(uri, 0, le16toh(state.hdr->hdrsize));
+    }
+    return 0;
+}
+
+/*
+    Attempts a resize and ensures that state is updated correctly and the given
+    new_size could actually be reached.
+*/
+static TPM_RESULT
+SWTPM_NVRAM_Linear_SafeResize(const char* uri, uint32_t new_size)
+{
+    TPM_RESULT rc = 0;
+    uint32_t result;
+
+    if (!state.ops->resize) {
+        return new_size < state.length ? 0 : TPM_SIZE;
+    }
+
+    rc = state.ops->resize(uri, &state.data, &result, new_size);
+    if (rc) {
+        return rc;
+    }
+
+    /* base address might have changed, update pointers */
+    state.hdr = (struct nvram_linear_hdr*)state.data;
+    state.length = result;
+
+    if (result < new_size) {
+        return TPM_SIZE;
+    }
+
+    return rc;
+}
+
+#define FILE_NR_INVALID 0xffffffff
+
+/*
+    Returns the offset into the state.hdr.files array given a TPM state name and
+    number. Will be FILE_NR_INVALID if out of bounds or unknown name.
+*/
+static uint32_t
+SWTPM_NVRAM_Linear_GetFileNr(const char *name)
+{
+    uint32_t rc = 0;
+    if (strcmp(name, TPM_PERMANENT_ALL_NAME) == 0) {
+        rc += 0;
+    } else if (strcmp(name, TPM_VOLATILESTATE_NAME) == 0) {
+        rc += 1;
+    } else if (strcmp(name, TPM_SAVESTATE_NAME) == 0) {
+        rc += 2;
+    } else {
+        logprintf(STDERR_FILENO,
+                  "SWTPM_NVRAM_Linear_GetFileOffset: Unknown name '%s'\n",
+                  name);
+        return FILE_NR_INVALID;
+    }
+    if (rc >= SWTPM_NVSTORE_LINEAR_MAX_STATES) {
+        logprintf(STDERR_FILENO,
+                  "SWTPM_NVRAM_Linear_GetFileOffset: File limit exceeded: %d\n",
+                  rc);
+        return FILE_NR_INVALID;
+    }
+    return rc;
+}
+
+/*
+    Allocate a new file entry in the linear address space of state.data.
+    The new file will be placed at the end.
+
+    Importantly, this may perform a resize, so pointers into state.data or
+    state.hdr must not be kept over this function call.
+*/
+static TPM_RESULT
+SWTPM_NVRAM_Linear_AllocFile(const char *uri, uint32_t file_nr, uint32_t size)
+{
+    TPM_RESULT rc = 0;
+    struct nvram_linear_hdr_file *file;
+    uint32_t new_offset = le16toh(state.hdr->hdrsize);
+    uint32_t new_size;
+    uint32_t cur_end;
+    uint32_t i;
+    uint32_t section_size = size;
+    ROUND_TO_NEXT_POWER_OF_2_32(section_size);
+
+    /* find end of current last file */
+    for (i = 0; i < SWTPM_NVSTORE_LINEAR_MAX_STATES; i++) {
+        file = &state.hdr->files[i];
+        if (!file->offset) {
+            continue;
+        }
+
+        cur_end = le32toh(file->offset) + le32toh(file->section_length);
+        if (cur_end > new_offset) {
+            new_offset = cur_end;
+        }
+    }
+
+    new_size = new_offset + section_size;
+    rc = SWTPM_NVRAM_Linear_SafeResize(uri, new_size);
+    if (rc) {
+        return rc;
+    }
+
+    file = &state.hdr->files[file_nr];
+    file->section_length = htole32(section_size);
+    file->data_length = htole32(size);
+    file->offset = htole32(new_offset);
+
+    TPM_DEBUG("SWTPM_NVRAM_Linear_AllocFile: allocated file %d @ %d "
+              "(len=%d section=%d)\n",
+              file_nr, new_offset, size, section_size);
+
+    return rc;
+}
+
+/*
+    Deallocate a file from state.data. It's entry in state.hdr will be zeroed,
+    and the file length adjusted accordingly (if 'resize' is TRUE).
+    If the file was not at the end, any following files will be moved forward,
+    as to not leave any holes. This simplifies the allocator strategy, since it
+    allows new files to always be placed at the end.
+
+    If resize is true, this may perform a resize, so pointers into state.data or
+    state.hdr must not be kept over this function call.
+*/
+static TPM_RESULT
+SWTPM_NVRAM_Linear_RemoveFile(const char *uri,
+                              uint32_t file_nr,
+                              TPM_BOOL resize)
+{
+    TPM_RESULT rc = 0;
+    uint32_t next_offset = 0xffffffff;
+    uint32_t state_end = 0;
+    uint32_t new_len;
+    uint32_t i, cur_offset, cur_end;
+    struct nvram_linear_hdr_file *file;
+    struct nvram_linear_hdr_file old_file = state.hdr->files[file_nr];
+
+    if (old_file.offset == 0) {
+        return 0;
+    }
+
+    TPM_DEBUG("SWTPM_NVRAM_Linear_RemoveFile: removing filenr %d (resize=%d)\n",
+              file_nr, resize);
+
+    state.hdr->files[file_nr].offset = 0;
+    state.hdr->files[file_nr].data_length = 0;
+    state.hdr->files[file_nr].section_length = 0;
+
+    /* find offset of file right after the one we remove, and adjust offsets */
+    for (i = 0; i < SWTPM_NVSTORE_LINEAR_MAX_STATES; i++) {
+        file = &state.hdr->files[i];
+        if (!file->offset) {
+            continue;
+        }
+
+        cur_offset = le32toh(file->offset);
+        if (cur_offset > le32toh(old_file.offset)) {
+            if (cur_offset < next_offset) {
+                next_offset = cur_offset;
+            }
+            cur_end = cur_offset + le32toh(file->section_length);
+            if (cur_end > state_end) {
+                state_end = cur_end;
+            }
+            file->offset = htole32(cur_offset -
+                                   le32toh(old_file.section_length));
+        }
+    }
+
+    if (next_offset != 0xffffffff) {
+        TPM_DEBUG("SWTPM_NVRAM_Linear_RemoveFile: compacting\n");
+        /* if we weren't the end, compact by moving following files forward */
+        memmove(state.data + le32toh(old_file.offset),
+                state.data + next_offset,
+                state_end - next_offset);
+    }
+
+    if (resize) {
+        new_len = state.length - le32toh(old_file.section_length);
+        rc = SWTPM_NVRAM_Linear_SafeResize(uri, new_len);
+        if (rc == 0) {
+            state.length = new_len;
+        }
+    }
+
+    return rc;
+}
+
+static TPM_RESULT
+SWTPM_NVRAM_Prepare_Linear(const char *uri)
+{
+    TPM_RESULT rc = 0;
+
+    TPM_DEBUG("SWTPM_NVRAM_Prepare_Linear: uri='%s'\n", uri);
+
+    if (state.initialized) {
+        if (strcmp(state.loaded_uri, uri) == 0) {
+            /* same URI loaded, this is okay, nothing to be done */
+            return 0;
+        }
+
+        logprintf(STDERR_FILENO,
+                  "SWTPM_NVRAM_PrepareLinear: Cannot prepare twice\n");
+        return TPM_FAIL;
+    }
+
+    state.loaded_uri = malloc(strlen(uri) + 1);
+    strcpy(state.loaded_uri, uri);
+
+    /* TODO: Parse URI prefixes ("iscsi://", "rbd://", etc...) */
+    state.ops = &nvram_linear_file_ops;
+
+    if ((rc = state.ops->open(uri, &state.data, &state.length))) {
+        return rc;
+    }
+
+    state.hdr = (struct nvram_linear_hdr*)state.data;
+
+    if (le64toh(state.hdr->magic) != SWTPM_NVSTORE_LINEAR_MAGIC) {
+        logprintf(STDOUT_FILENO,
+                  "Formatting '%s' as new linear NVRAM store\n",
+                  uri);
+
+        state.hdr->magic = htole64(SWTPM_NVSTORE_LINEAR_MAGIC);
+        state.hdr->version = SWTPM_NVSTORE_LINEAR_VERSION;
+        state.hdr->hdrsize = htole16(sizeof(struct nvram_linear_hdr));
+        memset(&state.hdr->files, 0, sizeof(state.hdr->files));
+
+        SWTPM_NVRAM_Linear_FlushHeader(uri);
+
+    } else {
+        /* assume valid state found */
+        if (state.hdr->version > SWTPM_NVSTORE_LINEAR_VERSION) {
+            logprintf(STDERR_FILENO,
+                      "SWTPM_NVRAM_PrepareLinear: Unknown format version: %d\n",
+                      state.hdr->version);
+            return TPM_FAIL;
+        }
+    }
+
+    state.initialized = TRUE;
+    return rc;
+}
+
+static TPM_RESULT
+SWTPM_NVRAM_LoadData_Linear(unsigned char **data,
+                            uint32_t *length,
+                            uint32_t tpm_number,
+                            const char *name,
+                            const char *uri)
+{
+    uint32_t file_nr;
+    uint32_t file_offset;
+    uint32_t file_data_len;
+    struct nvram_linear_hdr_file *file;
+
+    TPM_DEBUG("SWTPM_NVRAM_LoadData_Linear: request for %s:%d\n",
+              name, tpm_number);
+
+    file_nr = SWTPM_NVRAM_Linear_GetFileNr(name);
+    if (file_nr == FILE_NR_INVALID) {
+        return TPM_FAIL;
+    }
+
+    file = &state.hdr->files[file_nr];
+    file_offset = le32toh(file->offset);
+    file_data_len = le32toh(file->data_length);
+
+    if (!file_offset) {
+        return TPM_RETRY;
+    }
+
+    if (file_offset + file_data_len > state.length) {
+        /* shouldn't happen, but just to be safe */
+        return TPM_FAIL;
+    }
+
+    if (data == NULL) {
+        return TPM_FAIL;
+    }
+
+    /*
+        TODO: at the moment, callers require a pointer that can be 'free'd, but
+        for efficiency, it would be better to return the mapped area directly
+    */
+    *length = file_data_len;
+    *data = malloc(file_data_len);
+    if (*data == NULL) {
+        return TPM_FAIL;
+    }
+    memcpy(*data, state.data + file_offset, file_data_len);
+
+    TPM_DEBUG("SWTPM_NVRAM_LoadData_Linear: loaded %dB from %s:%d\n",
+              file_data_len, name, tpm_number);
+
+    return 0;
+}
+
+static TPM_RESULT
+SWTPM_NVRAM_StoreData_Linear(unsigned char *filedata,
+                             uint32_t filedata_length,
+                             uint32_t tpm_number,
+                             const char *name,
+                             const char *uri)
+{
+    TPM_RESULT rc = 0;
+    TPM_BOOL needs_hdr_flush = FALSE;
+    TPM_BOOL needs_full_flush = FALSE;
+    uint32_t file_nr;
+    uint32_t file_offset;
+    struct nvram_linear_hdr_file *file;
+
+    TPM_DEBUG("SWTPM_NVRAM_StoreData_Linear: request for %dB to %s:%d\n",
+              filedata_length, name, tpm_number);
+
+    file_nr = SWTPM_NVRAM_Linear_GetFileNr(name);
+    if (file_nr == FILE_NR_INVALID) {
+        return TPM_FAIL;
+    }
+
+    file = &state.hdr->files[file_nr];
+
+    if (!file->offset) {
+        /* alloc */
+        rc = SWTPM_NVRAM_Linear_AllocFile(uri, file_nr, filedata_length);
+        if (rc) {
+            return rc;
+        }
+        needs_hdr_flush = TRUE;
+    } else if (filedata_length > file->section_length) {
+        /* realloc, resize will be done by AllocFile */
+        rc = SWTPM_NVRAM_Linear_RemoveFile(uri, file_nr, FALSE);
+        if (rc) {
+            return rc;
+        }
+        rc = SWTPM_NVRAM_Linear_AllocFile(uri, file_nr, filedata_length);
+        if (rc) {
+            return rc;
+        }
+        needs_full_flush = TRUE;
+    }
+
+    /* resize might have changed pointer */
+    file = &state.hdr->files[file_nr];
+    file_offset = le32toh(file->offset);
+
+    if (filedata_length != le32toh(file->data_length)) {
+        file->data_length = htole32(filedata_length);
+        needs_hdr_flush = TRUE;
+    }
+
+    memcpy(state.data + file_offset, filedata, filedata_length);
+
+    TPM_DEBUG("SWTPM_NVRAM_StoreData_Linear: stored %dB to %s:%d\n",
+              filedata_length, name, tpm_number);
+
+    if (needs_full_flush) {
+        if (state.ops->flush) {
+            rc = state.ops->flush(uri, 0, state.length);
+        }
+        return rc;
+    }
+
+    if (needs_hdr_flush) {
+        rc = SWTPM_NVRAM_Linear_FlushHeader(uri);
+    }
+
+    if (rc == 0 && state.ops->flush) {
+        rc = state.ops->flush(uri, file_offset, filedata_length);
+    }
+
+    return rc;
+}
+
+static TPM_RESULT
+SWTPM_NVRAM_DeleteName_Linear(uint32_t tpm_number,
+                              const char *name,
+                              TPM_BOOL mustExist,
+                              const char *uri)
+{
+    TPM_RESULT rc = 0;
+    uint32_t file_nr;
+
+    file_nr = SWTPM_NVRAM_Linear_GetFileNr(name);
+    if (file_nr == FILE_NR_INVALID) {
+        rc = TPM_FAIL;
+    }
+
+    if (rc == 0) {
+        rc = SWTPM_NVRAM_Linear_RemoveFile(uri, file_nr, TRUE);
+    }
+
+    if (rc == 0 && state.ops->flush) {
+        /* full flush, RemoveFile can move around data */
+        rc = state.ops->flush(uri, 0, state.length);
+    }
+
+    return rc;
+}
+
+static void SWTPM_NVRAM_Cleanup_Linear(void) {
+    if (state.ops && state.ops->cleanup) {
+        state.ops->cleanup();
+    }
+    if (state.loaded_uri) {
+        free(state.loaded_uri);
+    }
+}
+
+static TPM_RESULT
+SWTPM_NVRAM_CheckState_Linear(const char *uri,
+                              const char *name,
+                              size_t *blobsize)
+{
+    TPM_RESULT rc = 0;
+    uint32_t file_nr;
+    struct nvram_linear_hdr_file *file;
+
+    file_nr = SWTPM_NVRAM_Linear_GetFileNr(name);
+    if (file_nr == FILE_NR_INVALID) {
+        rc = TPM_FAIL;
+    }
+
+    if (rc == 0) {
+         file = &state.hdr->files[file_nr];
+         if (file->offset == 0) {
+             rc = TPM_RETRY;
+         } else {
+             *blobsize = le32toh(file->data_length);
+         }
+    }
+
+    return rc;
+}
+
+struct nvram_backend_ops nvram_linear_ops = {
+    .prepare = SWTPM_NVRAM_Prepare_Linear,
+    .load    = SWTPM_NVRAM_LoadData_Linear,
+    .store   = SWTPM_NVRAM_StoreData_Linear,
+    .delete  = SWTPM_NVRAM_DeleteName_Linear,
+    .cleanup = SWTPM_NVRAM_Cleanup_Linear,
+    .check_state = SWTPM_NVRAM_CheckState_Linear,
+};

--- a/src/swtpm/swtpm_nvstore_linear.h
+++ b/src/swtpm/swtpm_nvstore_linear.h
@@ -1,0 +1,83 @@
+#ifndef _SWTPM_NVSTORE_LINEAR_H
+#define _SWTPM_NVSTORE_LINEAR_H
+
+#include <libtpms/tpm_types.h>
+
+#define SWTPM_NVSTORE_LINEAR_MAGIC 0x737774706d6c696e /* 'swtpmlin' */
+#define SWTPM_NVSTORE_LINEAR_VERSION 1
+/* TODO: Make this user configurable? */
+#define SWTPM_NVSTORE_LINEAR_MAX_STATES 15 /* 3 files per TPM = 5 TPMs */
+
+struct nvram_linear_hdr_file {
+    uint32_t offset; /* offset from beginning of file - 0 means unallocated */
+    uint32_t data_length; /* length of actually valid data */
+    uint32_t section_length; /* length until next file */
+} __attribute__((packed));
+
+/*
+    Represents a file header for a multi-part file format storing TPM states
+    within one linear address space. Stored in little-endian.
+*/
+struct nvram_linear_hdr {
+    uint64_t magic;
+    uint8_t  version;
+    uint8_t  _padding; /* at least align to 32 */
+    uint16_t hdrsize;
+
+    struct nvram_linear_hdr_file files[SWTPM_NVSTORE_LINEAR_MAX_STATES];
+} __attribute__((packed));
+
+/*
+    Implementation ops for linear data backends. The "linear" backend takes care
+    of the allocation strategy to pack multiple files/parts into one address
+    space, implementations only need to make sure that the linearized data is
+    written and accessed correctly.
+*/
+struct nvram_linear_store_ops {
+    /*
+        Called once upon initialization, if the URI prefix (e.g. file://)
+        matches the implementation. 'uri' is the raw, prefixed backend_uri
+        string. 'data' and 'length' should be set to a memory region that
+        contains the loaded data in it's entirety (e.g. when loaded from a file,
+        the mmap base address and file length).
+        If a new store is created, it must contain at least enough space to
+        store 'sizeof(struct nvram_linear_hdr)' bytes.
+    */
+    TPM_RESULT (*open)(const char* uri,
+                       unsigned char **data,
+                       uint32_t *length);
+
+    /*
+        Called whenever the data in the provided buffer has changed. Will be
+        called for every changed region, offset is relative to base (0 is for
+        header or full flushes). Can be left unimplemented if data stored in
+        given buffer is flushed automatically.
+    */
+    TPM_RESULT (*flush)(const char* uri,
+                        uint32_t offset,
+                        uint32_t count);
+
+    /*
+       Called whenever space has been freed or more space is required to store
+       data. Implementations can choose to leave this unimplemented, or make the
+       implementation a no-op, TPM_SIZE should be returned if 'requested_length'
+       can not be made available. 'data' and 'new_length' must be set similar to
+       open(), either to the same region or a different one (in case of remap or
+       similar).
+    */
+    TPM_RESULT (*resize)(const char* uri,
+                         unsigned char **data,
+                         uint32_t *new_length,
+                         uint32_t requested_length);
+
+    /*
+        Called when the instance should be closed, e.g. at program exit. No
+        further calls to other ops will be made after this one.
+    */
+    void (*cleanup)(void);
+};
+
+/* available store interfaces */
+extern struct nvram_linear_store_ops nvram_linear_file_ops;
+
+#endif /* _SWTPM_NVSTORE_LINEAR_H */

--- a/src/swtpm/swtpm_nvstore_linear_file.c
+++ b/src/swtpm/swtpm_nvstore_linear_file.c
@@ -1,0 +1,281 @@
+#include "config.h"
+
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <sys/ioctl.h>
+#include <linux/fs.h>
+#include <fcntl.h>
+
+#include <libtpms/tpm_types.h>
+#include <libtpms/tpm_library.h>
+#include <libtpms/tpm_error.h>
+
+#include "swtpm.h"
+#include "swtpm_debug.h"
+#include "swtpm_nvstore_linear.h"
+#include "logging.h"
+#include "tpmstate.h"
+
+/*
+    Provides a linear backend based on memory-mapping a filesystem path.
+    Can be used to access regular files (with automatic resizing) or block
+    devices (with pre-allocated constant size, must be big enough for all state,
+    otherwise writing will fail).
+*/
+
+static struct {
+    TPM_BOOL mapped;
+    int fd;
+    unsigned char *ptr;
+    TPM_BOOL can_truncate;
+    uint32_t size;
+} mmap_state;
+
+/*
+    Update ptr and stat in mmap_state. Closes mmap_state.fd on error.
+*/
+static TPM_RESULT
+SWTPM_NVRAM_LinearFile_Mmap(void)
+{
+    TPM_RESULT rc = 0;
+    struct stat st;
+    uint64_t bd_size;
+
+    TPM_DEBUG("SWTPM_NVRAM_LinearFile_Mmap: renewing mmap\n");
+
+    if (fstat(mmap_state.fd, &st)) {
+        logprintf(STDERR_FILENO,
+                  "SWTPM_NVRAM_LinearFile_Mmap: Could not stat file: %s\n",
+                  strerror(errno));
+        rc = TPM_FAIL;
+        goto fail;
+    }
+
+    if (st.st_size >= (uint32_t)sizeof(struct nvram_linear_hdr)) {
+        /* valid regular file-ish */
+        mmap_state.size = st.st_size;
+        mmap_state.can_truncate = true;
+    } else if (S_ISREG(st.st_mode)) {
+        /* too small, and regular file - make room for at least the header */
+        if (ftruncate(mmap_state.fd, sizeof(struct nvram_linear_hdr))) {
+            logprintf(STDERR_FILENO,
+                      "SWTPM_NVRAM_LinearFile_Mmap: Could not ftruncate file "
+                      "(too small): %s\n",
+                      strerror(errno));
+            rc = TPM_FAIL;
+            goto fail;
+        }
+
+        if (fstat(mmap_state.fd, &st)) {
+            logprintf(STDERR_FILENO,
+                      "SWTPM_NVRAM_LinearFile_Mmap: Could not stat file (after "
+                      "truncate): %s\n",
+                      strerror(errno));
+            rc = TPM_FAIL;
+            goto fail;
+        }
+
+        mmap_state.size = st.st_size;
+        mmap_state.can_truncate = true;
+    } else if (S_ISBLK(st.st_mode)) {
+        /* valid block device, can't resize, but can use as is */
+        if (ioctl(mmap_state.fd, BLKGETSIZE64, &bd_size)) {
+            logprintf(STDERR_FILENO,
+                      "SWTPM_NVRAM_LinearFile_Mmap: Could not get block device "
+                      "size): %s\n",
+                      strerror(errno));
+            rc = TPM_FAIL;
+            goto fail;
+        }
+
+        mmap_state.size = bd_size;
+        mmap_state.can_truncate = false;
+
+        if (mmap_state.size < (uint32_t)sizeof(struct nvram_linear_hdr)) {
+            logprintf(STDERR_FILENO, "SWTPM_NVRAM_LinearFile_Mmap: block device"
+                                     " too small, cannot resize\n");
+            rc = TPM_FAIL;
+            goto fail;
+        }
+    } else {
+        logprintf(STDERR_FILENO, "SWTPM_NVRAM_LinearFile_Mmap: invalid stat\n");
+        rc = TPM_FAIL;
+        goto fail;
+    }
+
+    mmap_state.ptr = mmap(NULL, mmap_state.size, PROT_READ | PROT_WRITE,
+                          MAP_SHARED, mmap_state.fd, 0);
+    if (mmap_state.ptr == MAP_FAILED) {
+        logprintf(STDERR_FILENO,
+                  "SWTPM_NVRAM_LinearFile_Mmap: Could not mmap file: %s\n",
+                  strerror(errno));
+        rc = TPM_FAIL;
+        goto fail;
+    }
+
+    mmap_state.mapped = true;
+    return rc;
+
+fail:
+    mmap_state.mapped = false;
+    close(mmap_state.fd);
+    return rc;
+}
+
+/*
+    Strip leading "file://" from uri if given.
+*/
+static const char*
+SWTPM_NVRAM_LinearFile_UriToPath(const char* uri)
+{
+    const char *path = uri;
+
+    if (strncmp(uri, "file://", 7) == 0) {
+        path += 7;
+    }
+
+    return path;
+}
+
+static TPM_RESULT
+SWTPM_NVRAM_LinearFile_Open(const char* uri,
+                            unsigned char **data,
+                            uint32_t *length)
+{
+    TPM_RESULT rc = 0;
+    const char *path = SWTPM_NVRAM_LinearFile_UriToPath(uri);
+
+    if (mmap_state.mapped) {
+        logprintf(STDERR_FILENO,
+                  "SWTPM_NVRAM_LinearFile_Open: Already open\n");
+        return TPM_FAIL;
+    }
+
+    mmap_state.fd = open(path, O_RDWR|O_CREAT, tpmstate_get_mode());
+    if (mmap_state.fd < 0) {
+        logprintf(STDERR_FILENO,
+                  "SWTPM_NVRAM_LinearFile_Open: Could not open file: %s\n",
+                  strerror(errno));
+        return TPM_FAIL;
+    }
+
+    rc = SWTPM_NVRAM_LinearFile_Mmap();
+    if (rc == 0) {
+        TPM_DEBUG("SWTPM_NVRAM_LinearFile_Open: Success opening '%s'\n", path);
+        *length = mmap_state.size;
+        *data = mmap_state.ptr;
+    }
+
+    return rc;
+}
+
+static TPM_RESULT
+SWTPM_NVRAM_LinearFile_Flush(const char* uri,
+                             uint32_t offset,
+                             uint32_t count)
+{
+    TPM_RESULT rc = 0;
+    uint8_t *msync_offset;
+    uint32_t msync_count;
+
+    if (!mmap_state.mapped) {
+        logprintf(STDERR_FILENO,
+                  "SWTPM_NVRAM_LinearFile_Flush: Nothing mapped\n");
+        rc = TPM_FAIL;
+    }
+
+    /* msync parameters must be page-aligned */
+    uint32_t pagesize = sysconf(_SC_PAGESIZE);
+    msync_offset = mmap_state.ptr + (offset & ~(pagesize - 1));
+    msync_count = (count + (pagesize - 1)) & ~(pagesize - 1);
+
+    TPM_DEBUG("SWTPM_NVRAM_LinearFile_Flush: msync %d@0x%x\n",
+              msync_count, msync_offset);
+
+    if (rc == 0 && msync(msync_offset, msync_count, MS_SYNC)) {
+        logprintf(STDERR_FILENO,
+                  "SWTPM_NVRAM_LinearFile_Flush: Error in msync: %s\n",
+                  strerror(errno));
+        rc = TPM_FAIL;
+    }
+
+    return rc;
+}
+
+static void SWTPM_NVRAM_LinearFile_Cleanup(void)
+{
+    if (!mmap_state.mapped)
+        return;
+
+    SWTPM_NVRAM_LinearFile_Flush(NULL, 0, mmap_state.size);
+    munmap(mmap_state.ptr, mmap_state.size);
+    close(mmap_state.fd);
+    mmap_state.fd = 0;
+    mmap_state.mapped = false;
+}
+
+static TPM_RESULT
+SWTPM_NVRAM_LinearFile_Resize(const char* uri,
+                              unsigned char **data,
+                              uint32_t *new_length,
+                              uint32_t requested_length)
+{
+    TPM_RESULT rc = 0;
+
+    if (!mmap_state.mapped) {
+        logprintf(STDERR_FILENO,
+                  "SWTPM_NVRAM_LinearFile_Resize: Nothing mapped\n");
+        return TPM_FAIL;
+    }
+
+    /* assume we can resize files, but not anything else (like blockdevs) */
+    if (mmap_state.can_truncate) {
+        TPM_DEBUG("SWTPM_NVRAM_LinearFile_Resize: resizing file to %d\n",
+                  requested_length);
+
+        rc = SWTPM_NVRAM_LinearFile_Flush(NULL, 0, mmap_state.size);
+        if (rc == 0 && munmap(mmap_state.ptr, mmap_state.size)) {
+            logprintf(STDERR_FILENO,
+                      "SWTPM_NVRAM_LinearFile_Resize: Error in munmap: %s\n",
+                      strerror(errno));
+            rc = TPM_FAIL;
+        }
+        /* only complain when ftruncate fails if growing was requested */
+        if (rc == 0 &&
+            ftruncate(mmap_state.fd, requested_length) &&
+            mmap_state.size < requested_length) {
+
+            logprintf(STDERR_FILENO,
+                      "SWTPM_NVRAM_LinearFile_Resize: Error in ftruncate: %s\n",
+                      strerror(errno));
+            rc = TPM_FAIL;
+        }
+        if (rc == 0) {
+            rc = SWTPM_NVRAM_LinearFile_Mmap();
+        }
+        if (rc == 0) {
+            *data = mmap_state.ptr;
+            *new_length = mmap_state.size;
+        }
+    } else {
+        TPM_DEBUG("SWTPM_NVRAM_LinearFile_Resize: ignoring resize non-file\n");
+
+        *new_length = mmap_state.size;
+        if (mmap_state.size < requested_length) {
+            rc = TPM_SIZE;
+        }
+    }
+
+    return rc;
+}
+
+struct nvram_linear_store_ops nvram_linear_file_ops = {
+    .open = SWTPM_NVRAM_LinearFile_Open,
+    .flush = SWTPM_NVRAM_LinearFile_Flush,
+    .resize = SWTPM_NVRAM_LinearFile_Resize,
+    .cleanup = SWTPM_NVRAM_LinearFile_Cleanup,
+};

--- a/src/swtpm/utils.h
+++ b/src/swtpm/utils.h
@@ -48,6 +48,17 @@
 #define min(a,b) ((a) < (b) ? (a) : (b))
 #define ARRAY_LEN(a) (sizeof(a) / sizeof((a)[0]))
 
+#define ROUND_TO_NEXT_POWER_OF_2_32(a) \
+    do { \
+      a--; \
+      a |= a >> 1; \
+      a |= a >> 2; \
+      a |= a >> 4; \
+      a |= a >> 8; \
+      a |= a >> 16; \
+      a++; \
+    } while(0);
+
 typedef void (*sighandler_t)(int);
 
 int install_sighandlers(int pipefd[2], sighandler_t handler);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -63,6 +63,8 @@ TESTS += \
 	test_tpm2_save_load_encrypted_state \
 	test_tpm2_save_load_state \
 	test_tpm2_save_load_state_2 \
+	test_tpm2_save_load_state_2_linear \
+	test_tpm2_save_load_state_2_block \
 	test_tpm2_save_load_state_3 \
 	test_tpm2_save_load_state_da_timeout \
 	test_tpm2_setbuffersize \

--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -25,7 +25,7 @@ if [ "${SWTPM_IFACE}" != "cuse" ]; then
 	noncuse='"tpm-send-command-header", "flags-opt-startup", '
 fi
 
-exp='\{ "type": "swtpm", "features": \[ "tpm-1.2",( "tpm-2.0",)? '${noncuse}${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd", "nvram-backend-dir" \], "version": "[^"]*" \}'
+exp='\{ "type": "swtpm", "features": \[ "tpm-1.2",( "tpm-2.0",)? '${noncuse}${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd", "nvram-backend-dir", "nvram-backend-file" \], "version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-capabilities:"
 	echo "Actual   : ${msg}"

--- a/tests/_test_save_load_state
+++ b/tests/_test_save_load_state
@@ -17,6 +17,12 @@ MY_SAVESTATE_STATE_FILE=$TPM_PATH/my.savestate
 SWTPM_CMD_UNIX_PATH=${TPM_PATH}/unix-cmd.sock
 SWTPM_CTRL_UNIX_PATH=${TPM_PATH}/unix-ctrl.sock
 SWTPM_INTERFACE=${SWTPM_INTERFACE:-cuse}
+LINEAR_STATE_FILE=$TPM_PATH/linear-state
+BACKEND_PARAM=""
+
+if [ ${SWTPM_TEST_LINEAR_FILE:-0} -ne 0 ]; then
+	BACKEND_PARAM="--tpmstate backend-uri=file://$LINEAR_STATE_FILE"
+fi
 
 logfile=$(mktemp)
 
@@ -38,6 +44,7 @@ source ${TESTDIR}/common
 rm -f $STATE_FILE $VOLATILE_STATE_FILE 2>/dev/null
 
 run_swtpm ${SWTPM_INTERFACE} \
+	${BACKEND_PARAM} \
 	--log file=$logfile
 
 display_processes_by_name "$SWTPM"
@@ -274,7 +281,7 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-if [ ! -r $VOLATILE_STATE_FILE ]; then
+if [ ${SWTPM_TEST_LINEAR_FILE:-0} -eq 0 ] && [ ! -r $VOLATILE_STATE_FILE ]; then
 	echo "Error: Volatile state file $VOLATILE_STATE_FILE does not exist."
 	echo "TPM Logfile:"
 	cat $logfile
@@ -326,11 +333,20 @@ if wait_process_gone ${SWTPM_PID} 4; then
 	exit 1
 fi
 
-if [ ! -e $STATE_FILE ]; then
-	echo "Error: TPM state file $STATE_FILE does not exist."
-	echo "TPM Logfile:"
-	cat $logfile
-	exit 1
+if [ ${SWTPM_TEST_LINEAR_FILE:-0} -ne 0 ]; then
+	if [ ! -e $LINEAR_STATE_FILE ]; then
+		echo "Error: TPM state file $LINEAR_STATE_FILE does not exist."
+		echo "TPM Logfile:"
+		cat $logfile
+		exit 1
+	fi
+else
+	if [ ! -e $STATE_FILE ]; then
+		echo "Error: TPM state file $STATE_FILE does not exist."
+		echo "TPM Logfile:"
+		cat $logfile
+		exit 1
+	fi
 fi
 
 echo "OK"

--- a/tests/_test_tpm2_print_capabilities
+++ b/tests/_test_tpm2_print_capabilities
@@ -26,7 +26,7 @@ if [ "${SWTPM_IFACE}" != "cuse" ]; then
 fi
 
 # The rsa key size reporting is variable, so use a regex
-exp='\{ "type": "swtpm", "features": \[( "tpm-1.2",)? "tpm-2.0", '${noncuse}${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd", "nvram-backend-dir"(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")? \], "version": "[^"]*" \}'
+exp='\{ "type": "swtpm", "features": \[( "tpm-1.2",)? "tpm-2.0", '${noncuse}${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd", "nvram-backend-dir", "nvram-backend-file"(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")? \], "version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-capabilities:"
 	echo "Actual   : ${msg}"

--- a/tests/test_save_load_state
+++ b/tests/test_save_load_state
@@ -39,4 +39,15 @@ bash _test_save_load_state
 ret=$?
 [ $ret -ne 0  ] && [ $ret -ne 77 ] && exit $ret
 
+echo "=== Testing with linear file backend ==="
+
+export SWTPM_INTERFACE=socket+socket
+export SWTPM_SERVER_NAME=localhost
+export SWTPM_SERVER_PORT=65418
+export SWTPM_CTRL_PORT=65419
+export SWTPM_TEST_LINEAR_FILE=1
+bash _test_save_load_state
+ret=$?
+[ $ret -ne 0  ] && [ $ret -ne 77 ] && exit $ret
+
 exit 0

--- a/tests/test_tpm2_save_load_state_2
+++ b/tests/test_tpm2_save_load_state_2
@@ -34,6 +34,13 @@ LOGFILE=$TPMDIR/logfile
 TMPFILE=$TPMDIR/tmpfile
 BINFILE=$TPMDIR/binfile
 SIGFILE=$TPMDIR/sigfile
+STATEFILE=${STATEFILE:-$TPMDIR/state}
+
+STORE_PARAM="dir=$TPMDIR"
+if [ ${SWTPM_TEST_LINEAR_FILE:-0} -ne 0 ]; then
+	echo "Testing with linear file backend ($STATEFILE)"
+	STORE_PARAM="backend-uri=file://$STATEFILE"
+fi
 
 source ${TESTDIR}/test_common
 source ${TESTDIR}/common
@@ -173,13 +180,13 @@ function fillup_nvram()
 export TPM_SERVER_TYPE=raw
 export TPM_SERVER_NAME=127.0.0.1
 export TPM_INTERFACE_TYPE=socsim
-export TPM_COMMAND_PORT=65446
+export TPM_COMMAND_PORT=${TPM_COMMAND_PORT:-65460}
 export TPM_DATA_DIR=$TPMDIR
 export TPM_SESSION_ENCKEY="807e2bfe898ddaed8fa6310e716a24dc" # for sessions
 
 $SWTPM_EXE socket \
 	--server port=${TPM_COMMAND_PORT} \
-	--tpmstate dir=$TPMDIR \
+	--tpmstate $STORE_PARAM \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--log file=$LOGFILE,level=20 \
@@ -233,7 +240,7 @@ echo "TPM was shut down"
 
 $SWTPM_EXE socket \
 	--server port=${TPM_COMMAND_PORT} \
-	--tpmstate dir=$TPMDIR \
+	--tpmstate $STORE_PARAM \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--log file=$LOGFILE,level=20 \
@@ -287,13 +294,18 @@ echo "TPM was shut down"
 #################################################################
 # Run TPM2 with previously saved state and verify it's the same
 
+if [ ${SWTPM_TEST_LINEAR_FILE:-0} -ne 0 ]; then
+	echo "Test 1 OK (skipped last with linear file)"
+	exit 0
+fi
+
 rm -f $TPMDIR/*
 cp -f ${TESTDIR}/data/tpm2state5/tpm2-00.permall $TPMDIR/tpm2-00.permall
 cp ${TESTDIR}/data/tpm2state5/signature.bin $SIGFILE
 
 $SWTPM_EXE socket \
 	--server port=${TPM_COMMAND_PORT} \
-	--tpmstate dir=$TPMDIR \
+	--tpmstate $STORE_PARAM \
 	--pid file=$PID_FILE \
 	--ctrl type=unixio,path=$SOCK_PATH \
 	--log file=$LOGFILE,level=20 \

--- a/tests/test_tpm2_save_load_state_2_block
+++ b/tests/test_tpm2_save_load_state_2_block
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if [ "$(id -u)" -ne 0 ]; then
+	echo "Need to be root to run this test."
+	exit 77
+fi
+
+STATEDIR=$(mktemp -d)
+STATEIMG=$STATEDIR/tpm2.img
+STATEFILE=""
+
+trap "cleanup" SIGTERM EXIT
+function cleanup()
+{
+	rm -rf $STATEDIR
+	if [ -n "$STATEFILE" ]; then
+		losetup -d $STATEFILE
+	fi
+}
+
+# allocate 4 MiB file
+fallocate -x -l $((4 * 1024 * 1024)) "$STATEIMG"
+# and loop mount it
+STATEFILE=$(losetup --show -f $STATEIMG)
+
+export SWTPM_TEST_LINEAR_FILE=1
+export TPM_COMMAND_PORT=65462
+export STATEFILE
+
+# don't exec so cleanup will remove the loop device
+$(dirname $0)/test_tpm2_save_load_state_2

--- a/tests/test_tpm2_save_load_state_2_linear
+++ b/tests/test_tpm2_save_load_state_2_linear
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export SWTPM_TEST_LINEAR_FILE=1
+export TPM_COMMAND_PORT=65461
+exec $(dirname $0)/test_tpm2_save_load_state_2


### PR DESCRIPTION
This RFC is based on the work of @Etsukata et. al. in #461 and #490. It uses the proposed abstraction layer to implement another nvram storage backend.

The backend is called "linear" (which, IMO, is a not a good name [for the user facing side anyway], "file" would have been much better... but is already used by, well, the "file" directory backend - maybe we should call that one "directory" on the commandline?). It provides a second, lighter abstraction layer weakly based on the design proposed in #461 - the "linear" backend itself maps files into a linear address space, a "linear backend" is then used to write those changes to wherever they need to go.

One such "linear backend" is the "linear file" one implemented together with the abstraction in the first patch. It simply mmaps a file or block device and writes data to it, using ftruncate to manage its size automatically (in case it's a regular file, a block device must be preallocated beforehand).

There are several TODOs still open within the code, but it does pass the provided test cases, and I was able to attach a block-device based backing store to a QEMU VM and boot into Windows Server correctly with it.

Incomplete list of TODOs:
* locking (is it necessary?)
* actual URI parsing (currently, always "linear file" backend is chosen, without prefix or with "file://")
* currently a maximum of 15 states are allowed, maybe make this user configurable? would make the header size dynamic though...

I hope this work doesn't conflict with something else already in the works? If so, see this as another design draft. The mentioned user-space iSCSI layer could be put on top of my "linear" abstraction fairly easily too I'd imagine.

I honestly didn't plan to make this a fully functional implementation at first but then got carried away a bit - looking forward to further discussion :)

Thanks!