### PR TITLE
swtpm: Don't set MAIN_LOOP_FLAG_END_ON_HUP flag in CMD_SET_DATAFD handler

### DIFF
--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -790,8 +790,7 @@ int ctrlchannel_process_fd(int fd,
             goto err_bad_input;
         }
 
-        mlp->flags |= MAIN_LOOP_FLAG_USE_FD | MAIN_LOOP_FLAG_KEEP_CONNECTION |
-                       MAIN_LOOP_FLAG_END_ON_HUP;
+        mlp->flags |= MAIN_LOOP_FLAG_USE_FD | MAIN_LOOP_FLAG_KEEP_CONNECTION;
         mlp->fd = *data_fd;
 
         *res_p = htobe32(TPM_SUCCESS);


### PR DESCRIPTION
We recently agreed in [this conversation](https://github.com/stefanberger/swtpm/pull/509#issuecomment-890412478) that the `CMD_SET_DATAFD` handler shouldn't be setting `MAIN_LOOP_FLAG_END_ON_HUP` because:

- `MAIN_LOOP_FLAG_END_ON_HUP` is causing `swtpm` to _unconditionally_ terminate when the data channel connection drops,
- the `--terminate` command-line switch—which is supposed to allow the user to control this behavior—isn't being respected,
- the `CMD_SET_DATAFD` handler should stick to doing what it's meant to do (i.e. set the data channel FD) and nothing more, and
- consumers who want the daemon to self-terminate upon data channel HUP should simply use the `--terminate` switch, which has existed from the very beginning and is _the_ proper, documented, and officially supported way of achieving that behavior.

[Near the end of the discussion](https://github.com/stefanberger/swtpm/pull/509#issuecomment-890974225) we also agreed that we didn't want to break libvirt, which wasn't using `--terminate` and seemed to instead be relying on the implicit uncoditional termination behavior. This is no longer a concern because:

1. I've made [this contribution](https://gitlab.com/libvirt/libvirt/-/commit/dbc605d8d91fac2f6e55b9fc86d0e61085a9ec71) to libvirt which will now be launching `swtpm` with the `--terminate` switch 🎉, and
2. it turns out libvirt had [a failsafe](https://github.com/stefanberger/swtpm/pull/509#issuecomment-919031703) _all along_ which guarantees that `swtpm` be killed whenever QEMU dies, for _any_ reason.

Thanks to # 2 we can address this in `swtpm` now, without breaking _any_ version of libvirt, and without having to wait for a new downstream release.