### PR TITLE
Check libtpms version

### DIFF
--- a/man/man8/swtpm.pod
+++ b/man/man8/swtpm.pod
@@ -290,6 +290,8 @@ may contain the following:
     {
       "type": "swtpm",
       "features": [
+        "tpm-1.2",
+        "tpm-2.0",
         "cmdarg-seccomp",
         "cmdarg-key-fd",
         "cmdarg-pwd-fd",
@@ -298,12 +300,29 @@ may contain the following:
         "rsa-keysize-1024",
         "rsa-keysize-2048",
         "rsa-keysize-3072"
-      ]
+      ],
+      "version": "0.7.0"
     }
+
+The version field is available since 0.7.
 
 The meaning of the feature verbs is as follows:
 
 =over 4
+
+=item B<tpm-1.2>
+
+TPM 1.2 emulation is supported (libtpms is compiled with 1.2 support).
+
+Since 0.7
+
+==item B<tpm-2.0>
+
+TPM 2 emulation is supported (libtpms is compiled with 2.0 support).
+
+(the I<--tpm2> option is supported)
+
+Since 0.7
 
 =item B<cmdarg-seccomp>
 

--- a/man/man8/swtpm_cert.pod
+++ b/man/man8/swtpm_cert.pod
@@ -157,8 +157,11 @@ The output may contain the following:
       "features": [
         "cmdarg-signkey-pwd",
         "cmdarg-parentkey-pwd"
-      ]
+      ],
+      "version": "0.7.0"
     }
+
+The version field is available since 0.7.
 
 The maining of the feature verbs is as follows:
 

--- a/man/man8/swtpm_cuse.pod
+++ b/man/man8/swtpm_cuse.pod
@@ -175,8 +175,11 @@ may contain the following:
       "features": [
         "cmdarg-seccomp",
         "cmdarg-key-fd"
-      ]
+      ],
+      "version": "0.7.0"
     }
+
+The version field is available since 0.7.
 
 The meaning of the feature verbs is as follows:
 

--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -198,8 +198,11 @@ The output may contain the following:
         "tpm2-rsa-keysize-2048",
         "tpm2-rsa-keysize-3072",
         "tpm12-not-need-root"
-      ]
+      ],
+      "version": "0.7.0"
     }
+
+The version field is available since 0.7.
 
 The meaning of the feature verbs is as follows:
 

--- a/src/swtpm/capabilities.c
+++ b/src/swtpm/capabilities.c
@@ -43,6 +43,7 @@
 #include <string.h>
 
 #include <libtpms/tpm_library.h>
+#include <libtpms/tpm_error.h>
 
 #include "capabilities.h"
 #include "logging.h"
@@ -122,19 +123,28 @@ int capabilities_print_json(bool cusetpm)
 #else
     const char *cmdarg_seccomp = "";
 #endif
+    const char *with_tpm1 = "";
+    const char *with_tpm2 = "";
     char *keysizecaps = NULL;
 
     ret = get_rsa_keysize_caps(&keysizecaps);
     if (ret < 0)
         goto cleanup;
 
