### PR TITLE
swtpm: Allow sched_setattr in seccomp profile for CUSE TPM

### DIFF
--- a/src/swtpm/seccomp_profile.c
+++ b/src/swtpm/seccomp_profile.c
@@ -148,7 +148,6 @@ int create_seccomp_profile(bool cusetpm, unsigned int action)
         SCMP_SYS(sched_setparam),
         SCMP_SYS(sched_setscheduler),
         SCMP_SYS(sched_setaffinity),
-        SCMP_SYS(sched_setattr),
         SCMP_SYS(vhangup),
         SCMP_SYS(sethostname),
         SCMP_SYS(setdomainname),
@@ -253,6 +252,8 @@ int create_seccomp_profile(bool cusetpm, unsigned int action)
 #ifdef __NR_clone3
         SCMP_SYS(clone3),
 #endif
+        /* misc */
+        SCMP_SYS(sched_setattr), /* caller: g_thread_pool_new() glib v2.68 */
     };
     scmp_filter_ctx ctx;
     int ret;


### PR DESCRIPTION
glib's (v2.68) g_thread_pool_new() calls the syscall sched_setattr(),
which we must allow to avoid termination of the CUSE TPM.

This patch resolves issue #520.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>