### PR TITLE
debian: Remove trousers from list of dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -57,13 +57,12 @@ Architecture: any
 Description: Tools for the TPM emulator
  The swtpm-tools package contains the following types of tools:
   - swtpm_bios: Tool for initializing the TPM
-  - swtpm_ioctl: Tool for controlling the CUSE TPM
+  - swtpm_ioctl: Tool for controlling the CUSE/socket/chardev TPM
   - swtpm_setup: Tool for creating the initial state of the TPM; this
       tool basically simulates TPM manufacturing where certificates are
       written into the NVRAM of the TPM
   - swtpm_cert: Creation of certificates for the TPM (x509)
 Depends: gnutls-bin,
          swtpm (= ${binary:Version}),
-         trousers (>= 0.3.9),
          ${misc:Depends},
          ${shlibs:Depends}


### PR DESCRIPTION
Trouser is needed by samples/swtpm-create-tpmca which in turn needs
GnuTLS tpmtool but doesn't install on Ubuntu machines when there's no
TPM 1.2 available or /dev/tpm0 is a TPM 2, so remove it from the list
of dependencies.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>