+    if (TPMLIB_ChooseTPMVersion(TPMLIB_TPM_VERSION_1_2) == TPM_SUCCESS)
+        with_tpm1 = "\"tpm-1.2\", ";
+    if (TPMLIB_ChooseTPMVersion(TPMLIB_TPM_VERSION_2) == TPM_SUCCESS)
+        with_tpm2 = "\"tpm-2.0\", ";
+
     n =  asprintf(&string,
          "{ "
          "\"type\": \"swtpm\", "
          "\"features\": [ "
-             "%s%s%s%s%s%s"
+             "%s%s%s%s%s%s%s%s"
           " ] "
          "}",
+         with_tpm1,
+         with_tpm2,
          !cusetpm     ? "\"tpm-send-command-header\", ": "",
          !cusetpm     ? "\"flags-opt-startup\", "      : "",
          cmdarg_seccomp,

--- a/src/swtpm/capabilities.c
+++ b/src/swtpm/capabilities.c
@@ -68,7 +68,7 @@ static int get_rsa_keysize_caps(char **keysizecaps)
     int n;
 
     if (!info_data)
-        goto oom;
+        goto cleanup;
 
     start = strstr(info_data, needle);
     if (start) {

--- a/src/swtpm/capabilities.c
+++ b/src/swtpm/capabilities.c
@@ -141,7 +141,8 @@ int capabilities_print_json(bool cusetpm)
          "\"type\": \"swtpm\", "
          "\"features\": [ "
              "%s%s%s%s%s%s%s%s"
-          " ] "
+          " ], "
+         "\"version\": \"" VERSION "\" "
          "}",
          with_tpm1,
          with_tpm2,

--- a/src/swtpm/cuse_tpm.c
+++ b/src/swtpm/cuse_tpm.c
@@ -1581,19 +1581,20 @@ int swtpm_cuse_main(int argc, char **argv, const char *prgname, const char *ifac
         goto exit;
     }
 
-    /*
-     * choose the TPM version early so that getting/setting
-     * buffer size works.
-     */
+    if (printcapabilities) {
+        /*
+         * Choose the TPM version so that getting/setting buffer size works.
+         * Ignore failure, for backward compatibility when TPM 1.2 is disabled.
+         */
+        TPMLIB_ChooseTPMVersion(tpmversion);
+        ret = capabilities_print_json(true) ? EXIT_FAILURE : EXIT_SUCCESS;
+        goto exit;
+    }
+
     if (TPMLIB_ChooseTPMVersion(tpmversion) != TPM_SUCCESS) {
         logprintf(STDERR_FILENO,
                   "Error: Could not choose TPM version.\n");
         ret = EXIT_FAILURE;
-        goto exit;
-    }
-
-    if (printcapabilities) {
-        ret = capabilities_print_json(true) ? EXIT_FAILURE : EXIT_SUCCESS;
         goto exit;
     }
 

--- a/src/swtpm/swtpm.c
+++ b/src/swtpm/swtpm.c
@@ -404,19 +404,20 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
         exit(EXIT_FAILURE);
     }
 
-    /*
-     * choose the TPM version early so that getting/setting
-     * buffer size works.
-     */
+    if (printcapabilities) {
+        /*
+         * Choose the TPM version so that getting/setting buffer size works.
+         * Ignore failure, for backward compatibility when TPM 1.2 is disabled.
+         */
+        TPMLIB_ChooseTPMVersion(mlp.tpmversion);
+        ret = capabilities_print_json(false);
+        exit(ret ? EXIT_FAILURE : EXIT_SUCCESS);
+    }
+
     if (TPMLIB_ChooseTPMVersion(mlp.tpmversion) != TPM_SUCCESS) {
         logprintf(STDERR_FILENO,
                   "Error: Could not choose TPM version.\n");
         exit(EXIT_FAILURE);
-    }
-
-    if (printcapabilities) {
-        ret = capabilities_print_json(false);
-        exit(ret ? EXIT_FAILURE : EXIT_SUCCESS);
     }
 
     if (handle_ctrlchannel_options(ctrlchdata, &mlp.cc) < 0 ||

--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -458,19 +458,20 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
     }
 #endif
 
-    /*
-     * choose the TPM version early so that getting/setting
-     * buffer size works.
-     */
+    if (printcapabilities) {
+        /*
+         * Choose the TPM version so that getting/setting buffer size works.
+         * Ignore failure, for backward compatibility when TPM 1.2 is disabled.
+         */
+        TPMLIB_ChooseTPMVersion(mlp.tpmversion);
+        ret = capabilities_print_json(false);
+        exit(ret ? EXIT_FAILURE : EXIT_SUCCESS);
+    }
+
     if (TPMLIB_ChooseTPMVersion(mlp.tpmversion) != TPM_SUCCESS) {
         logprintf(STDERR_FILENO,
                   "Error: Could not choose TPM version.\n");
         exit(EXIT_FAILURE);
-    }
-
-    if (printcapabilities) {
-        ret = capabilities_print_json(false);
-        exit(ret ? EXIT_FAILURE : EXIT_SUCCESS);
     }
 
     SWTPM_NVRAM_Set_TPMVersion(mlp.tpmversion);

--- a/src/swtpm_cert/ek-cert.c
+++ b/src/swtpm_cert/ek-cert.c
@@ -985,8 +985,9 @@ static void capabilities_print_json()
             "\"features\": [ "
              "\"cmdarg-signkey-pwd\""
              ", \"cmdarg-parentkey-pwd\""
-              " ] "
-             "}\n");
+            " ], "
+            "\"version\": \"" VERSION "\" "
+            "}\n");
 }
 
 int

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -978,7 +978,9 @@ static int print_capabilities(char **swtpm_prg_l)
     printf("{ \"type\": \"swtpm_setup\", "
            "\"features\": [ \"cmdarg-keyfile-fd\", \"cmdarg-pwdfile-fd\", \"tpm12-not-need-root\""
            ", \"cmdarg-write-ek-cert-files\""
-           "%s ] }\n", param);
+           "%s ], "
+           "\"version\": \"" VERSION "\" "
+           "}\n", param);
 
     g_strfreev(keysize_strs);
 

