### PR TITLE
swptm_ioctl: Eliminate an unreachable statement

### DIFF
--- a/src/swtpm_ioctl/tpm_ioctl.c
+++ b/src/swtpm_ioctl/tpm_ioctl.c
@@ -420,8 +420,6 @@ static int do_save_state_blob(int fd, bool is_chardev, const char *blobtype,
         } else {
             offset += devtoh32(is_chardev, pgs.u.resp.length);
         }
-        if (!is_chardev)
-            break;
     }
 
     close(file_fd);


### PR DESCRIPTION
If is_chardev is false, then we have a buffersize of 4096 bytes per
the following statement:

322    if (!is_chardev)
323        buffersize = 4096;

With this we end up in the following if branch:

384        if (buffersize) {
385            /* continue with the read interface */
[...]
418
419            break;
420        } else {

Per the break in line 419 we leave the loop, thus cannot reach the
statement we remove:

423        if (!is_chardev)
424            break;

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>