### PR TITLE
swtpm: Add size to each type of state and use JSON object

### DIFF
--- a/src/swtpm/swtpm_nvstore.c
+++ b/src/swtpm/swtpm_nvstore.c
@@ -1327,8 +1327,8 @@ int SWTPM_NVRAM_PrintJson(void)
         TPM_VOLATILESTATE_NAME,
         TPM_SAVESTATE_NAME,
     };
-    char state_str[64] = "";
-    size_t i, n, o;
+    char state_str[200] = "";
+    size_t i, n, o, blobsize;
     int ret = -1;
 
     rc = SWTPM_NVRAM_Init();
@@ -1337,12 +1337,13 @@ int SWTPM_NVRAM_PrintJson(void)
         backend_uri = tpmstate_get_backend_uri();
 
         for (i = 0; i < ARRAY_LEN(states); i++) {
-            rc = g_nvram_backend_ops->check_state(backend_uri, states[i]);
+            rc = g_nvram_backend_ops->check_state(backend_uri, states[i],
+                                                  &blobsize);
             if (rc == TPM_SUCCESS) {
                 n = snprintf(&state_str[o], sizeof(state_str) - o,
-                             "%s \"%s\"",
+                             "%s {\"name\": \"%s\", \"size\": %zu}",
                              (o > 0) ? "," : "",
-                             states[i]);
+                             states[i], blobsize);
                 if (n >= sizeof(state_str) - o)
                     goto exit;
                 o += n;

--- a/src/swtpm/swtpm_nvstore.h
+++ b/src/swtpm/swtpm_nvstore.h
@@ -122,7 +122,8 @@ struct nvram_backend_ops {
                          TPM_BOOL mustExist,
                          const char *uri);
     TPM_RESULT (*check_state)(const char *uri,
-                              const char *name);
+                              const char *name,
+                              size_t *blobsize);
     void (*cleanup)(void);
 };
 

--- a/src/swtpm/swtpm_nvstore_dir.c
+++ b/src/swtpm/swtpm_nvstore_dir.c
@@ -175,7 +175,8 @@ SWTPM_NVRAM_GetFilepathForName(char *filepath,       /* output: rooted file path
 
 static TPM_RESULT
 SWTPM_NVRAM_CheckState_Dir(const char *uri,
-                           const char *name)
+                           const char *name,
+                           size_t *blobsize)
 {
     TPM_RESULT    rc = 0;
     char          filepath[FILENAME_MAX]; /* rooted file path from name */
@@ -200,6 +201,9 @@ SWTPM_NVRAM_CheckState_Dir(const char *uri,
             rc = TPM_FAIL;
         else if (!S_ISREG(statbuf.st_mode))
             rc = TPM_FAIL;
+
+        if (rc == 0)
+            *blobsize = statbuf.st_size;
     }
 
     return rc;

--- a/tests/_test_print_states
+++ b/tests/_test_print_states
@@ -56,7 +56,7 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-exp='\{ "type": "swtpm", "states": \[ "permall" \] \}'
+exp='\{ "type": "swtpm", "states": \[ \{"name": "permall", "size": 6\} \] \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-states:"
 	echo "Actual   : ${msg}"

--- a/tests/_test_tpm2_print_states
+++ b/tests/_test_tpm2_print_states
@@ -56,7 +56,7 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-exp='\{ "type": "swtpm", "states": \[ "permall" \] \}'
+exp='\{ "type": "swtpm", "states": \[ \{"name": "permall", "size": 6\} \] \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-states:"
 	echo "Actual   : ${msg}"


### PR DESCRIPTION
Add the size of the type state to the --print-states output and switch
back to a JSON object when enumerating the blobs.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>