--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -25,8 +25,8 @@ if [ "${SWTPM_IFACE}" != "cuse" ]; then
 	noncuse='"tpm-send-command-header", "flags-opt-startup", '
 fi
 
-exp='{ "type": "swtpm", "features": [ '${noncuse}${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd" ] }'
-if [ "${msg}" != "${exp}" ]; then
+exp='\{ "type": "swtpm", "features": \[ "tpm-1.2",( "tpm-2.0",)? '${noncuse}${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd" \] \}'
+if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-capabilities:"
 	echo "Actual   : ${msg}"
 	echo "Expected : ${exp}"

--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -25,7 +25,7 @@ if [ "${SWTPM_IFACE}" != "cuse" ]; then
 	noncuse='"tpm-send-command-header", "flags-opt-startup", '
 fi
 
-exp='\{ "type": "swtpm", "features": \[ "tpm-1.2",( "tpm-2.0",)? '${noncuse}${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd" \] \}'
+exp='\{ "type": "swtpm", "features": \[ "tpm-1.2",( "tpm-2.0",)? '${noncuse}${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd" \], "version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-capabilities:"
 	echo "Actual   : ${msg}"
@@ -43,7 +43,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # The are some variable parameters at the end, use regex
-exp='\{ "type": "swtpm_setup", "features": \[ "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", "tpm12-not-need-root", "cmdarg-write-ek-cert-files"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")? \] \}'
+exp='\{ "type": "swtpm_setup", "features": \[ "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", "tpm12-not-need-root", "cmdarg-write-ek-cert-files"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")? \], "version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_SETUP} to --print-capabilities:"
 	echo "Actual   : ${msg}"
@@ -62,8 +62,8 @@ if [ -x "$(type -P $(echo "${SWTPM_CERT}" | cut -d" " -f1) )" ]; then
 		exit 1
 	fi
 
-	exp='{ "type": "swtpm_cert", "features": [ "cmdarg-signkey-pwd", "cmdarg-parentkey-pwd" ] }'
-	if [ "${msg}" != "${exp}" ]; then
+	exp='\{ "type": "swtpm_cert", "features": \[ "cmdarg-signkey-pwd", "cmdarg-parentkey-pwd" \], "version": "[^"]*" \}'
+	if ! [[ "${msg}" =~ ${exp} ]]; then
 		echo "Unexpected response from ${SWTPM_CERT} to --print-capabilities:"
 		echo "Actual   : ${msg}"
 		echo "Expected : ${exp}"

--- a/tests/_test_tpm2_print_capabilities
+++ b/tests/_test_tpm2_print_capabilities
@@ -26,7 +26,7 @@ if [ "${SWTPM_IFACE}" != "cuse" ]; then
 fi
 
 # The rsa key size reporting is variable, so use a regex
-exp='\{ "type": "swtpm", "features": \[ '${noncuse}${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd"(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")? \] \}'
+exp='\{ "type": "swtpm", "features": \[( "tpm-1.2",)? "tpm-2.0", '${noncuse}${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd"(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")? \] \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-capabilities:"
 	echo "Actual   : ${msg}"

--- a/tests/_test_tpm2_print_capabilities
+++ b/tests/_test_tpm2_print_capabilities
@@ -26,7 +26,7 @@ if [ "${SWTPM_IFACE}" != "cuse" ]; then
 fi
 
 # The rsa key size reporting is variable, so use a regex
-exp='\{ "type": "swtpm", "features": \[( "tpm-1.2",)? "tpm-2.0", '${noncuse}${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd"(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")? \] \}'
+exp='\{ "type": "swtpm", "features": \[( "tpm-1.2",)? "tpm-2.0", '${noncuse}${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd"(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")? \], "version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-capabilities:"
 	echo "Actual   : ${msg}"
