### PR TITLE
Allow customization of default PCR banks using configure option and swtpm_setup.conf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,6 +9,7 @@ SUBDIRS   = \
 	man \
 	samples \
 	src \
+	scripts \
 	tests
 
 ACLOCAL_AMFLAGS = -I m4

--- a/configure.ac
+++ b/configure.ac
@@ -346,6 +346,28 @@ fi
 AM_CONDITIONAL([WITH_GNUTLS], [test "x$with_gnutls" = "xyes"])
 AC_SUBST([GNUTLS_LIBS])
 
+DEFAULT_PCR_BANKS="sha256"
+AC_ARG_ENABLE([default-pcr-banks],
+              AS_HELP_STRING(
+                  [--enable-default-pcr-banks=list of PCR banks],
+                  [Have swtpm_setup activate the given PCR banks by default;
+                  default is sha256]
+              ),
+              [],
+              []
+)
+
+if test "x$enable_default_pcr_banks" != "x"; then
+    DEFAULT_PCR_BANKS="$enable_default_pcr_banks"
+fi
+AC_MSG_CHECKING([which PCR banks to activate by default])
+if $srcdir/scripts/test_pcr_bank_list $DEFAULT_PCR_BANKS; then
+	AC_MSG_RESULT([$DEFAULT_PCR_BANKS])
+else
+	AC_MSG_ERROR([$DEFAULT_PCR_BANKS is an invalid list of PCR banks])
+fi
+AC_SUBST([DEFAULT_PCR_BANKS])
+
 AC_PATH_PROG([EXPECT], expect)
 if test "x$EXPECT" = "x"; then
 	AC_MSG_ERROR([expect is required: expect package])
@@ -556,6 +578,7 @@ AC_CONFIG_FILES([Makefile                   \
 		samples/swtpm-localca.conf  \
 		samples/swtpm-create-user-config-files \
 		samples/swtpm_setup.conf    \
+		scripts/Makefile            \
 		include/Makefile            \
 		include/swtpm/Makefile      \
 		include/swtpm.h             \
@@ -587,6 +610,8 @@ printf "with_cuse       : %5s  (no = no CUSE interface)\n" $with_cuse
 printf "with_chardev    : %5s  (no = no chardev interface)\n" $with_chardev
 printf "with_vtpm_proxy : %5s  (no = no vtpm proxy support; Linux only)\n" $with_vtpm_proxy
 printf "with_seccomp    : %5s  (no = no seccomp profile; Linux only)\n" $with_seccomp
+printf "\n"
+printf "active PCR banks  : %s\n" $DEFAULT_PCR_BANKS
 echo
 echo "Version to build  : $PACKAGE_VERSION"
 echo "Crypto library    : $cryptolib"

--- a/man/man8/swtpm_setup.conf.pod
+++ b/man/man8/swtpm_setup.conf.pod
@@ -89,6 +89,12 @@ that will be passed to the invoked program using the --optsfile
 option described above. If omitted, the invoked program will use
 the default options file.
 
+=item B<active_pcr_banks> (since v0.7)
+
+This keyword is to be followed by a comma-separated list
+of names of PCR banks. The list must not contain any spaces.
+Valid PCR bank names are sha1, sha256, sha384, and sha512.
+
 =back
 
 =head1 SEE ALSO

--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -164,8 +164,12 @@ used for creating the certificates and may be required by that tool.
 =item B<--pcr-banks <PCR banks>>
 
 Optional comma-separated list of PCR banks to activate. Providing '-'
-allows a user to skip the selection and activates all PCR banks. By default
-the sha1 and sha256 banks are activated.
+allows a user to skip the selection and activates all PCR banks.
+If this option is not provided, the I<swtpm_setup.conf> configuration
+file will be consulted for the active_pcr_banks entry. If no such
+entry is found then the default set of PCR banks will be activated.
+The default set of PCR banks can be determined using the I<--help>
+option.
 
 =item B<--swtpm_ioctl <executable>>
 

--- a/samples/swtpm_setup.conf.in
+++ b/samples/swtpm_setup.conf.in
@@ -2,3 +2,5 @@
 create_certs_tool= @BINDIR@/swtpm_localca
 create_certs_tool_config = @SYSCONFDIR@/swtpm-localca.conf
 create_certs_tool_options = @SYSCONFDIR@/swtpm-localca.options
+# Comma-separated list (no spaces) of PCR banks to activate by default
+active_pcr_banks = @DEFAULT_PCR_BANKS@

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -1,0 +1,8 @@
+#
+# Makefile.am
+#
+# For the license, see the COPYING file in the root directory.
+#
+
+EXTRA_DIST = \
+	test_pcr_bank_list

--- a/scripts/test_pcr_bank_list
+++ b/scripts/test_pcr_bank_list
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+[[ $1 =~ ^(sha1|sha256|sha384|sha512)(,(sha1|sha256|sha384|sha512)){0,3}$ ]] \
+ && exit 0
+exit 1

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -63,8 +63,6 @@
 /* default configuration file */
 #define SWTPM_SETUP_CONF "swtpm_setup.conf"
 
-#define DEFAULT_PCR_BANKS "sha256"
-
 /* Default logging goes to stderr */
 gchar *gl_LOGFILE = NULL;
 

--- a/src/swtpm_setup/swtpm_setup_conf.h.in
+++ b/src/swtpm_setup/swtpm_setup_conf.h.in
@@ -17,4 +17,6 @@
 #define SYSCONFDIR "@SYSCONFDIR@"
 #define BINDIR "@BINDIR@"
 
+#define DEFAULT_PCR_BANKS "@DEFAULT_PCR_BANKS@"
+
 #endif /* SWTPM_SETUP_CONF_H */

--- a/src/swtpm_setup/swtpm_setup_utils.c
+++ b/src/swtpm_setup/swtpm_setup_utils.c
@@ -134,10 +134,13 @@ int create_config_files(gboolean overwrite, gboolean root_flag,
     filedata[SWTPM_SETUP_CONF] = g_strdup_printf(
         "create_certs_tool = %s\n"
         "create_certs_tool_config = %s\n"
-        "create_certs_tool_options = %s\n",
+        "create_certs_tool_options = %s\n"
+        "# Comma-separated list (no spaces) of PCR banks to activate by default\n"
+        "active_pcr_banks = %s\n",
         create_certs_tool,
         configfiles[SWTPM_LOCALCA_CONF],
-        configfiles[SWTPM_LOCALCA_OPTIONS]
+        configfiles[SWTPM_LOCALCA_OPTIONS],
+        DEFAULT_PCR_BANKS
     );
 
     /* swtpm-localca.conf */


### PR DESCRIPTION
This PR extends the configure script with a --enable-default-pcr-banks option to allow setting the default PCR banks to activate. By default the sha256 bank is now activated. Also allow the configuration of the default PCR bank via the swtpm_setup.conf configuration file's active_pcr_banks entry, which is used if the user didn't pass a choice via the command line. If nothing is found in swtpm_setup.conf then fall back to what was chosen when configure was run.
