### PR TITLE
rpm: Remove man8/swtpm_localca.8 from specfile

### DIFF
--- a/swtpm.spec
+++ b/swtpm.spec
@@ -157,7 +157,6 @@ fi
 %{_mandir}/man8/swtpm-localca.conf.8*
 %{_mandir}/man8/swtpm-localca.options.8*
 %{_mandir}/man8/swtpm-localca.8*
-%{_mandir}/man8/swtpm_localca.8*
 %{_mandir}/man8/swtpm_setup.8*
 %{_mandir}/man8/swtpm_setup.conf.8*
 %config(noreplace) %{_sysconfdir}/swtpm_setup.conf

--- a/swtpm.spec.in
+++ b/swtpm.spec.in
@@ -157,7 +157,6 @@ fi
 %{_mandir}/man8/swtpm-localca.conf.8*
 %{_mandir}/man8/swtpm-localca.options.8*
 %{_mandir}/man8/swtpm-localca.8*
-%{_mandir}/man8/swtpm_localca.8*
 %{_mandir}/man8/swtpm_setup.8*
 %{_mandir}/man8/swtpm_setup.conf.8*
 %config(noreplace) %{_sysconfdir}/swtpm_setup.conf


### PR DESCRIPTION
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>