@@ -44,7 +44,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # The are some variable parameters at the end, use regex
-exp='\{ "type": "swtpm_setup", "features": \[ "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", "tpm12-not-need-root", "cmdarg-write-ek-cert-files"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")? \] \}'
+exp='\{ "type": "swtpm_setup", "features": \[ "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", "tpm12-not-need-root", "cmdarg-write-ek-cert-files"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")? \], "version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_SETUP} to --print-capabilities:"
 	echo "Actual   : ${msg}"
@@ -63,8 +63,8 @@ if [ -x "$(type -P $(echo "${SWTPM_CERT}" | cut -d" " -f1) )" ]; then
 		exit 1
 	fi
 
-	exp='{ "type": "swtpm_cert", "features": [ "cmdarg-signkey-pwd", "cmdarg-parentkey-pwd" ] }'
-	if [ "${msg}" != "${exp}" ]; then
+	exp='\{ "type": "swtpm_cert", "features": \[ "cmdarg-signkey-pwd", "cmdarg-parentkey-pwd" \], "version": "[^"]*" \}'
+	if ~ [[ "${msg}" =~ ${exp} ]]; then
 		echo "Unexpected response from ${SWTPM_CERT} to --print-capabilities:"
 		echo "Actual   : ${msg}"
 		echo "Expected : ${exp}"

--- a/tests/common
+++ b/tests/common
@@ -831,3 +831,15 @@ function validate_pidfile()
 		exit 1
 	fi
 }
+
+# Check whether swtpm can use a TPM 1.2
+function skip_test_no_tpm12()
+{
+	local swtpm_exe="$1"
+
+	local res=$(${swtpm_exe} socket --print-capabilities | grep '"tpm-1.2"')
+	if [ -z "${res}" ]; then
+		echo "${swtpm_exe} does not provide a TPM 1.2"
+		exit 77
+	fi
+}

--- a/tests/common
+++ b/tests/common
@@ -843,3 +843,15 @@ function skip_test_no_tpm12()
 		exit 77
 	fi
 }
+
+# Check whether swtpm can use a TPM 2.0
+function skip_test_no_tpm20()
+{
+	local swtpm_exe="$1"
+
+	local res=$(${swtpm_exe} socket --print-capabilities | grep '"tpm-2.0"')
+	if [ -z "${res}" ]; then
+		echo "${swtpm_exe} does not provide a TPM 2.0"
+		exit 77
+	fi
+}

--- a/tests/test_commandline
+++ b/tests/test_commandline
@@ -13,6 +13,7 @@ TESTDIR=${abs_top_testdir:=$(dirname "$0")}
 
 # need SWTPM to be set
 source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
 
 TPMDIR=`mktemp -d`
 PID_FILE=$TPMDIR/${SWTPM}.pid

--- a/tests/test_ctrlchannel
+++ b/tests/test_ctrlchannel
@@ -28,6 +28,7 @@ SWTPM_INTERFACE=socket+unix
 SWTPM_SERVER_PORT=65430
 SWTPM_SERVER_NAME=localhost
 source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
 
 # Test 1: test the control channel on the socket tpm
 

--- a/tests/test_ctrlchannel2
+++ b/tests/test_ctrlchannel2
@@ -16,6 +16,7 @@ RESP_PATH=$TPMDIR/resp
 VOLATILESTATE=$TPMDIR/volatile
 
 source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
 
 trap "cleanup" SIGTERM EXIT
 

