### PR TITLE
debian: downgrade trousers package dependency to suggested

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -64,6 +64,6 @@ Description: Tools for the TPM emulator
   - swtpm_cert: Creation of certificates for the TPM (x509)
 Depends: gnutls-bin,
          swtpm (= ${binary:Version}),
-         trousers (>= 0.3.9),
          ${misc:Depends},
          ${shlibs:Depends}
+Suggests: trousers (>= 0.3.9)


### PR DESCRIPTION
Currently `trousers` is listed as (hard) Dependency, but it does not
seems to be required for quite a few usecases, e.g., ours where we
mainly using swtpm for providing a tpm to VMs.

With trousers in Debian one gets an additional pain point: it comes
with rather dated and in some cirumstances failing by mistake init
script [0] that can throw errors when setting up during installation
and thus fail the whole installation of swtpm as Debian policy for
`Depends` hits:

> A package will not be configured unless all of the packages listed
> in its Depends field have been correctly configured
-- [1]

Declaring dependencies for things are not a hard requirement means
that a user will be required to install more dependencies than
actually needed.

Just documenting that as fact why I investigated in the
hard-requirement on trousers in the first place, not an actual
justification - it's a packaging bug after all.

So downgrade the dependency to "Suggests", as it seems a reasonable
level when checking its documented meaning:

> This is used to declare that one package may be more useful with
> one or more others. Using this field tells the packaging system and
> the user that the listed packages are related to this one and can
> perhaps enhance its usefulness, but that installing this one without
> them is perfectly reasonable.
-- [1]

[0]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=895201
[1]: https://www.debian.org/doc/debian-policy/ch-relationships.html

Signed-off-by: Thomas Lamprecht <t.lamprecht@proxmox.com>