### PR TITLE
Fix more memory leaks detected with --enable-sanitizers

### DIFF
--- a/src/swtpm_localca/swtpm_localca.c
+++ b/src/swtpm_localca/swtpm_localca.c
@@ -868,6 +868,8 @@ int main(int argc, char *argv[])
 
 out:
 error:
+    g_strfreev(config_file_lines);
+    g_strfreev(swtpm_cert_env);
     g_strfreev(tpm_attr_params);
     g_strfreev(tpm_spec_params);
 

--- a/src/swtpm_localca/swtpm_localca.c
+++ b/src/swtpm_localca/swtpm_localca.c
@@ -871,5 +871,5 @@ error:
     g_strfreev(tpm_attr_params);
     g_strfreev(tpm_spec_params);
 
-    exit(ret);
+    return ret;
 }

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -1648,7 +1648,7 @@ out:
     g_strfreev(swtpm_prg_l);
     g_free(gl_LOGFILE);
 
-    exit(ret);
+    return ret;
 
 error:
     ret = 1;


### PR DESCRIPTION
This PR fixes more memory leaks that were detected with --enable-sanitizers and that can be easier detected with gcc.