--- a/tests/test_ctrlchannel3
+++ b/tests/test_ctrlchannel3
@@ -23,6 +23,7 @@ function cleanup()
 }
 
 source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
 
 if ! [[ "$(uname -s)" =~ Linux ]]; then
 	echo "Need Linux to run UnixIO test for CMD_SET_DATAFD."

--- a/tests/test_ctrlchannel4
+++ b/tests/test_ctrlchannel4
@@ -24,6 +24,7 @@ function cleanup()
 
 SWTPM_INTERFACE=socket+unix
 source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
 
 # Test 1: test the control channel on the chardev tpm
 

--- a/tests/test_encrypted_state
+++ b/tests/test_encrypted_state
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_getcap
+++ b/tests/test_getcap
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_hashing
+++ b/tests/test_hashing
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_hashing2
+++ b/tests/test_hashing2
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_init
+++ b/tests/test_init
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_locality
+++ b/tests/test_locality
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_migration_key
+++ b/tests/test_migration_key
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_parameters
+++ b/tests/test_parameters
@@ -63,6 +63,7 @@ FILESIZES=(
 )
 
 source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
 
 SWTPM=swtpm
 SWTPM_EXE=${SWTPM_EXE:-$ROOT/src/swtpm/$SWTPM}

--- a/tests/test_print_capabilities
+++ b/tests/test_print_capabilities
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IFACE=cuse

--- a/tests/test_resume_volatile
+++ b/tests/test_resume_volatile
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_samples_create_tpmca
+++ b/tests/test_samples_create_tpmca
@@ -75,6 +75,7 @@ function cleanup()
 
 trap "cleanup" SIGTERM EXIT
 source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
 
 PATH=${ROOT}/src/swtpm_bios:${ROOT}/src/swtpm_cert:${PATH}
 

--- a/tests/test_save_load_encrypted_state
+++ b/tests/test_save_load_encrypted_state
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_save_load_state
+++ b/tests/test_save_load_state
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_setbuffersize
+++ b/tests/test_setbuffersize
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_swtpm_bios
+++ b/tests/test_swtpm_bios
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_swtpm_setup_create_cert
+++ b/tests/test_swtpm_setup_create_cert
@@ -7,6 +7,7 @@ TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 SRCDIR=${abs_top_srcdir:-$(dirname "$0")/..}
 
 source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
 
 SWTPM_LOCALCA=${ROOT}/src/swtpm_localca/swtpm_localca
 

