### PR TITLE
Minor fixes for --print-states option

### DIFF
--- a/src/swtpm/cuse_tpm.c
+++ b/src/swtpm/cuse_tpm.c
@@ -1619,7 +1619,7 @@ int swtpm_cuse_main(int argc, char **argv, const char *prgname, const char *ifac
             ret = EXIT_FAILURE;
             goto exit;
         }
-        ret = SWTPM_NVRAM_Print_Json();
+        ret = SWTPM_NVRAM_PrintJson();
         ret = ret ? EXIT_FAILURE : EXIT_SUCCESS;
         goto exit;
     }

--- a/src/swtpm/swtpm.c
+++ b/src/swtpm/swtpm.c
@@ -450,7 +450,7 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
                       "Error: --tpmstate option is required for --print-states\n");
             goto exit_failure;
         }
-        ret = SWTPM_NVRAM_Print_Json();
+        ret = SWTPM_NVRAM_PrintJson();
         if (ret == 0)
             goto exit_success;
         else

--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -493,7 +493,7 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
                       "Error: --tpmstate option is required for --print-states\n");
             exit(EXIT_FAILURE);
         }
-        ret = SWTPM_NVRAM_Print_Json();
+        ret = SWTPM_NVRAM_PrintJson();
         if (ret)
             goto exit_failure;
         else

--- a/src/swtpm/swtpm_nvstore.c
+++ b/src/swtpm/swtpm_nvstore.c
@@ -1296,9 +1296,10 @@ int SWTPM_NVRAM_PrintJson(void)
             ret = -1;
             goto cleanup;
         }
-    }
 
-    printf("{ \"type\": \"swtpm\", \"states\": [%s] }", state_str ? state_str : "");
+        printf("{ \"type\": \"swtpm\", \"states\": [%s] }", state_str ? state_str : "");
+    } else
+        ret = -1;
 
 cleanup:
     free(state_str);

--- a/src/swtpm/swtpm_nvstore.c
+++ b/src/swtpm/swtpm_nvstore.c
@@ -1264,7 +1264,7 @@ cleanup:
  *    [ { "name": "tpm2-00.permall" } ]
  *  }
  */
-int SWTPM_NVRAM_Print_Json(void)
+int SWTPM_NVRAM_PrintJson(void)
 {
     TPM_RESULT rc = 0;
     int ret = 0, n;

--- a/src/swtpm/swtpm_nvstore.h
+++ b/src/swtpm/swtpm_nvstore.h
@@ -122,6 +122,6 @@ struct nvram_backend_ops {
                          TPM_BOOL mustExist,
                          const char *uri);
 };
-int SWTPM_NVRAM_Print_Json(void);
+int SWTPM_NVRAM_PrintJson(void);
 
 #endif /* _SWTPM_NVSTORE_H */

--- a/tests/test_tpm2_print_states
+++ b/tests/test_tpm2_print_states
@@ -8,12 +8,12 @@ skip_test_no_tpm20 "${SWTPM_EXE}"
 cd "$(dirname "$0")"
 
 export SWTPM_IFACE=cuse
-bash _test_print_states
+bash _test_tpm2_print_states
 ret=$?
 [ $ret -ne 0 ] && [ $ret -ne 77 ] && exit $ret
 
 export SWTPM_IFACE=socket
-bash _test_print_states
+bash _test_tpm2_print_states
 ret=$?
 [ $ret -ne 0 ] && [ $ret -ne 77 ] && exit $ret
 


### PR DESCRIPTION
Some minor fixes for `--print-states` which is recently introduced in https://github.com/stefanberger/swtpm/pull/524. This PR includes function name change (Print_Json => PrintJson), a test fix and error handling fix. 