### PR TITLE
swtpm: Disable fsync on file & dir due to TPM timeouts (issue #597)

### DIFF
--- a/src/swtpm/swtpm_nvstore_dir.c
+++ b/src/swtpm/swtpm_nvstore_dir.c
@@ -350,8 +350,12 @@ SWTPM_NVRAM_StoreData_Dir(unsigned char *filedata,
     char          filepath[FILENAME_MAX]; /* rooted file path from name */
     const char    *tpm_state_path = NULL;
 
+#if 0
     static bool   do_dir_fsync = true; /* turn off fsync on dir if it fails,
                                           most likely due to AppArmor */
+#endif
+    /* don't do fsync on dir since this may cause TPM command timeouts */
+    static bool   do_dir_fsync = false;
 
     tpm_state_path = SWTPM_NVRAM_Uri_to_Dir(uri);
 
@@ -394,6 +398,7 @@ SWTPM_NVRAM_StoreData_Dir(unsigned char *filedata,
             rc = TPM_FAIL;
         }
     }
+#if 0 // disabled due to triggering TPM timeouts
     if (rc == 0 && fd >= 0) {
         TPM_DEBUG("  SWTPM_NVRAM_StoreData: Syncing file %s\n", tmpfile);
         irc = fsync(fd);
@@ -406,6 +411,7 @@ SWTPM_NVRAM_StoreData_Dir(unsigned char *filedata,
             TPM_DEBUG("  SWTPM_NVRAM_StoreData: Synced file %s\n", tmpfile);
         }
     }
+#endif
     if (fd >= 0) {
         TPM_DEBUG("  SWTPM_NVRAM_StoreData: Closing file %s\n", tmpfile);
         irc = close(fd);             /* @1 */


### PR DESCRIPTION
We cannot currently fsync on the TPM's state file and the dir since this
takes too long and commands in a VM may time out. The reason for this is
that the TPM 2 code occasionally writes the permanent state out even on
commands like TPM2_PCR_Extend that must not take a long time.

See explanation for this in the libtpms PR https://github.com/stefanberger/libtpms/pull/274 .

We will re-enable this feature in 'a while' once the updated libtpms
version has been made more widely available.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>