### PR TITLE
tests: Skip TPM 2 pkcs11-related test when ASAN is used

### DIFF
--- a/tests/test_tpm2_swtpm_localca_pkcs11.test
+++ b/tests/test_tpm2_swtpm_localca_pkcs11.test
@@ -43,6 +43,8 @@ function cleanup()
 	${TESTDIR}/softhsm_setup teardown
 }
 
+skip_test_linked_with_asan "${SWTPM_LOCALCA}"
+
 unset GNUTLS_PIN
 export PIN="abcdef"
 


### PR DESCRIPTION
The key is freed using 'gnutls_privkey_deinit(pkcs11key)', yet the
following memory leaks show up that are most likely in the pkcs11 module.
Skip the test if ASAN is being used to avoid the test failure.

Direct leak of 55080 byte(s) in 1 object(s) allocated from:
    #0 0x7fdabb152af7 in calloc (/lib64/libasan.so.6+0xaeaf7)
    #1 0x7fdab6b737c6 in C_Initialize (/usr/lib64/pkcs11/libtpm2_pkcs11.so+0x147c6)
    #2 0x7fdab9a5f8a9 in initialize_module_inlock_reentrant (/lib64/libp11-kit.so.0+0x2b8a9)
    #3 0x7fdab9a5fc88 in managed_C_Initialize (/lib64/libp11-kit.so.0+0x2bc88)
    #4 0x7fdab9a66018 in p11_kit_modules_initialize (/lib64/libp11-kit.so.0+0x32018)
    #5 0x7fdab9a66778 in p11_kit_modules_load_and_initialize (/lib64/libp11-kit.so.0+0x32778)
    #6 0x7fdabab10dc5 in auto_load (/lib64/libgnutls.so.30+0x9cdc5)
    #7 0x7fdabab12656 in gnutls_pkcs11_init (/lib64/libgnutls.so.30+0x9e656)
    #8 0x7fdabab12779 in _gnutls_pkcs11_check_init (/lib64/libgnutls.so.30+0x9e779)
    #9 0x7fdabab1af1f in gnutls_pkcs11_privkey_import_url (/lib64/libgnutls.so.30+0xa6f1f)
    #10 0x7fdabaaee0e3 in gnutls_privkey_import_url (/lib64/libgnutls.so.30+0x7a0e3)
    #11 0x40abee in main /home/stefanb/dev/swtpm/src/swtpm_cert/ek-cert.c:1399
    #12 0x7fdab9f5ab74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
    #13 0x40366d in _start (/home/stefanb/dev/swtpm/src/swtpm_cert/swtpm_cert+0x40366d)

Indirect leak of 8208 byte(s) in 1 object(s) allocated from:
    #0 0x7fdabb152af7 in calloc (/lib64/libasan.so.6+0xaeaf7)
    #1 0x7fdab6b736f9 in C_Initialize (/usr/lib64/pkcs11/libtpm2_pkcs11.so+0x146f9)
    #2 0x7fdab9a5f8a9 in initialize_module_inlock_reentrant (/lib64/libp11-kit.so.0+0x2b8a9)
    #3 0x7fdab9a5fc88 in managed_C_Initialize (/lib64/libp11-kit.so.0+0x2bc88)
    #4 0x7fdab9a66018 in p11_kit_modules_initialize (/lib64/libp11-kit.so.0+0x32018)
    #5 0x7fdab9a66778 in p11_kit_modules_load_and_initialize (/lib64/libp11-kit.so.0+0x32778)
    #6 0x7fdabab10dc5 in auto_load (/lib64/libgnutls.so.30+0x9cdc5)
    #7 0x7fdabab12656 in gnutls_pkcs11_init (/lib64/libgnutls.so.30+0x9e656)
    #8 0x7fdabab12779 in _gnutls_pkcs11_check_init (/lib64/libgnutls.so.30+0x9e779)
    #9 0x7fdabab1af1f in gnutls_pkcs11_privkey_import_url (/lib64/libgnutls.so.30+0xa6f1f)
    #10 0x7fdabaaee0e3 in gnutls_privkey_import_url (/lib64/libgnutls.so.30+0x7a0e3)
    #11 0x40abee in main /home/stefanb/dev/swtpm/src/swtpm_cert/ek-cert.c:1399
    #12 0x7fdab9f5ab74 in __libc_start_main (/lib64/libc.so.6+0x27b74)
    #13 0x40366d in _start (/home/stefanb/dev/swtpm/src/swtpm_cert/swtpm_cert+0x40366d)

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>