### PR TITLE
swtpm: Call msync with length = 0 on Cygwin

### DIFF
--- a/src/swtpm/swtpm_nvstore_linear_file.c
+++ b/src/swtpm/swtpm_nvstore_linear_file.c
@@ -200,7 +200,12 @@ SWTPM_NVRAM_LinearFile_Flush(const char* uri SWTPM_ATTR_UNUSED,
     /* msync parameters must be page-aligned */
     uint32_t pagesize = sysconf(_SC_PAGESIZE);
     msync_offset = mmap_state.ptr + (offset & ~(pagesize - 1));
+#if defined(__CYGWIN__)
+    /* Cygwin uses Win API FlushViewOfFile, which we call with len = 0 */
+    msync_count = 0;
+#else
     msync_count = (count + (pagesize - 1)) & ~(pagesize - 1);
+#endif
 
     TPM_DEBUG("SWTPM_NVRAM_LinearFile_Flush: msync %d@0x%x\n",
               msync_count, msync_offset);


### PR DESCRIPTION
Cygwin internally uses the Windows API call FlushViewOfFile that
seems to not like to be called with an excessive number of bytes.
Instead, call it with length = 0 so that 'the file is flushed from
the base address to the end of the mapping' and then msync() succeeds.

Source:
https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-flushviewoffile

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>