### PR TITLE
swtpm: Fix case when no backend URI has been specified

### DIFF
--- a/src/swtpm/swtpm_nvstore.c
+++ b/src/swtpm/swtpm_nvstore.c
@@ -179,7 +179,11 @@ TPM_RESULT SWTPM_NVRAM_Init(void)
     TPM_DEBUG(" SWTPM_NVRAM_Init:\n");
 
     backend_uri = tpmstate_get_backend_uri();
-    if (strncmp(backend_uri, "dir://", 6) == 0) {
+    if (!backend_uri) {
+        logprintf(STDERR_FILENO,
+                  "SWTPM_NVRAM_Init: Missing backend URI.\n");
+        rc = TPM_FAIL;
+    } else if (strncmp(backend_uri, "dir://", 6) == 0) {
         g_nvram_backend_ops = &nvram_dir_ops;
     } else if (strncmp(backend_uri, "file://", 7) == 0) {
         g_nvram_backend_ops = &nvram_linear_ops;


### PR DESCRIPTION
It is possible to start swtpm with this command line even though
neither storage nor communication channels have been provided.

./src/swtpm/swtpm socket --flags not-need-init,startup-clear

Since sending a startup message to the TPM will cause it to
want to store permanent state, we have to handle the case when
no storage backend was given and therefore the backend_uri
is NULL.

Previously the above command line caused a NULL pointer exception
but now handles this case with the following output:

swtpm: SWTPM_NVRAM_Init: Missing backend URI.
swtpm: Error: Could not initialize libtpms.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>