### PR TITLE
build-sys: Add -Wno-deprecated-declarations to default CFLAGS (OSSL 3)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -466,6 +466,7 @@ AC_SUBST([TSS_GROUP])
 CFLAGS="$CFLAGS -Wreturn-type -Wsign-compare -Wswitch-enum"
 CFLAGS="$CFLAGS -Wmissing-prototypes -Wall -Werror"
 CFLAGS="$CFLAGS -Wformat -Wformat-security"
+CFLAGS="$CFLAGS -Wno-deprecated-declarations"
 CFLAGS="$CFLAGS $GNUTLS_CFLAGS $COVERAGE_CFLAGS"
 
 LDFLAGS="$LDFLAGS $COVERAGE_LDFLAGS"


### PR DESCRIPTION
To be able to build with OpenSSL 3.0 we need to added
-Wno-deprecated-declarations to the default CFLAGS.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>