### PR TITLE
swtpm: Disable fsync on file and dir due to TPM command timeouts

### DIFF
--- a/src/swtpm/swtpm_nvstore_dir.c
+++ b/src/swtpm/swtpm_nvstore_dir.c
@@ -350,8 +350,12 @@ SWTPM_NVRAM_StoreData_Dir(unsigned char *filedata,
     char          filepath[FILENAME_MAX]; /* rooted file path from name */
     const char    *tpm_state_path = NULL;
 
+#if 0
     static bool   do_dir_fsync = true; /* turn off fsync on dir if it fails,
                                           most likely due to AppArmor */
+#endif
+    /* don't do fsync on dir since this may cause TPM command timeouts */
+    static bool   do_dir_fsync = false;
 
     tpm_state_path = SWTPM_NVRAM_Uri_to_Dir(uri);
 
@@ -394,6 +398,7 @@ SWTPM_NVRAM_StoreData_Dir(unsigned char *filedata,
             rc = TPM_FAIL;
         }
     }
+#if 0 // disabled due to triggering TPM timeouts
     if (rc == 0 && fd >= 0) {
         TPM_DEBUG("  SWTPM_NVRAM_StoreData: Syncing file %s\n", tmpfile);
         irc = fsync(fd);
@@ -406,6 +411,7 @@ SWTPM_NVRAM_StoreData_Dir(unsigned char *filedata,
             TPM_DEBUG("  SWTPM_NVRAM_StoreData: Synced file %s\n", tmpfile);
         }
     }
+#endif
     if (fd >= 0) {
         TPM_DEBUG("  SWTPM_NVRAM_StoreData: Closing file %s\n", tmpfile);
         irc = close(fd);             /* @1 */


### PR DESCRIPTION
We cannot currently fsync on the TPM's state file and the dir since this
takes too long and commands in a VM may timeout. The reason for this is
that the TPM 2 code occasionally writes the permanent state out even on
commands like TPM_PCRExtend that must not take a long time.

Since the permanent state has changed it is currently the best to actually
write it out until there's a better method to determine whether the state
needs to be written. One method would be to never write the state out if
short-running commmands are executed.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>