### PR TITLE
Openssl not certtool

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -294,23 +294,9 @@ if test "x$with_gnutls" != "xno"; then
     fi
 fi
 
-if test "x$with_gnutls" != "xno"; then
-    AC_PATH_PROG([GNUTLS_CERTTOOL], certtool)
-    if test "x$GNUTLS_CERTTOOL" = "x"; then
-        if test "x$with_gnutls" = "xyes"; then
-            AC_MSG_ERROR("Could not find certtool. Is gnutls-utils/gnutls-bin installed?")
-        else
-            with_gnutls=no
-        fi
-    fi
-    dnl certtool changed how it takes private key passwords
-    dnl 3.3.29 is too old (RHEL 7); we need at least gnutls 3.4.0
-    AC_MSG_CHECKING([for gnutls 3.4.0 or later])
-    $(pkg-config gnutls --atleast-version=3.4.0)
-    if test $? -ne 0; then
-        AC_MSG_ERROR([gnutls 3.4.0 is required])
-    fi
-    AC_MSG_RESULT([yes])
+AC_PATH_PROG([OPENSSL], openssl)
+if test "x$OPENSSL" = "x"; then
+    AC_MSG_ERROR("Could not find openssl. Is it installed?")
 fi
 
 if test "x$with_gnutls" != "xno"; then

--- a/configure.ac
+++ b/configure.ac
@@ -294,6 +294,25 @@ if test "x$with_gnutls" != "xno"; then
     fi
 fi
 
+if test "x$with_gnutls" != "xno"; then
+    AC_PATH_PROG([GNUTLS_CERTTOOL], certtool)
+    if test "x$GNUTLS_CERTTOOL" = "x"; then
+        if test "x$with_gnutls" = "xyes"; then
+            AC_MSG_ERROR("Could not find certtool. Is gnutls-utils/gnutls-bin installed?")
+        else
+            with_gnutls=no
+        fi
+    fi
+    dnl certtool changed how it takes private key passwords
+    dnl 3.3.29 is too old (RHEL 7); we need at least gnutls 3.4.0
+    AC_MSG_CHECKING([for gnutls 3.4.0 or later])
+    $(pkg-config gnutls --atleast-version=3.4.0)
+    if test $? -ne 0; then
+        AC_MSG_ERROR([gnutls 3.4.0 is required])
+    fi
+    AC_MSG_RESULT([yes])
+fi
+
 AC_PATH_PROG([OPENSSL], openssl)
 if test "x$OPENSSL" = "x"; then
     AC_MSG_ERROR("Could not find openssl. Is it installed?")

--- a/debian/control
+++ b/debian/control
@@ -60,7 +60,7 @@ Description: Tools for the TPM emulator
       tool basically simulates TPM manufacturing where certificates are
       written into the NVRAM of the TPM
   - swtpm_cert: Creation of certificates for the TPM (x509)
-Depends: gnutls-bin,
+Depends: openssl,
          swtpm (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}

--- a/man/man8/swtpm_localca.pod
+++ b/man/man8/swtpm_localca.pod
@@ -28,12 +28,6 @@ swtpm-localca-rootca-cert.pem respectively. The environment variable
 SWTPM_ROOTCA_PASSWORD can be set for the password of the root CA's
 private key.
 
-Note: Due to limitations of 'certtool', the possible passwords used for
-securing the root CA's private key and the intermedia CA's private
-key have to be passed over the command line and therefore will be visible
-to others on the system. If you are concerned about this, you should create
-the CAs elsewhere and copy them onto the target system.
-
 The following options are supported:
 
 =over 4

--- a/tests/test_swtpm_setup_create_cert
+++ b/tests/test_swtpm_setup_create_cert
@@ -95,7 +95,7 @@ if [ ! -r "${CERTSERIAL}" ]; then
 	exit 1
 fi
 
-if [ -z "$(grep "ENCRYPTED PRIVATE KEY" ${workdir}/swtpm-localca-rootca-privkey.pem)" ]; then
+if [ -z "$(grep "Proc-Type: 4,ENCRYPTED" ${workdir}/swtpm-localca-rootca-privkey.pem)" ]; then
 	echo "Error: Root CA's private key should be encrypted"
 	cat ${workdir}/swtpm-localca-rootca-privkey.pem
 	exit 1

--- a/tests/test_tpm2_swtpm_localca
+++ b/tests/test_tpm2_swtpm_localca
@@ -92,7 +92,7 @@ do
        echo "Error: Root CA's private key is password protected but should not be."
        exit 1
      fi
-     export SWTPM_ROOTCA_PASSWORD=xyz
+     export SWTPM_ROOTCA_PASSWORD=wxyz
   fi
 
   if [ ! -r "${workdir}/ek.cert" ]; then

--- a/tests/test_tpm2_swtpm_localca
+++ b/tests/test_tpm2_swtpm_localca
@@ -75,20 +75,20 @@ do
   fi
 
   # Signing key should always be password protected
-  if [ -z "$(grep "ENCRYPTED PRIVATE KEY" "${SIGNINGKEY}")" ]; then
+  if [ -z "$(grep "Proc-Type: 4,ENCRYPTED" "${SIGNINGKEY}")" ]; then
     echo "Error: Signing key is not password protected."
     exit 1
   fi
 
   # For the root CA's key we flip the password protection
   if [ -n "${SWTPM_ROOTCA_PASSWORD}" ] ;then
-     if [ -z "$(grep "ENCRYPTED PRIVATE KEY" "${workdir}/swtpm-localca-rootca-privkey.pem")" ]; then
+     if [ -z "$(grep "Proc-Type: 4,ENCRYPTED" "${workdir}/swtpm-localca-rootca-privkey.pem")" ]; then
        echo "Error: Root CA's private key is not password protected."
        exit 1
      fi
      unset SWTPM_ROOTCA_PASSWORD
   else
-     if [ -n "$(grep "ENCRYPTED PRIVATE KEY" "${workdir}/swtpm-localca-rootca-privkey.pem")" ]; then
+     if [ -n "$(grep "Proc-Type: 4,ENCRYPTED" "${workdir}/swtpm-localca-rootca-privkey.pem")" ]; then
        echo "Error: Root CA's private key is password protected but should not be."
        exit 1
      fi
@@ -133,7 +133,7 @@ do
   fi
 
   # Delete all keys to have CA re-created
-  rm -rf "${workdir}"/*.pem
+  rm -rf "${workdir}"/*.pem "$workdir"/index.txt "$workdir"/serial
 done
 
 echo "Test 1: OK"

--- a/tests/test_tpm2_swtpm_setup_create_cert
+++ b/tests/test_tpm2_swtpm_setup_create_cert
@@ -118,6 +118,7 @@ for keysize in $(echo $keysizes); do
 	fi
 
 	rm -rf "${SIGNINGKEY}" "${ISSUERCERT}" "${CERTSERIAL}" ${USER_CERTSDIR}/ek-*.crt
+	rm -rf "$workdir/serial" "$workdir/index.txt"
 done
 
 echo "Test 1: OK"


### PR DESCRIPTION
openssl (libcrypto) is a required dependency of swtpm_setup, but libggnutls is an optional dependency only required for swtpm_cert.  The openssl command is capable of doing everything certtool does, so use openssl to reduce dependencies.
    
This also fixes a documented bug that passwords must be passed on the commandline, because openssl supports passing them in by other methods.

The impetus for proposing this change is that certtool is in Ubuntu universe, but openssl is in Ubuntu main, so we would like to not have this as a runtime dependency.  (Keeping it as a build-time dependency for the tests is not a concern.)