### PR TITLE
swtpm_setup: Only activate SHA256 PCR bank, not SHA1 bank anymore

### DIFF
--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -62,7 +62,7 @@
 /* default configuration file */
 #define SWTPM_SETUP_CONF "swtpm_setup.conf"
 
-#define DEFAULT_PCR_BANKS "sha1,sha256"
+#define DEFAULT_PCR_BANKS "sha256"
 
 /* Default logging goes to stderr */
 gchar *gl_LOGFILE = NULL;


### PR DESCRIPTION
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>