### PR TITLE
Reenable fsync() on state file and directory

### DIFF
--- a/src/swtpm/swtpm_nvstore_dir.c
+++ b/src/swtpm/swtpm_nvstore_dir.c
@@ -350,12 +350,8 @@ SWTPM_NVRAM_StoreData_Dir(unsigned char *filedata,
     char          filepath[FILENAME_MAX]; /* rooted file path from name */
     const char    *tpm_state_path = NULL;
 
-#if 0
     static bool   do_dir_fsync = true; /* turn off fsync on dir if it fails,
                                           most likely due to AppArmor */
-#endif
-    /* don't do fsync on dir since this may cause TPM command timeouts */
-    static bool   do_dir_fsync = false;
 
     tpm_state_path = SWTPM_NVRAM_Uri_to_Dir(uri);
 
@@ -398,7 +394,6 @@ SWTPM_NVRAM_StoreData_Dir(unsigned char *filedata,
             rc = TPM_FAIL;
         }
     }
-#if 0 // disabled due to triggering TPM timeouts
     if (rc == 0 && fd >= 0) {
         TPM_DEBUG("  SWTPM_NVRAM_StoreData: Syncing file %s\n", tmpfile);
         irc = fsync(fd);
@@ -411,7 +406,6 @@ SWTPM_NVRAM_StoreData_Dir(unsigned char *filedata,
             TPM_DEBUG("  SWTPM_NVRAM_StoreData: Synced file %s\n", tmpfile);
         }
     }
-#endif
     if (fd >= 0) {
         TPM_DEBUG("  SWTPM_NVRAM_StoreData: Closing file %s\n", tmpfile);
         irc = close(fd);             /* @1 */

--- a/tests/_test_tpm2_savestate
+++ b/tests/_test_tpm2_savestate
@@ -122,6 +122,10 @@ if [ "$RES" != "$exp" ]; then
 	exit 1
 fi
 
+# Wait 5 seconds to check whether the permanent state changes due to the PCR_Read
+sha1_permanent="$(get_sha1_file "${STATE_FILE}")"
+sleep 5
+
 swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 # Read PCR 10
 #                                                   length         CC            count       hashalg         sz
@@ -131,6 +135,13 @@ if [ "$RES" != "$exp" ]; then
 	echo "Error: (2) Did not get expected result from TPM2_PCR_Read(10)"
 	echo "expected: $exp"
 	echo "received: $RES"
+	exit 1
+fi
+
+if [ "${sha1_permanent}" != "$(get_sha1_file "${STATE_FILE}")" ]; then
+	echo "Error: To avoid command timeouts, the permanent state ${STATE_FILE} must "
+	echo "       not change due short-running commands like TPM2_PCR_Read()."
+	echo "       You need a more recent version of libtpms."
 	exit 1
 fi
 


### PR DESCRIPTION
Reenable fsync() on state file and directory. This depends on availability of packages of libtpms with the required fix.