### PR TITLE
Introduce "--print-states" to check TPM state existence

### DIFF
--- a/src/swtpm/swtpm_nvstore.c
+++ b/src/swtpm/swtpm_nvstore.c
@@ -195,6 +195,47 @@ void SWTPM_NVRAM_Shutdown(void)
     memset(&migrationkey, 0, sizeof(migrationkey));
 }
 
+/* SWTPM_NVRAM_GetFilenameForName() constructs a file name from the name.
+ * A temporary filename used to write to may be created. It should be rename()'d to
+ * the non-temporary filename.
+ */
+
+TPM_RESULT
+SWTPM_NVRAM_GetFilenameForName(char *filename,       /* output: filename */
+                               size_t bufsize,
+                               uint32_t tpm_number,
+                               const char *name,     /* input: abstract name */
+                               TPM_BOOL is_tempfile) /* input: is temporary file? */
+{
+    TPM_RESULT res = TPM_SUCCESS;
+    int n;
+    const char *suffix = "";
+
+    TPM_DEBUG(" SWTPM_NVRAM_GetFilenameForName: For name %s\n", name);
+
+    switch (tpmstate_get_version()) {
+    case TPMLIB_TPM_VERSION_1_2:
+        break;
+    case TPMLIB_TPM_VERSION_2:
+        suffix = "2";
+        break;
+    }
+
+    if (is_tempfile) {
+        n = snprintf(filename, bufsize, "TMP%s-%02lx.%s", suffix, (unsigned long)tpm_number, name);
+    } else {
+        n = snprintf(filename, bufsize, "tpm%s-%02lx.%s", suffix, (unsigned long)tpm_number, name);
+    }
+    if ((size_t)n > bufsize) {
+        res = TPM_FAIL;
+    }
+
+    TPM_DEBUG("  SWTPM_NVRAM_GetFilenameForName: File name %s\n", filename);
+
+    return res;
+}
+
+
 /* Load 'data' of 'length' from the 'name'.
 
    'data' must be freed after use.

--- a/src/swtpm/swtpm_nvstore.h
+++ b/src/swtpm/swtpm_nvstore.h
@@ -87,6 +87,12 @@ TPM_RESULT SWTPM_NVRAM_SetStateBlob(unsigned char *data,
                                     uint32_t tpm_number,
                                     uint32_t blobtype);
 
+TPM_RESULT SWTPM_NVRAM_GetFilenameForName(char *filename,
+                                          size_t bufsize,
+                                          uint32_t tpm_number,
+                                          const char *name,
+                                          TPM_BOOL is_tempfile);
+
 size_t SWTPM_NVRAM_FileKey_Size(void);
 static inline TPM_BOOL SWTPM_NVRAM_Has_FileKey(void)
 {

--- a/src/swtpm/swtpm_nvstore.h
+++ b/src/swtpm/swtpm_nvstore.h
@@ -122,5 +122,6 @@ struct nvram_backend_ops {
                          TPM_BOOL mustExist,
                          const char *uri);
 };
+int SWTPM_NVRAM_Print_Json(void);
 
 #endif /* _SWTPM_NVSTORE_H */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -39,7 +39,8 @@ TESTS += \
 	test_tpm12 \
 	test_wrongorder \
 	\
-	test_print_capabilities
+	test_print_capabilities \
+	test_swtpm_setup_overwrite
 
 TESTS += \
 	test_tpm2_ctrlchannel2 \
@@ -68,7 +69,8 @@ TESTS += \
 	\
 	test_tpm2_swtpm_bios \
 	\
-	test_tpm2_ibmtss2
+	test_tpm2_ibmtss2 \
+	test_tpm2_swtpm_setup_overwrite
 
 if WITH_GNUTLS
 TESTS += \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -40,6 +40,7 @@ TESTS += \
 	test_wrongorder \
 	\
 	test_print_capabilities \
+	test_print_states \
 	test_swtpm_setup_overwrite
 
 TESTS += \
@@ -55,6 +56,7 @@ TESTS += \
 	test_tpm2_migration_key \
 	test_tpm2_partial_reads \
 	test_tpm2_print_capabilities \
+	test_tpm2_print_states \
 	test_tpm2_resume_volatile \
 	test_tpm2_savestate \
 	test_tpm2_save_load_encrypted_state \
@@ -165,6 +167,7 @@ EXTRA_DIST=$(TESTS) \
 	_test_migration_key \
 	_test_migration_key_2 \
 	_test_print_capabilities \
+	_test_print_states \
 	_test_resume_volatile \
 	_test_save_load_encrypted_state \
 	_test_save_load_state \
@@ -181,6 +184,7 @@ EXTRA_DIST=$(TESTS) \
 	_test_tpm2_locality \
 	_test_tpm2_migration_key \
 	_test_tpm2_print_capabilities \
