### PR TITLE
tests: Make TPM 1.2 and IBM TSS2 test compile with OSSL 3.0

### DIFF
--- a/tests/test_tpm12
+++ b/tests/test_tpm12
@@ -85,7 +85,7 @@ if [ $? -ne 0 ]; then
 fi
 
 ./autogen
-LIBS="" CFLAGS="-g -O2" ./configure
+LIBS="" CFLAGS="-g -O2 -DOPENSSL_SUPPRESS_DEPRECATED=1" ./configure
 make -j$(nproc)
 
 pushd utils &>/dev/null

--- a/tests/test_tpm2_ibmtss2
+++ b/tests/test_tpm2_ibmtss2
@@ -96,7 +96,7 @@ fi
 
 autoreconf --force --install
 unset CFLAGS LDFLAGS LIBS
-./configure --disable-tpm-1.2
+CFLAGS="-DOPENSSL_SUPPRESS_DEPRECATED" ./configure --disable-tpm-1.2
 make -j4
 
 pushd utils


### PR DESCRIPTION
Add CFLAGS="-DOPENSSL_SUPPRESS_DEPRECATED=1" to the configure line
to avoid compile-time errors when building with OpenSSL 3.0.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>