### PR TITLE
swtpm: Use EVP_CIPHER in SWTPM_SymmetricKeyData_Encrypt/Decrypt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -156,8 +156,6 @@ openssl)
 	AC_MSG_RESULT([Building with openssl crypto library])
 	LIBCRYPTO_LIBS=$(pkg-config --libs libcrypto)
 	AC_SUBST([LIBCRYPTO_LIBS])
-	LIBCRYPTO_EXTRA_CFLAGS="-DOPENSSL_SUPPRESS_DEPRECATED"
-	AC_SUBST([LIBCRYPTO_EXTRA_CFLAGS])
 	;;
 esac
 

--- a/src/swtpm/Makefile.am
+++ b/src/swtpm/Makefile.am
@@ -70,8 +70,7 @@ libswtpm_libtpms_la_CFLAGS = \
 	$(CFLAGS) \
 	$(HARDENING_CFLAGS) \
 	$(GLIB_CFLAGS) \
-	$(LIBSECCOMP_CFLAGS) \
-	$(LIBCRYPTO_EXTRA_CFLAGS)
+	$(LIBSECCOMP_CFLAGS)
 
 libswtpm_libtpms_la_LDFLAGS = \
 	$(MY_LDFLAGS) \


### PR DESCRIPTION
Use the EVP_CIPHER implementation for the AES CBC computations. This
API has been supported already in OpenSSL 1.1.x for sure and is also
not deprecated in OpenSSL 3.0.

This partially resolves issue #538.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>