+	_test_tpm2_print_states \
 	_test_tpm2_probe \
 	_test_tpm2_resume_volatile \
 	_test_tpm2_savestate \

--- a/tests/_test_print_states
+++ b/tests/_test_print_states
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# For the license, see the LICENSE file in the root directory.
+#set -x
+
+ROOT=${abs_top_builddir:-$(pwd)/..}
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+
+PATH=$ROOT/src/swtpm:$PATH
+
+[ "${SWTPM_IFACE}" == "cuse" ] && source ${TESTDIR}/test_cuse
+source ${TESTDIR}/common
+
+trap "cleanup" SIGTERM EXIT
+
+function cleanup()
+{
+	rm -rf ${workdir}
+}
+
+# Test 1: No states
+
+workdir=$(mktemp -d)
+msg="$(${SWTPM_EXE} ${SWTPM_IFACE} --print-states --tpmstate dir=${workdir} 2>&1)"
+
+if [ $? -ne 0 ]; then
+	echo "Error: Could not pass --print-states"
+	echo "${msg}"
+	exit 1
+fi
+
+exp='\{ "type": "swtpm", "states": \[\] \}'
+if ! [[ ${msg} =~ ${exp} ]]; then
+	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-states:"
+	echo "Actual   : ${msg}"
+	echo "Expected : ${exp}"
+	echo "Test 1: Failed"
+	exit 1
+fi
+
+echo "Test 1: OK"
+cleanup
+
+# Test 2: Existing state
+
+workdir=$(mktemp -d)
+statefile="${workdir}/tpm-00.permall"
+dummydata="DUMMY"
+echo $dummydata > ${statefile}
+
+msg="$(${SWTPM_EXE} ${SWTPM_IFACE} --print-states --tpmstate dir=${workdir} 2>&1)"
+
+if [ $? -ne 0 ]; then
+	echo "Error: Could not pass --print-states"
+	echo "${msg}"
+	exit 1
+fi
+
+exp='\{ "type": "swtpm", "states": \[ \{ "name": "tpm-00.permall" \} \] \}'
+if ! [[ ${msg} =~ ${exp} ]]; then
+	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-states:"
+	echo "Actual   : ${msg}"
+	echo "Expected : ${exp}"
+	exit 1
+fi
+
+echo "Test 2: OK"
+cleanup
+
+exit 0

--- a/tests/_test_tpm2_print_states
+++ b/tests/_test_tpm2_print_states
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# For the license, see the LICENSE file in the root directory.
+#set -x
+
+ROOT=${abs_top_builddir:-$(pwd)/..}
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+
+PATH=$ROOT/src/swtpm:$PATH
+
+[ "${SWTPM_IFACE}" == "cuse" ] && source ${TESTDIR}/test_cuse
+source ${TESTDIR}/common
+
+trap "cleanup" SIGTERM EXIT
+
+function cleanup()
+{
+	rm -rf ${workdir}
+}
+
+# Test 1: No states
+
+workdir=$(mktemp -d)
+msg="$(${SWTPM_EXE} ${SWTPM_IFACE} --print-states --tpm2 --tpmstate dir=${workdir} 2>&1)"
+
+if [ $? -ne 0 ]; then
+	echo "Error: Could not pass --print-states"
+	echo "${msg}"
+	exit 1
+fi
+
+exp='\{ "type": "swtpm", "states": \[\] \}'
+if ! [[ ${msg} =~ ${exp} ]]; then
+	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-states:"
+	echo "Actual   : ${msg}"
+	echo "Expected : ${exp}"
+	echo "Test 1: Failed"
+	exit 1
+fi
+
+echo "Test 1: OK"
+cleanup
+
+# Test 2: Existing state
+
+workdir=$(mktemp -d)
+statefile="${workdir}/tpm2-00.permall"
+dummydata="DUMMY"
+echo $dummydata > ${statefile}
+
+msg="$(${SWTPM_EXE} ${SWTPM_IFACE} --print-states --tpm2 --tpmstate dir=${workdir} 2>&1)"
+
+if [ $? -ne 0 ]; then
+	echo "Error: Could not pass --print-states"
+	echo "${msg}"
+	exit 1
+fi
+
+exp='\{ "type": "swtpm", "states": \[ \{ "name": "tpm2-00.permall" \} \] \}'
+if ! [[ ${msg} =~ ${exp} ]]; then
+	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-states:"
+	echo "Actual   : ${msg}"
+	echo "Expected : ${exp}"
+	exit 1
+fi
+
+echo "Test 2: OK"
+cleanup
+
+exit 0

