### PR TITLE
swtpm_localca: Replace certain characters in VMId's

### DIFF
--- a/src/swtpm_localca/swtpm_localca.c
+++ b/src/swtpm_localca/swtpm_localca.c
@@ -633,6 +633,7 @@ int main(int argc, char *argv[])
         case 'v': /* --vmid */
             g_free(vmid);
             vmid = g_strdup(optarg);
+            vmid_replacechars(vmid);
             break;
         case 'o': /* --optsfile */
             g_free(optsfile);

--- a/src/swtpm_localca/swtpm_localca_utils.c
+++ b/src/swtpm_localca/swtpm_localca_utils.c
@@ -137,3 +137,24 @@ void unlock_file(int lockfd) {
         close(lockfd);
     }
 }
+
+/* Replace a few characters in vmid so it can be used by CommonName in cert */
+void vmid_replacechars(char *vmid) {
+    size_t i = 0;
+    char c;
+
+    while ((c = vmid[i])) {
+        switch (c) {
+        case '+':
+            // https://github.com/gnutls/gnutls/blob/gnutls_3_6_x/lib/x509/x509_dn.c#L167
+            if (i == 0 || vmid[i - 1] != '\\')
+                vmid[i] = '_';
+            break;
+        case ',':
+            // no commas allowed
+            vmid[i] = '_';
+            break;
+        }
+        i++;
+    }
+}

--- a/src/swtpm_localca/swtpm_localca_utils.h
+++ b/src/swtpm_localca/swtpm_localca_utils.h
@@ -20,4 +20,6 @@ int makedir(const char *dirname, const char *purpose);
 int lock_file(const gchar *lockfile);
 void unlock_file(int lockfd);
 
+void vmid_replacechars(char *vmid);
+
 #endif /* SWTPM_LOCALCA_UTILS_H */


### PR DESCRIPTION
Certain characters are not accepted by gnutls when creating the
subject with the 'CN' from the vmid, so we have to replace those
characters with another one, such as '_'.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>