### PR TITLE
swtpm_setup: Forward --logfile option to swtpm

### DIFF
--- a/src/swtpm/swtpm.c
+++ b/src/swtpm/swtpm.c
@@ -406,6 +406,15 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
         exit(EXIT_FAILURE);
     }
 
+    /* change process ownership before accessing files */
+    if (runas) {
+        if (change_process_owner(runas) < 0)
+            exit(EXIT_FAILURE);
+    }
+
+    if (handle_log_options(logdata) < 0)
+        exit(EXIT_FAILURE);
+
     if (mlp.fd >= 0 && mlp.fd < 3) {
         /* no std{in,out,err} */
         logprintf(STDERR_FILENO,
@@ -434,12 +443,6 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
         goto exit_failure;
     }
 
-    /* change process ownership before accessing files */
-    if (runas) {
-        if (change_process_owner(runas) < 0)
-            goto exit_failure;
-    }
-
     tpmstate_set_version(mlp.tpmversion);
 
     if (printstates) {
@@ -457,8 +460,7 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
             goto exit_failure;
     }
 
-    if (handle_log_options(logdata) < 0 ||
-        handle_key_options(keydata) < 0 ||
+    if (handle_key_options(keydata) < 0 ||
         handle_migration_key_options(migkeydata) < 0 ||
         handle_pid_options(piddata) < 0 ||
         handle_locality_options(localitydata, &mlp.locality_flags) < 0 ||

--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -457,6 +457,15 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
         exit(EXIT_FAILURE);
     }
 
+    /* change process ownership before accessing files */
+    if (runas) {
+        if (change_process_owner(runas) < 0)
+            exit(EXIT_FAILURE);
+    }
+
+    if (handle_log_options(logdata) < 0)
+        exit(EXIT_FAILURE);
+
     if (handle_locality_options(localitydata, &mlp.locality_flags) < 0)
         exit(EXIT_FAILURE);
 
@@ -515,14 +524,7 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
         goto exit_failure;
     }
 
-    /* change process ownership before accessing files */
-    if (runas) {
-        if (change_process_owner(runas) < 0)
-            goto exit_failure;
-    }
-
-    if (handle_log_options(logdata) < 0 ||
-        handle_key_options(keydata) < 0 ||
+    if (handle_key_options(keydata) < 0 ||
         handle_migration_key_options(migkeydata) < 0 ||
         handle_pid_options(piddata) < 0 ||
         handle_tpmstate_options(tpmstatedata) < 0 ||

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -61,6 +61,7 @@ static int swtpm_start(struct swtpm *self)
     g_autofree gchar *server_fd = NULL;
     g_autofree gchar *ctrl_fd = NULL;
     g_autofree gchar *keyopts = NULL;
+    g_autofree gchar *logop = NULL;
     g_autofree gchar **argv = NULL;
     struct stat statbuf;
     gboolean success;
@@ -88,6 +89,11 @@ static int swtpm_start(struct swtpm *self)
     if (self->keyopts != NULL) {
         keyopts = g_strdup(self->keyopts);
         argv = concat_arrays(argv, (gchar*[]){"--key", keyopts, NULL}, TRUE);
+    }
+
+    if (gl_LOGFILE != NULL) {
+        logop = g_strdup_printf("file=%s", gl_LOGFILE);
+        argv = concat_arrays(argv, (gchar*[]){"--log", logop, NULL}, TRUE);
     }
 
     if (socketpair(AF_UNIX, SOCK_STREAM, 0, self->ctrl_fds) != 0) {

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -704,6 +704,7 @@ static int check_state_overwrite(gchar **swtpm_prg_l, unsigned int flags,
     g_autoptr(GError) error = NULL;
     g_autofree gchar **argv = NULL;
     g_autofree gchar *dirop = g_strdup_printf("dir=%s", tpm_state_path);
+    g_autofree gchar *logop = NULL;
     g_autofree gchar **my_argv = NULL;
 
     my_argv = concat_arrays((gchar*[]) {
@@ -716,7 +717,13 @@ static int check_state_overwrite(gchar **swtpm_prg_l, unsigned int flags,
     if (flags & SETUP_TPM2_F)
         my_argv = concat_arrays(my_argv, (gchar*[]) { "--tpm2", NULL }, TRUE);
 
+    if (gl_LOGFILE != NULL) {
+        logop = g_strdup_printf("file=%s", gl_LOGFILE);
+        my_argv = concat_arrays(my_argv, (gchar*[]){"--log", logop, NULL}, TRUE);
+    }
+
     argv = concat_arrays(swtpm_prg_l, my_argv, FALSE);
+
     success = g_spawn_sync(NULL, argv, NULL, G_SPAWN_STDERR_TO_DEV_NULL, NULL, NULL,
                            &standard_output, NULL, &exit_status, &error);
     if (!success) {
@@ -911,8 +918,15 @@ static int get_supported_tpm_versions(gchar **swtpm_prg_l, gboolean *swtpm_has_t
     g_autoptr(GError) error = NULL;
     g_autofree gchar **argv = NULL;
     gchar *my_argv[] = { "--print-capabilities", NULL };
+    g_autofree gchar *logop = NULL;
 
     argv = concat_arrays(swtpm_prg_l, my_argv, FALSE);
+
+    if (gl_LOGFILE != NULL) {
+        logop = g_strdup_printf("file=%s", gl_LOGFILE);
+        argv = concat_arrays(argv, (gchar*[]){"--log", logop, NULL}, TRUE);
+    }
+
     success = g_spawn_sync(NULL, argv, NULL, G_SPAWN_STDERR_TO_DEV_NULL, NULL, NULL,
                            &standard_output, NULL, &exit_status, &error);
     if (!success) {
@@ -944,6 +958,7 @@ static int get_rsa_keysizes(unsigned long flags, gchar **swtpm_prg_l,
     gchar **argv = NULL;
     char *p;
     int n;
+    g_autofree gchar *logop = NULL;
 
     *n_keysizes = 0;
 
@@ -951,6 +966,11 @@ static int get_rsa_keysizes(unsigned long flags, gchar **swtpm_prg_l,
         gchar *my_argv[] = { "--tpm2", "--print-capabilities", NULL };
 
         argv = concat_arrays(swtpm_prg_l, my_argv, FALSE);
+
+        if (gl_LOGFILE != NULL) {
+            logop = g_strdup_printf("file=%s", gl_LOGFILE);
+            argv = concat_arrays(argv, (gchar*[]){"--log", logop, NULL}, TRUE);
+        }
 
         success = g_spawn_sync(NULL, argv, NULL, G_SPAWN_STDERR_TO_DEV_NULL, NULL, NULL,
                                &standard_output, NULL, &exit_status, &error);


### PR DESCRIPTION
Whenever swtpm_setup is executed with --logfile option, forward the option to swtpm (--log file=...). This helps debugging swtpm initialization issues.