--- a/tests/test_print_states
+++ b/tests/test_print_states
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
+cd "$(dirname "$0")"
+
+export SWTPM_IFACE=cuse
+bash _test_print_states
+ret=$?
+[ $ret -ne 0 ] && [ $ret -ne 77 ] && exit $ret
+
+export SWTPM_IFACE=socket
+bash _test_print_states
+ret=$?
+[ $ret -ne 0 ] && [ $ret -ne 77 ] && exit $ret
+
+exit 0

--- a/tests/test_swtpm_setup_overwrite
+++ b/tests/test_swtpm_setup_overwrite
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+# For the license, see the LICENSE file in the root directory.
+
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+SRCDIR=${abs_top_srcdir:-$(dirname "$0")/..}
+
+source ${TESTDIR}/common
+skip_test_no_tpm12 "${SWTPM_EXE}"
+STATEBASENAME="tpm-00.permall"
+
+SWTPM_SETUP_CONF=$SRCDIR/samples/swtpm_setup.conf
+
+trap "cleanup" SIGTERM EXIT
+
+function cleanup()
+{
+	rm -rf ${workdir}
+}
+
+# Test 1: --not-overwrite with dummy state file
+
+workdir=$(mktemp -d)
+statefile="${workdir}/${STATEBASENAME}"
+dummydata="DUMMY"
+echo $dummydata > ${statefile}
+
+$SWTPM_SETUP \
+	--not-overwrite \
+	--tpm-state ${workdir} \
+	--config ${SWTPM_SETUP_CONF} \
+	--logfile ${workdir}/logfile \
+	--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}"
+
+if [ $? -ne 0 ]; then
+	echo "Test 1 failed: Error: Could not run $SWTPM_SETUP."
+	echo "Setup Logfile:"
+	cat ${workdir}/logfile
+	exit 1
+fi
+
+if [ -z "$(grep ${dummydata} ${statefile})" ]; then
+	echo "Test 1 failed: Error: The state file was unexpectedly overwritten."
+	echo "Setup Logfile:"
+	cat ${workdir}/logfile
+	exit 1
+fi
+
+echo "Test 1 passed"
+cleanup
+
+# Test 2: --overwrite with dummy state file
+
+workdir=$(mktemp -d)
+statefile="${workdir}/${STATEBASENAME}"
+dummydata="DUMMY"
+echo $dummydata > ${statefile}
+
+$SWTPM_SETUP \
+	--overwrite \
+	--tpm-state ${workdir} \
+	--config ${SWTPM_SETUP_CONF} \
+	--logfile ${workdir}/logfile \
+	--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}"
+
+if [ $? -ne 0 ]; then
+	echo "Test 2 failed: Error: Could not run $SWTPM_SETUP."
+	echo "Setup Logfile:"
+	cat ${workdir}/logfile
+	exit 1
+fi
+
+if [ -n "$(grep ${dummydata} ${statefile})" ]; then
+	echo "Test 2 failed: Error: The state file was not overwritten."
+	echo "Setup Logfile:"
+	cat ${workdir}/logfile
+	exit 1
+fi
+
+echo "Test 2 passed"
+cleanup
+
+# Test 3: neither "--overwrite" nor "--not-overwrite" with dummy state file
+
+workdir=$(mktemp -d)
+statefile="${workdir}/${STATEBASENAME}"
+dummydata="DUMMY"
+echo $dummydata > ${statefile}
+
+$SWTPM_SETUP \
+	--tpm-state ${workdir} \
+	--config ${SWTPM_SETUP_CONF} \
+	--logfile ${workdir}/logfile \
+	--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}"
+
+if [ $? -ne 1 ]; then
+	echo "Test 3 failed: Error: $SWTPM_SETUP did not exit with exit code 1."
+	echo "Setup Logfile:"
+	cat ${workdir}/logfile
+	exit 1
+fi
+
+if [ -z "$(grep ${dummydata} ${statefile})" ]; then
+	echo "Test 3 failed: Error: The state file was unexpectedly overwritten."
+	echo "Setup Logfile:"
+	cat ${workdir}/logfile
+	exit 1
+fi
+
+echo "Test 3 passed"
+cleanup
+
+exit 0

--- a/tests/test_tpm2_print_states
+++ b/tests/test_tpm2_print_states
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
+cd "$(dirname "$0")"
+
+export SWTPM_IFACE=cuse
+bash _test_print_states
+ret=$?
+[ $ret -ne 0 ] && [ $ret -ne 77 ] && exit $ret
+
+export SWTPM_IFACE=socket
+bash _test_print_states
+ret=$?
+[ $ret -ne 0 ] && [ $ret -ne 77 ] && exit $ret
+
+exit 0

