### PR TITLE
swtpm_setup: Initialize variables to avoid compiler warnings

### DIFF
--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -1175,7 +1175,8 @@ int main(int argc, char *argv[])
     const struct passwd *curr_user;
     struct group *curr_grp;
     char *endptr;
-    gboolean swtpm_has_tpm12, swtpm_has_tpm2;
+    gboolean swtpm_has_tpm12 = FALSE;
+    gboolean swtpm_has_tpm2 = FALSE;
     int fds_to_pass[1] = { -1 };
     unsigned n_fds_to_pass = 0;
     char tmpbuffer[200];


### PR DESCRIPTION
Fix issue #591 by initializing the variables swtpm_has_tpm2 and
swtpm_has_tpm12.

swtpm_setup.c:1178:31: note: 'swtpm_has_tpm2' was declared here
     gboolean swtpm_has_tpm12, swtpm_has_tpm2;
                               ^~~~~~~~~~~~~~
swtpm_setup.c:1019:5: error: 'swtpm_has_tpm12' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     printf("{ \"type\": \"swtpm_setup\", "
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            "\"features\": [ %s%s\"cmdarg-keyfile-fd\", \"cmdarg-pwdfile-fd\", \"tpm12-not-need-root\""

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>