### PR TITLE
aes: Avoid defining an already defined macro

### DIFF
--- a/src/swtpm/swtpm_aes.c
+++ b/src/swtpm/swtpm_aes.c
@@ -52,7 +52,9 @@
 #include "swtpm_aes.h"
 #include "logging.h"
 
+#ifndef printf
 #define printf(X ...)
+#endif
 
 typedef const EVP_CIPHER *(*evpfunc)(void);
 


### PR DESCRIPTION
printf() is already defined as a macro when the compiler in use does not
support __va_arg_pack, which is the case for e.g. clang:
```
../../../src/swtpm/swtpm_aes.c:55:9: error: 'printf' macro redefined
[-Werror,-Wmacro-redefined]
        ^
/usr/include/bits/stdio2.h:115:11: note: previous definition is here
          ^
1 error generated.
```