### PR TITLE
Add support for --reconfigure for swtpm_setup to reconfigure the active PCR banks

### DIFF
--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -188,6 +188,11 @@ the I<--print-capabilities> option. The default size is 2048 bits for
 both TPM 1.2 and TPM 2. If 'max' is passed, the largest possible key
 size is used.
 
+=item B<--reconfigure> (since v0.7)
+
+This option allows the reconfiguration of the active PCR banks of a
+TPM 2 using the I<--pcr-banks> option.
+
 =item B<--print-capabilities> (since v0.2)
 
 Print capabilities that were added to swtpm_setup after version 0.1.
@@ -200,6 +205,7 @@ The output may contain the following:
         "cmdarg-pwdfile-fd",
         "cmdarg-write-ek-cert-files",
         "cmdarg-create-config-files",
+	"cmdarg-reconfigure-pcr-banks",
         "tpm2-rsa-keysize-2048",
         "tpm2-rsa-keysize-3072",
         "tpm12-not-need-root",
@@ -230,6 +236,11 @@ The I<--write-ek-cert-files> option is supported.
 =item B<cmdarg-create-config-files> (since v0.7)
 
 The I<--create-config-files> option is supported.
+
+=item B<cmdarg-reconfigure-pcr-banks> (since v0.7)
+
+The I<--reconfigure> option is supported and allows the reconfiguration of
+the active PCR banks.
 
 =item B<tpm2-rsa-keysize-2048, ...> (since v0.4)
 

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -43,22 +43,22 @@
 #define DEFAULT_OWNER_PASSWORD "ooo"
 #define DEFAULT_SRK_PASSWORD   "sss"
 
-#define SETUP_CREATE_EK_F           1
-#define SETUP_TAKEOWN_F             2
-#define SETUP_EK_CERT_F             4
-#define SETUP_PLATFORM_CERT_F       8
-#define SETUP_LOCK_NVRAM_F          16
-#define SETUP_SRKPASS_ZEROS_F       32
-#define SETUP_OWNERPASS_ZEROS_F     64
-#define SETUP_STATE_OVERWRITE_F     128
-#define SETUP_STATE_NOT_OVERWRITE_F 256
-#define SETUP_TPM2_F                512
-#define SETUP_ALLOW_SIGNING_F       1024
-#define SETUP_TPM2_ECC_F            2048
-#define SETUP_CREATE_SPK_F          4096
-#define SETUP_DISPLAY_RESULTS_F     8192
-#define SETUP_DECRYPTION_F          16384
-#define SETUP_WRITE_EK_CERT_FILES_F 32768
+#define SETUP_CREATE_EK_F           (1 << 0)
+#define SETUP_TAKEOWN_F             (1 << 1)
+#define SETUP_EK_CERT_F             (1 << 2)
+#define SETUP_PLATFORM_CERT_F       (1 << 3)
+#define SETUP_LOCK_NVRAM_F          (1 << 4)
+#define SETUP_SRKPASS_ZEROS_F       (1 << 5)
+#define SETUP_OWNERPASS_ZEROS_F     (1 << 6)
+#define SETUP_STATE_OVERWRITE_F     (1 << 7)
+#define SETUP_STATE_NOT_OVERWRITE_F (1 << 8)
+#define SETUP_TPM2_F                (1 << 9)
+#define SETUP_ALLOW_SIGNING_F       (1 << 10)
+#define SETUP_TPM2_ECC_F            (1 << 11)
+#define SETUP_CREATE_SPK_F          (1 << 12)
+#define SETUP_DISPLAY_RESULTS_F     (1 << 13)
+#define SETUP_DECRYPTION_F          (1 << 14)
+#define SETUP_WRITE_EK_CERT_FILES_F (1 << 15)
 
 /* default configuration file */
 #define SWTPM_SETUP_CONF "swtpm_setup.conf"

--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -43,7 +43,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # The are some variable parameters at the end, use regex
-exp='\{ "type": "swtpm_setup", "features": \[ "tpm-1.2",( "tpm-2.0",)? "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", "tpm12-not-need-root", "cmdarg-write-ek-cert-files", "cmdarg-create-config-files"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")? \], "version": "[^"]*" \}'
+exp='\{ "type": "swtpm_setup", "features": \[ "tpm-1.2",( "tpm-2.0",)? "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", "tpm12-not-need-root", "cmdarg-write-ek-cert-files", "cmdarg-create-config-files", "cmdarg-reconfigure-pcr-banks"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")? \], "version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_SETUP} to --print-capabilities:"
 	echo "Actual   : ${msg}"

