### PR TITLE
swtpm: Search for all state files and use abstracted names in JSON

### DIFF
--- a/tests/_test_print_states
+++ b/tests/_test_print_states
@@ -56,7 +56,7 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-exp='\{ "type": "swtpm", "states": \[ \{ "name": "tpm-00.permall" \} \] \}'
+exp='\{ "type": "swtpm", "states": \[ "permall" \] \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-states:"
 	echo "Actual   : ${msg}"

--- a/tests/_test_tpm2_print_states
+++ b/tests/_test_tpm2_print_states
@@ -56,7 +56,7 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-exp='\{ "type": "swtpm", "states": \[ \{ "name": "tpm2-00.permall" \} \] \}'
+exp='\{ "type": "swtpm", "states": \[ "permall" \] \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-states:"
 	echo "Actual   : ${msg}"


### PR DESCRIPTION
Search for all the state files not just the permanent state and
when printing the JSON use the abstracted names rather than concrete
filenames that are only valid for the dir backend but will likely
not exist in other backends.

Adjust swtpm_setup to search for the abstracted name and also
adjust the error message to print out the abstracted name.

Adjust the test cases.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>