### PR TITLE
rpm: Update spec file to also work on CentOS9-stream

### DIFF
--- a/swtpm.spec
+++ b/swtpm.spec
@@ -1,3 +1,4 @@
+# spec file for RHEL/CentOS and Fedora
 %bcond_without gnutls
 
 # Macros needed by SELinux
@@ -24,7 +25,9 @@ BuildRequires:  net-tools
 BuildRequires:  openssl-devel
 BuildRequires:  socat
 BuildRequires:  softhsm
+%if (0%{?fedora}) || (0%{?rhel} && 0%{?rhel} < 9)
 BuildRequires:  trousers >= 0.3.9
+%endif
 %if %{with gnutls}
 BuildRequires:  gnutls >= 3.1.0
 BuildRequires:  gnutls-devel

--- a/swtpm.spec.in
+++ b/swtpm.spec.in
@@ -1,3 +1,4 @@
+# spec file for RHEL/CentOS and Fedora
 %bcond_without gnutls
 
 # Macros needed by SELinux
@@ -24,7 +25,9 @@ BuildRequires:  net-tools
 BuildRequires:  openssl-devel
 BuildRequires:  socat
 BuildRequires:  softhsm
+%if (0%{?fedora}) || (0%{?rhel} && 0%{?rhel} < 9)
 BuildRequires:  trousers >= 0.3.9
+%endif
 %if %{with gnutls}
 BuildRequires:  gnutls >= 3.1.0
 BuildRequires:  gnutls-devel


### PR DESCRIPTION
CentOS9 has no more trousers, so disable it for rhel >= 9.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>