--- a/tests/_test_tpm2_print_capabilities
+++ b/tests/_test_tpm2_print_capabilities
@@ -44,7 +44,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # The are some variable parameters at the end, use regex
-exp='\{ "type": "swtpm_setup", "features": \[( "tpm-1.2",)? "tpm-2.0", "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", "tpm12-not-need-root", "cmdarg-write-ek-cert-files", "cmdarg-create-config-files"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")? \], "version": "[^"]*" \}'
+exp='\{ "type": "swtpm_setup", "features": \[( "tpm-1.2",)? "tpm-2.0", "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", "tpm12-not-need-root", "cmdarg-write-ek-cert-files", "cmdarg-create-config-files", "cmdarg-reconfigure-pcr-banks"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")? \], "version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_SETUP} to --print-capabilities:"
 	echo "Actual   : ${msg}"

--- a/tests/common
+++ b/tests/common
@@ -686,10 +686,10 @@ function run_swtpm_bios()
 function get_filesize()
 {
 	if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-) ]]; then
-		stat -c%s $1
+		stat -c%s "$1"
 	else
 		# OpenBSD
-		stat -f%z $1
+		stat -f%z "$1"
 	fi
 }
 
@@ -699,10 +699,10 @@ function get_filesize()
 function get_filemode()
 {
 	if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-) ]]; then
-		stat -c%a $1
+		stat -c%a "$1"
 	else
 		# BSDs
-		stat -f%Lp $1
+		stat -f%Lp "$1"
 	fi
 }
 
@@ -712,10 +712,10 @@ function get_filemode()
 function get_fileowner()
 {
 	if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-) ]]; then
-		stat -c"%u %g" $1
+		stat -c"%u %g" "$1"
 	else
 		# BSDs
-		stat -f"%u %g" $1
+		stat -f"%u %g" "$1"
 	fi
 }
 
@@ -725,10 +725,10 @@ function get_fileowner()
 function get_fileowner_names()
 {
 	if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-) ]]; then
-		stat -c"%U %G" $1
+		stat -c"%U %G" "$1"
 	else
 		# BSDs
-		stat -f"%Su %Sg" $1
+		stat -f"%Su %Sg" "$1"
 	fi
 }
 
@@ -737,20 +737,20 @@ function get_fileowner_names()
 # @1: filename
 function get_sha1_file()
 {
-	if ! [ -r $1 ]; then
+	if ! [ -r "$1" ]; then
 		echo "[file $1 does not exist]"
 		return
 	fi
 	case "$(uname -s)" in
 	Linux|CYGWIN*)
-		sha1sum $1 | cut -f1 -d" "
+		sha1sum "$1" | cut -f1 -d" "
 		;;
 	Darwin)
-		shasum $1 | cut -f1 -d" "
+		shasum "$1" | cut -f1 -d" "
 		;;
 	*)
 		# OpenBSD
-		sha1 $1 | cut -d "=" -f2 | tr -d " "
+		sha1 "$1" | cut -d "=" -f2 | tr -d " "
 	esac
 }
 

--- a/tests/test_tpm2_swtpm_setup_create_cert
+++ b/tests/test_tpm2_swtpm_setup_create_cert
@@ -122,53 +122,110 @@ done
 
 echo "Test 1: OK"
 
+function swtpm_setup_reconfigure() {
+	local workdir="$1"
+	local pwdfile="$2"
 
-# we need to create at least one cert: --create-ek-cert
-$SWTPM_SETUP \
-	--tpm2 \
-	--ecc \
-	--tpm-state "${workdir}" \
-	--create-ek-cert \
-	--config "${workdir}/swtpm_setup.conf" \
-	--logfile "${workdir}/logfile" \
-	--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}" \
-	--overwrite \
-	--write-ek-cert-files "${workdir}"
+	# Reconfigure the active PCR banks a few times; the size of the state
+	# file must not change but its content (hash) must change every time
+	# since activating the PCR banks changes a few bits in the permanent
+	# state, also when the state is not encrypted.
+	local PERMALL_FILE="${workdir}/tpm2-00.permall"
+	local permall_size=$(get_filesize "${PERMALL_FILE}")
 
-if [ $? -ne 0 ]; then
-	echo "Error: Could not run $SWTPM_SETUP."
-	echo "Logfile output:"
-	cat "${workdir}/logfile"
-	exit 1
-fi
+	for pcrbanks in "sha1" "sha1,sha256" "sha1,sha256,sha384,sha512"; do
+		# hash must change between before and after
+		permall_hash=$(get_sha1_file "${PERMALL_FILE}")
 