--- a/tests/test_tpm2_swtpm_setup_overwrite
+++ b/tests/test_tpm2_swtpm_setup_overwrite
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+# For the license, see the LICENSE file in the root directory.
+
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+SRCDIR=${abs_top_srcdir:-$(dirname "$0")/..}
+
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+STATEBASENAME="tpm2-00.permall"
+
+SWTPM_SETUP_CONF=$SRCDIR/samples/swtpm_setup.conf
+
+trap "cleanup" SIGTERM EXIT
+
+function cleanup()
+{
+	rm -rf ${workdir}
+}
+
+# Test 1: --not-overwrite with dummy state file
+
+workdir=$(mktemp -d)
+statefile="${workdir}/${STATEBASENAME}"
+dummydata="DUMMY"
+echo $dummydata > ${statefile}
+
+$SWTPM_SETUP \
+	--tpm2 \
+	--not-overwrite \
+	--tpm-state ${workdir} \
+	--config ${SWTPM_SETUP_CONF} \
+	--logfile ${workdir}/logfile \
+	--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}"
+
+if [ $? -ne 0 ]; then
+	echo "Test 1 failed: Error: Could not run $SWTPM_SETUP."
+	echo "Setup Logfile:"
+	cat ${workdir}/logfile
+	exit 1
+fi
+
+if [ -z "$(grep ${dummydata} ${statefile})" ]; then
+	echo "Test 1 failed: Error: The state file was unexpectedly overwritten."
+	echo "Setup Logfile:"
+	cat ${workdir}/logfile
+	exit 1
+fi
+
+echo "Test 1 passed"
+cleanup
+
+# Test 2: --overwrite with dummy state file
+
+workdir=$(mktemp -d)
+statefile="${workdir}/${STATEBASENAME}"
+dummydata="DUMMY"
+echo $dummydata > ${statefile}
+
+$SWTPM_SETUP \
+	--tpm2 \
+	--overwrite \
+	--tpm-state ${workdir} \
+	--config ${SWTPM_SETUP_CONF} \
+	--logfile ${workdir}/logfile \
+	--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}"
+
+if [ $? -ne 0 ]; then
+	echo "Test 2 failed: Error: Could not run $SWTPM_SETUP."
+	echo "Setup Logfile:"
+	cat ${workdir}/logfile
+	exit 1
+fi
+
+if [ -n "$(grep ${dummydata} ${statefile})" ]; then
+	echo "Test 2 failed: Error: The state file was not overwritten."
+	echo "Setup Logfile:"
+	cat ${workdir}/logfile
+	exit 1
+fi
+
+echo "Test 2 passed"
+cleanup
+
+# Test 3: neither "--overwrite" nor "--not-overwrite" with dummy state file
+
+workdir=$(mktemp -d)
+statefile="${workdir}/${STATEBASENAME}"
+dummydata="DUMMY"
+echo $dummydata > ${statefile}
+
+$SWTPM_SETUP \
+	--tpm2 \
+	--tpm-state ${workdir} \
+	--config ${SWTPM_SETUP_CONF} \
+	--logfile ${workdir}/logfile \
+	--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}"
+
+if [ $? -ne 1 ]; then
+	echo "Test 3 failed: Error: $SWTPM_SETUP did not exit with exit code 1."
+	echo "Setup Logfile:"
+	cat ${workdir}/logfile
+	exit 1
+fi
+
+if [ -z "$(grep ${dummydata} ${statefile})" ]; then
+	echo "Test 3 failed: Error: The state file was unexpectedly overwritten."
+	echo "Setup Logfile:"
+	cat ${workdir}/logfile
+	exit 1
+fi
+
+echo "Test 3 passed"
+cleanup
+
+exit 0


### PR DESCRIPTION
Currently, swtpm_setup checks TPM state existence by directly accessing TPM state dir. To support pluggable storage backend https://github.com/stefanberger/swtpm/issues/461 , it's better for swtpm_setup not to have dependencies on implementation details of TPM state backend.

This PR introduces a new option "--print-states" to swtpm. With this option, swtpm shows TPM state status as follows:

```
      $ swtpm socket --print-states --tpmstate dir=/tmp --tpm2 | jq .
      {
        "type": "swtpm",
        "states": [
          {
            "name": "tpm2-00.permall"
          }
        ]
      }
```

Through that output, swtpm_setup can check existence of TPM state.

Current "--print-states" only shows "permall" state as it's the only one currently required for swtpm_setup. Of course it's open to discuss whether we should have other names ("volatile", "savestate").

### Commits Summary

* 2386357 swtpm_setup: Add tests for --overwrite options
  * Tests for swtpm_setup to ensure we can keep current behavior.
* d79a52c swtpm: Add GetFilepathForName()
  * Move GetFilenameForName() to nvstore.c so that we can use the func from "--print-states"
* bd95b57 swtpm: Add --print-states for reporting TPM states status
  * Implementation of "--print-states".
* 268d4dd swtpm_setup: Use --print-states in check_state_overwrite()
  * Replace check_state_overwrite() implementation.