--- a/tests/test_tpm12
+++ b/tests/test_tpm12
@@ -24,6 +24,7 @@ function cleanup() {
 trap "cleanup" EXIT
 
 source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
 
 WORKDIR=$(mktemp -d)
 TESTLOG=${WORKDIR}/test.log

--- a/tests/test_tpm2_ctrlchannel2
+++ b/tests/test_tpm2_ctrlchannel2
@@ -18,6 +18,7 @@ VOLATILESTATE=$TPMDIR/volatile
 
 source ${TESTDIR}/common
 source ${TESTDIR}/test_common
+skip_test_no_tpm20 "${SWTPM_EXE}"
 
 trap "cleanup" SIGTERM EXIT
 

--- a/tests/test_tpm2_derived_keys
+++ b/tests/test_tpm2_derived_keys
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm2_encrypted_state
+++ b/tests/test_tpm2_encrypted_state
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm2_getcap
+++ b/tests/test_tpm2_getcap
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm2_hashing
+++ b/tests/test_tpm2_hashing
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm2_hashing2
+++ b/tests/test_tpm2_hashing2
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm2_hashing3
+++ b/tests/test_tpm2_hashing3
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm2_ibmtss2
+++ b/tests/test_tpm2_ibmtss2
@@ -28,6 +28,8 @@ function cleanup() {
 trap "cleanup" EXIT
 
 source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 WORKDIR=$(mktemp -d)
 
 REGLOG=${WORKDIR}/reglog

--- a/tests/test_tpm2_init
+++ b/tests/test_tpm2_init
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm2_locality
+++ b/tests/test_tpm2_locality
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm2_migration_key
+++ b/tests/test_tpm2_migration_key
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm2_parameters
+++ b/tests/test_tpm2_parameters
@@ -2,8 +2,11 @@
 
 # For the license, see the LICENSE file in the root directory.
 
-ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 SRCDIR=${abs_top_srcdir:-$(dirname "$0")/..}
 
 PATH=$ROOT/src/swtpm:$PATH

--- a/tests/test_tpm2_partial_reads
+++ b/tests/test_tpm2_partial_reads
@@ -36,6 +36,7 @@ trap "cleanup" EXIT
 
 [ "${SWTPM_INTERFACE}" == "cuse" ] && source test_cuse
 source common
+skip_test_no_tpm20 "${SWTPM_EXE}"
 
 run_swtpm ${SWTPM_INTERFACE} --tpm2
 

--- a/tests/test_tpm2_print_capabilities
+++ b/tests/test_tpm2_print_capabilities
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IFACE=cuse

--- a/tests/test_tpm2_probe
+++ b/tests/test_tpm2_probe
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm2_resume_volatile
+++ b/tests/test_tpm2_resume_volatile
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm2_save_load_encrypted_state
+++ b/tests/test_tpm2_save_load_encrypted_state
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm2_save_load_state
+++ b/tests/test_tpm2_save_load_state
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm2_save_load_state_2
+++ b/tests/test_tpm2_save_load_state_2
@@ -37,6 +37,8 @@ SIGFILE=$TPMDIR/sigfile
 
 source ${TESTDIR}/test_common
 source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 
 trap "cleanup" SIGTERM EXIT
 

--- a/tests/test_tpm2_save_load_state_3
+++ b/tests/test_tpm2_save_load_state_3
@@ -46,6 +46,8 @@ HKEYPUB=${TESTDIR}/data/tpm2state3/hkey.pub
 
 source ${TESTDIR}/test_common
 source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 
 trap "cleanup" SIGTERM EXIT
 

--- a/tests/test_tpm2_save_load_state_da_timeout
+++ b/tests/test_tpm2_save_load_state_da_timeout
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm2_savestate
+++ b/tests/test_tpm2_savestate
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm2_setbuffersize
+++ b/tests/test_tpm2_setbuffersize
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm2_swtpm_bios
+++ b/tests/test_tpm2_swtpm_bios
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm2_swtpm_setup_create_cert
+++ b/tests/test_tpm2_swtpm_setup_create_cert
@@ -8,6 +8,7 @@ ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
 source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
 
 SWTPM_LOCALCA=${TOPBUILD}/src/swtpm_localca/swtpm_localca
 

--- a/tests/test_tpm2_volatilestate
+++ b/tests/test_tpm2_volatilestate
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm2_vtpm_proxy
+++ b/tests/test_tpm2_vtpm_proxy
@@ -34,6 +34,8 @@ function cleanup()
 trap "cleanup" EXIT
 
 source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 source ${TESTDIR}/load_vtpm_proxy
 
 rm -f $STATE_FILE $VOLATILE_STATE_FILE 2>/dev/null

--- a/tests/test_tpm2_wrongorder
+++ b/tests/test_tpm2_wrongorder
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_tpm_probe
+++ b/tests/test_tpm_probe
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_volatilestate
+++ b/tests/test_volatilestate
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100

--- a/tests/test_vtpm_proxy
+++ b/tests/test_vtpm_proxy
@@ -34,6 +34,8 @@ function cleanup()
 trap "cleanup" EXIT
 
 source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
 source ${TESTDIR}/load_vtpm_proxy
 
 rm -f $STATE_FILE $VOLATILE_STATE_FILE 2>/dev/null

--- a/tests/test_wrongorder
+++ b/tests/test_wrongorder
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
 cd "$(dirname "$0")"
 
 export SWTPM_IOCTL_BUFFERSIZE=100


### PR DESCRIPTION
After libtpms gains support for disabling TPM 1.2 (https://github.com/stefanberger/libtpms/pull/244), adapt swtpm to cope with and check the libtpms supported versions.

I left a couple of things for later (eh, someone else? :)):
- Some tests could be improved to work regardless of the supported versions.
- Also, it may be worth to make the test check the version at runtime, to avoid having to run configure again when libtpms is modified.

Resolves #512 