### PR TITLE
configure: drop python dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ addons:
         - sed
         - bash
         - dh-exec
-        - python3-pip
-        - python3-twisted
         - libfuse-dev
         - libglib2.0-dev
         - libjson-glib-dev
@@ -48,7 +46,6 @@ before_install:
       sudo apt-get -y install trousers
     fi
 script:
-  - sudo pip3 install --upgrade pip==20.3.3
   - if [ ! -d libtpms ]; then git clone https://github.com/stefanberger/libtpms; fi
   - cd libtpms
   - if [ -n "${LIBTPMS_GIT_CHECKOUT}" ]; then

--- a/configure.ac
+++ b/configure.ac
@@ -371,18 +371,6 @@ if test "x$CP" = "x"; then
 	AC_MSG_ERROR([cp is required])
 fi
 
-AM_PATH_PYTHON([3.3])
-
-AC_PATH_PROG([PIP3], pip3)
-if test "x$PIP3" = "x"; then
-	AC_PATH_PROG([PIP3], pip)
-	if test "x$PIP3" = "x"; then
-		AC_MSG_WARN([pip3 is required to uninstall the built package])
-	else
-		AC_MSG_WARN([Using pip as pip3 tool])
-	fi
-fi
-
 AC_ARG_ENABLE([hardening],
   AS_HELP_STRING([--disable-hardening], [Disable hardening flags]))
 


### PR DESCRIPTION
as far as I can tell, 0.6.0 dropped the python dependency, yet the
configure still looks out for a python to be available. I don't believe
it makes any use of it.

This reduces the dependency graph on build.