### PR TITLE
Debian improve postinst

### DIFF
--- a/debian/swtpm-tools.postinst.in
+++ b/debian/swtpm-tools.postinst.in
@@ -6,6 +6,19 @@ SWTPM_LOCALCA_DIR=@LOCALSTATEDIR@/lib/swtpm-localca
 
 case "$1" in
 	configure)
+		# creating @TSS_USER@ group if he isn't already there
+		if ! getent group @TSS_USER@ >/dev/null; then
+			addgroup --system @TSS_USER@
+		fi
+
+		# creating @TSS_USER@ user if he isn't already there
+		if ! getent passwd @TSS_USER@ >/dev/null; then
+			adduser --system --ingroup @TSS_USER@ --shell /bin/false \
+			    --home /var/lib/tpm --no-create-home \
+			    --gecos "TPM software stack" \
+			    @TSS_USER@
+		fi
+
 		if ! [ -d $SWTPM_LOCALCA_DIR ]; then
 			mkdir -p $SWTPM_LOCALCA_DIR
 			chown @TSS_USER@:root $SWTPM_LOCALCA_DIR


### PR DESCRIPTION
The first patch shouldn't raise too much objection, but I'm not 100% about the second one, why not create that directory on the fly when required or let all that handle tpm-udev[0], as that'd be required anyway if one wants to use the functionality where this directory is  actually needed, at least fwict.

[0]: https://salsa.debian.org/debian/tpm-udev/-/blob/master/debian/tpm-udev.postinst