### PR TITLE
tests: Skip chardev related tests after checking for chardev support

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,17 +15,12 @@ TESTS = \
 	test_vtpm_proxy \
 	test_tpm2_vtpm_proxy
 
-if WITH_CHARDEV
-TESTS += \
-	test_ctrlchannel2 \
-	test_ctrlchannel4 \
-	test_tpm2_ctrlchannel2
-endif
-
 TESTS += \
 	test_commandline \
 	test_ctrlchannel \
+	test_ctrlchannel2 \
 	test_ctrlchannel3 \
+	test_ctrlchannel4 \
 	test_encrypted_state \
 	test_getcap \
 	test_hashing \
@@ -47,6 +42,7 @@ TESTS += \
 	test_print_capabilities
 
 TESTS += \
+	test_tpm2_ctrlchannel2 \
 	test_tpm2_derived_keys \
 	test_tpm2_encrypted_state \
 	test_tpm2_init \

--- a/tests/common
+++ b/tests/common
@@ -855,3 +855,16 @@ function skip_test_no_tpm20()
 		exit 77
 	fi
 }
+
+# Check whether swtpm supports chardev interface
+function skip_test_no_chardev()
+{
+	local swtpm_exe="$1"
+
+	local res=$(${swtpm_exe} chardev --help 2>&1 |
+		    grep "Unsupported TPM interface")
+	if [ -n "${res}" ]; then
+		echo "${swtpm_exe} does not support chardev interface"
+		exit 77
+	fi
+}

--- a/tests/test_ctrlchannel2
+++ b/tests/test_ctrlchannel2
@@ -16,6 +16,7 @@ RESP_PATH=$TPMDIR/resp
 VOLATILESTATE=$TPMDIR/volatile
 
 source ${TESTDIR}/common
+skip_test_no_chardev "${SWTPM_EXE}"
 skip_test_no_tpm12 "${SWTPM_EXE}"
 
 trap "cleanup" SIGTERM EXIT

--- a/tests/test_ctrlchannel4
+++ b/tests/test_ctrlchannel4
@@ -24,6 +24,7 @@ function cleanup()
 
 SWTPM_INTERFACE=socket+unix
 source ${TESTDIR}/common
+skip_test_no_chardev "${SWTPM_EXE}"
 skip_test_no_tpm12 "${SWTPM_EXE}"
 
 # Test 1: test the control channel on the chardev tpm

--- a/tests/test_tpm2_ctrlchannel2
+++ b/tests/test_tpm2_ctrlchannel2
@@ -18,6 +18,7 @@ VOLATILESTATE=$TPMDIR/volatile
 
 source ${TESTDIR}/common
 source ${TESTDIR}/test_common
+skip_test_no_chardev "${SWTPM_EXE}"
 skip_test_no_tpm20 "${SWTPM_EXE}"
 
 trap "cleanup" SIGTERM EXIT


### PR DESCRIPTION
Skip tests that require the chardev after checking for the chardev
interface support in swtpm. Remove the conditional addition of chardev
related tests from the Makefile.am.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>