### PR TITLE
swtpm_setup: Add support for checking for TPM 1.2 and TPM 2 support     

### DIFF
--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -197,7 +197,9 @@ The output may contain the following:
         "cmdarg-write-ek-cert-files",
         "tpm2-rsa-keysize-2048",
         "tpm2-rsa-keysize-3072",
-        "tpm12-not-need-root"
+        "tpm12-not-need-root",
+        "tpm-1.2",
+        "tpm-2.0"
       ],
       "version": "0.7.0"
     }
@@ -230,6 +232,14 @@ tpm2-rsa-keysize verbs is shown then only RSA 2048 bit keys are supported.
 This option implies that any user can setup a TPM 1.2. Previously only root
 or the 'tss' user, depending on configuration and availability of this account,
 could do that.
+
+=item B<tpm-1.2> (since 0.7)
+
+TPM 1.2 setup is supported (libtpms is compiled with TPM 1.2 support).
+
+==item B<tpm-2.0> (since 0.7)
+
+TPM 2 setup is supported (libtpms is compiled with TPM 2 support).
 
 =back
 

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -1328,7 +1328,7 @@ int main(int argc, char *argv[])
     swtpm_prg_l = split_cmdline(swtpm_prg);
     tmp = g_find_program_in_path(swtpm_prg_l[0]);
     if (!tmp) {
-        logerr(gl_LOGFILE, "TPM at %s is not an executable.\n", swtpm_prg);
+        logerr(gl_LOGFILE, "swtpm at %s is not an executable.\n", swtpm_prg_l[0]);
         goto error;
     }
     g_free(tmp);

--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -72,7 +72,7 @@ if [ -x "$(type -P $(echo "${SWTPM_CERT}" | cut -d" " -f1) )" ]; then
 
 	echo "Test 3: OK"
 else
-	echo "Test 2: SKIP -- ${SWTPM_CERT} not found or not an executable"
+	echo "Test 3: SKIP -- ${SWTPM_CERT} not found or not an executable"
 fi
 
 exit 0

--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -43,7 +43,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # The are some variable parameters at the end, use regex
-exp='\{ "type": "swtpm_setup", "features": \[ "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", "tpm12-not-need-root", "cmdarg-write-ek-cert-files"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")? \], "version": "[^"]*" \}'
+exp='\{ "type": "swtpm_setup", "features": \[ "tpm-1.2",( "tpm-2.0",)? "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", "tpm12-not-need-root", "cmdarg-write-ek-cert-files"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")? \], "version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_SETUP} to --print-capabilities:"
 	echo "Actual   : ${msg}"

--- a/tests/_test_tpm2_print_capabilities
+++ b/tests/_test_tpm2_print_capabilities
@@ -73,7 +73,7 @@ if [ -x "$(type -P $(echo "${SWTPM_CERT}" | cut -d" " -f1) )" ]; then
 
 	echo "Test 3: OK"
 else
-	echo "Test 2: SKIP -- ${SWTPM_CERT} not found or not an executable"
+	echo "Test 3: SKIP -- ${SWTPM_CERT} not found or not an executable"
 fi
 
 exit 0

--- a/tests/_test_tpm2_print_capabilities
+++ b/tests/_test_tpm2_print_capabilities
@@ -44,7 +44,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # The are some variable parameters at the end, use regex
-exp='\{ "type": "swtpm_setup", "features": \[ "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", "tpm12-not-need-root", "cmdarg-write-ek-cert-files"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")? \], "version": "[^"]*" \}'
+exp='\{ "type": "swtpm_setup", "features": \[( "tpm-1.2",)? "tpm-2.0", "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", "tpm12-not-need-root", "cmdarg-write-ek-cert-files"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")? \], "version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_SETUP} to --print-capabilities:"
 	echo "Actual   : ${msg}"


### PR DESCRIPTION
Implement get_supported_tpm_versions to get swtpm's support for TPM 1.2
and TPM 2 and use it error out in case user choose a TPM version that
is not supported. Also display the supported TPM versions in the
capabilites JSON.