### PR TITLE
swtpm: Cleanup storage backend on shutdown to unlock dir

### DIFF
--- a/src/swtpm/swtpm_nvstore.c
+++ b/src/swtpm/swtpm_nvstore.c
@@ -195,6 +195,8 @@ TPM_RESULT SWTPM_NVRAM_Init(void)
 
 void SWTPM_NVRAM_Shutdown(void)
 {
+    if (g_nvram_backend_ops)
+        g_nvram_backend_ops->cleanup();
     memset(&filekey, 0, sizeof(filekey));
     memset(&migrationkey, 0, sizeof(migrationkey));
 }

--- a/src/swtpm/swtpm_nvstore.h
+++ b/src/swtpm/swtpm_nvstore.h
@@ -121,6 +121,7 @@ struct nvram_backend_ops {
                          const char *name,
                          TPM_BOOL mustExist,
                          const char *uri);
+    void (*cleanup)(void);
 };
 int SWTPM_NVRAM_PrintJson(void);
 

--- a/src/swtpm/swtpm_nvstore_dir.h
+++ b/src/swtpm/swtpm_nvstore_dir.h
@@ -73,6 +73,9 @@ SWTPM_NVRAM_DeleteName_Dir(uint32_t tpm_number,
                            TPM_BOOL mustExist,
                            const char *uri);
 
+void
+SWTPM_NVRAM_Cleanup_Dir(void);
+
 extern struct nvram_backend_ops nvram_dir_ops;
 
 #endif /* _SWTPM_NVSTORE_DIR_H */


### PR DESCRIPTION
Cleanup on the storage backend side on shutdown to unlock the
locked directory.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>