### PR TITLE
swtpm_setup: Fix exit code on error to be '1'. 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@
 #       This file is derived from tpm-tool's configure.in.
 #
 
-AC_INIT([swtpm], [0.6.1])
+AC_INIT([swtpm], [0.6.2])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_HEADERS([config.h])

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -1468,9 +1468,12 @@ int main(int argc, char *argv[])
           tmpbuffer);
 
 out:
-error:
     g_strfreev(swtpm_prg_l);
     g_free(gl_LOGFILE);
 
     exit(ret);
+
+error:
+    ret = 1;
+    goto out;
 }

--- a/swtpm.spec
+++ b/swtpm.spec
@@ -7,7 +7,7 @@
 
 Summary: TPM Emulator
 Name:           swtpm
-Version:        0.6.1
+Version:        0.6.2
 Release:        1%{?dist}
 License:        BSD
 Url:            https://github.com/stefanberger/swtpm


### PR DESCRIPTION
Backport a patch for swtpm_setup.