-if [ ! -r "${SIGNINGKEY}" ]; then
-	echo "Error: Signingkey file ${SIGNINGKEY} was not created."
-	exit 1
-fi
+		$SWTPM_SETUP \
+			--tpm2 \
+			--tpm-state "${workdir}" \
+			--config "${workdir}/swtpm_setup.conf" \
+			--logfile "${workdir}/logfile" \
+			--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}" \
+			--pcr-banks "${pcrbanks}" \
+			--reconfigure \
+			${pwdfile:+--pwdfile "${pwdfile}"}
+		if [ $? -ne 0 ]; then
+			echo "Error: Could not run $SWTPM_SETUP --reconfigure."
+			echo "Logfile output:"
+			cat "${workdir}/logfile"
+			exit 1
+		fi
 
-if [ ! -r "${ISSUERCERT}" ]; then
-	echo "Error: Issuer cert file ${ISSUERCERT} was not created."
-	exit 1
-fi
+		local newhash=$(get_sha1_file "${PERMALL_FILE}")
+		if [ "${newhash}" = "${permall_hash}" ]; then
+			echo "Error: The hash of the permanent state did not change."
+			exit 1
+		fi
 
-if [ ! -r "${CERTSERIAL}" ]; then
-	echo "Error: Cert serial number file ${CERTSERIAL} was not created."
-	exit 1
-fi
+		local newsize=$(get_filesize "${PERMALL_FILE}")
+		if [ "${newsize}" != "${permall_size}" ]; then
+			echo "Error: The size of the permanent state file changed."
+			echo "Actual  : ${tmp}"
+			echo "Expected: ${permall_size}"
+		fi
+		echo "Filesize: ${newsize}; hash: ${newhash}; pwdfile: ${pwdfile}"
+	done
+}
 
-certfile="${workdir}/ek-secp384r1.crt"
-if [ ! -f "${certfile}" ]; then
-	echo "Error: EK file '${certfile}' was not written."
-	ls -l "${workdir}"
-	exit 1
-fi
+# Create with certificates with and without encryption enabled and reconfigure
+# the PCR banks
+PWDFILE="${workdir}/pwd"
+echo -n "password" > "${PWDFILE}"
+rm -f "${workdir}/logfile"
 
-if [ -z "$($CERTTOOL --inder --infile "${certfile}" -i | grep "384 bits")" ]; then
-	echo "Error: EK file '${certfile}' is not an ECC 384 bit key."
-	$CERTTOOL --inder --infile "${certfile}" -i
-	exit 1
-fi
+for pwdfile in "" "${PWDFILE}"; do
+	$SWTPM_SETUP \
+		--tpm2 \
+		--ecc \
+		--tpm-state "${workdir}" \
+		--create-ek-cert \
+		--create-platform-cert \
+		--config "${workdir}/swtpm_setup.conf" \
+		--logfile "${workdir}/logfile" \
+		--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}" \
+		--overwrite \
+		--write-ek-cert-files "${workdir}" \
+		${pwdfile:+--pwdfile "${pwdfile}"}
+
+	if [ $? -ne 0 ]; then
+		echo "Error: Could not run $SWTPM_SETUP."
+		echo "Logfile output:"
+		cat "${workdir}/logfile"
+		exit 1
+	fi
+
+	if [ ! -r "${SIGNINGKEY}" ]; then
+		echo "Error: Signingkey file ${SIGNINGKEY} was not created."
+		exit 1
+	fi
+
+	if [ ! -r "${ISSUERCERT}" ]; then
+		echo "Error: Issuer cert file ${ISSUERCERT} was not created."
+		exit 1
+	fi
+
+	if [ ! -r "${CERTSERIAL}" ]; then
+		echo "Error: Cert serial number file ${CERTSERIAL} was not created."
+		exit 1
+	fi
+
+	certfile="${workdir}/ek-secp384r1.crt"
+	if [ ! -f "${certfile}" ]; then
+		echo "Error: EK file '${certfile}' was not written."
+		ls -l "${workdir}"
+		exit 1
+	fi
+
+	if [ -z "$($CERTTOOL --inder --infile "${certfile}" -i | grep "384 bits")" ]; then
+		echo "Error: EK file '${certfile}' is not an ECC 384 bit key."
+		$CERTTOOL --inder --infile "${certfile}" -i
+		exit 1
+	fi
+
+	swtpm_setup_reconfigure "${workdir}" "${pwdfile}"
+done
 
 echo "Test 2: OK"
 


### PR DESCRIPTION
Add a --reconfigure option to swtpm_setup so that an existing state can be reconfigured
with a new set of active PCR banks.