### PR TITLE
swtpm: Make fsync() errors non-fatal (for libvirt using AppArmor) 

### DIFF
--- a/src/swtpm/swtpm_nvstore_dir.c
+++ b/src/swtpm/swtpm_nvstore_dir.c
@@ -350,9 +350,6 @@ SWTPM_NVRAM_StoreData_Dir(unsigned char *filedata,
     char          filepath[FILENAME_MAX]; /* rooted file path from name */
     const char    *tpm_state_path = NULL;
 
-    static bool   do_fsync = true; /* turn off fsync if it fails, most
-                                      likely due to AppArmor */
-
     tpm_state_path = SWTPM_NVRAM_Uri_to_Dir(uri);
 
     if (rc == 0) {
@@ -394,14 +391,14 @@ SWTPM_NVRAM_StoreData_Dir(unsigned char *filedata,
             rc = TPM_FAIL;
         }
     }
-    if (rc == 0 && fd >= 0 && do_fsync) {
+    if (rc == 0 && fd >= 0) {
         TPM_DEBUG("  SWTPM_NVRAM_StoreData: Syncing file %s\n", tmpfile);
         irc = fsync(fd);
         if (irc != 0) {
-            do_fsync = false;
             logprintf(STDERR_FILENO,
-                      "SWTPM_NVRAM_StoreData: Error syncing file, %s. Check AppArmor profile.\n",
+                      "SWTPM_NVRAM_StoreData: Error (fatal) syncing file, %s\n",
                       strerror(errno));
+            rc = TPM_FAIL;
         } else {
             TPM_DEBUG("  SWTPM_NVRAM_StoreData: Synced file %s\n", tmpfile);
         }
@@ -437,7 +434,7 @@ SWTPM_NVRAM_StoreData_Dir(unsigned char *filedata,
      *  directory containing the file has also reached disk. For that an
      *  explicit fsync() on a file descriptor for the directory is also needed.
      */
-    if (rc == 0 && fd >= 0 && do_fsync) {
+    if (rc == 0 && fd >= 0) {
         TPM_DEBUG(" SWTPM_NVRAM_StoreData: Opening dir %s\n", tpm_state_path);
         dir_fd = open(tpm_state_path, O_RDONLY);
         if (dir_fd < 0) {
@@ -451,10 +448,10 @@ SWTPM_NVRAM_StoreData_Dir(unsigned char *filedata,
         TPM_DEBUG("  SWTPM_NVRAM_StoreData: Syncing dir %s\n", tpm_state_path);
         irc = fsync(dir_fd);
         if (irc != 0) {
-            do_fsync = false;
             logprintf(STDERR_FILENO,
-                      "SWTPM_NVRAM_StoreData: Error syncing dir, %s. Check AppArmor profile.\n",
+                      "SWTPM_NVRAM_StoreData: Error (fatal) syncing dir, %s\n",
                       strerror(errno));
+            rc = TPM_FAIL;
         } else {
             TPM_DEBUG("  SWTPM_NVRAM_StoreData: Synced dir %s\n", tpm_state_path);
         }


### PR DESCRIPTION
Only recent libvirt versions have the patch for the AppArmor profile for
libvirt to allow fsync after opening a directory. Rather than failing
hard on this error, log it once and continue and do not try fsync again
after.

This patch addresses the problems seen on Ubuntu related to an older
version of libvirt without the AppArmor profile update.
- issue #484
- issue #549
- issue #559

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>