### PR TITLE
build-sys: Use -DOPENSSL_SUPPRESS_DEPRECATED (OSSL 3)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -151,6 +151,8 @@ openssl)
 	AC_MSG_RESULT([Building with openssl crypto library])
 	LIBCRYPTO_LIBS=$(pkg-config --libs libcrypto)
 	AC_SUBST([LIBCRYPTO_LIBS])
+	LIBCRYPTO_EXTRA_CFLAGS="-DOPENSSL_SUPPRESS_DEPRECATED"
+	AC_SUBST([LIBCRYPTO_EXTRA_CFLAGS])
 	;;
 esac
 
@@ -457,7 +459,6 @@ AC_SUBST([TSS_GROUP])
 CFLAGS="$CFLAGS -Wreturn-type -Wsign-compare -Wswitch-enum"
 CFLAGS="$CFLAGS -Wmissing-prototypes -Wall -Werror"
 CFLAGS="$CFLAGS -Wformat -Wformat-security"
-CFLAGS="$CFLAGS -Wno-deprecated-declarations"
 CFLAGS="$CFLAGS $GNUTLS_CFLAGS $COVERAGE_CFLAGS"
 
 LDFLAGS="$LDFLAGS $COVERAGE_LDFLAGS"

--- a/src/swtpm/Makefile.am
+++ b/src/swtpm/Makefile.am
@@ -63,7 +63,8 @@ libswtpm_libtpms_la_CFLAGS = \
 	-I$(top_srcdir)/include/swtpm \
 	$(HARDENING_CFLAGS) \
 	$(GLIB_CFLAGS) \
-	$(LIBSECCOMP_CFLAGS)
+	$(LIBSECCOMP_CFLAGS) \
+	$(LIBCRYPTO_EXTRA_CFLAGS)
 
 libswtpm_libtpms_la_LDFLAGS = \
 	$(HARDENING_LDFLAGS)


### PR DESCRIPTION
Use the (undocumented) OPENSSL_SUPPRESS_DEPRECATED to suppress the
deprecated API warnings when compiling swtpm and swtpm_setup with
OpenSSL 3.0.0 replacing the global -Wno-deprecated-declarations.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>