### PR TITLE
swtpm: Add missing braces around TPM_DEBUG after if statement

### DIFF
--- a/src/swtpm/swtpm_nvstore_dir.c
+++ b/src/swtpm/swtpm_nvstore_dir.c
@@ -145,8 +145,9 @@ SWTPM_NVRAM_Validate_Dir(const char *tpm_state_path)
             rc = TPM_FAIL;
         }
     }
-    if (rc == 0)
+    if (rc == 0) {
         TPM_DEBUG("SWTPM_NVRAM_Validate_Dir: Rooted state path %s\n", tpm_state_path);
+    }
 
     return rc;
 }


### PR DESCRIPTION
Fix the following compilation issue:

swtpm_nvstore_dir.c: In function 'SWTPM_NVRAM_Validate_Dir':
swtpm_nvstore_dir.c:149:86: error: suggest braces around empty body in an 'if' statement [-Werror=empty-body]
         TPM_DEBUG("SWTPM_NVRAM_Validate_Dir: Rooted state path %s\n", tpm_state_path);
                                                                                      ^
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>