### PR TITLE
build-sys: Use -Wno-deprecated-declarations only for swtpm and swtpm_…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -466,7 +466,6 @@ AC_SUBST([TSS_GROUP])
 CFLAGS="$CFLAGS -Wreturn-type -Wsign-compare -Wswitch-enum"
 CFLAGS="$CFLAGS -Wmissing-prototypes -Wall -Werror"
 CFLAGS="$CFLAGS -Wformat -Wformat-security"
-CFLAGS="$CFLAGS -Wno-deprecated-declarations"
 CFLAGS="$CFLAGS $GNUTLS_CFLAGS $COVERAGE_CFLAGS"
 
 LDFLAGS="$LDFLAGS $COVERAGE_LDFLAGS"

--- a/src/swtpm/Makefile.am
+++ b/src/swtpm/Makefile.am
@@ -68,6 +68,7 @@ libswtpm_libtpms_la_CFLAGS = \
 	-I$(top_srcdir)/include/swtpm \
 	$(MY_CFLAGS) \
 	$(CFLAGS) \
+	-Wno-deprecated-declarations \
 	$(HARDENING_CFLAGS) \
 	$(GLIB_CFLAGS) \
 	$(LIBSECCOMP_CFLAGS)

--- a/src/swtpm_setup/Makefile.am
+++ b/src/swtpm_setup/Makefile.am
@@ -44,6 +44,7 @@ swtpm_setup_CFLAGS = \
 	-I$(top_srcdir)/src/utils \
 	$(MY_CFLAGS) \
 	$(CFLAGS) \
+	-Wno-deprecated-declarations \
 	$(HARDENING_CFLAGS) \
 	$(GLIB_CFLAGS) \
 	$(JSON_GLIB_CFLAGS)


### PR DESCRIPTION
…setup

Rather than applying -Wno-deprecated-declarations everywhere, only
build swtpm and swtpm_setup with it.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>