### PR TITLE
tests: OSSL 3: Make TPM 1.2 test compile; skip IBM TSS 2 test

### DIFF
--- a/tests/test_tpm12
+++ b/tests/test_tpm12
@@ -85,7 +85,7 @@ if [ $? -ne 0 ]; then
 fi
 
 ./autogen
-LIBS="" CFLAGS="-g -O2" ./configure
+LIBS="" CFLAGS="-g -O2 -DOPENSSL_SUPPRESS_DEPRECATED=1" ./configure
 make -j$(nproc)
 
 pushd utils &>/dev/null

--- a/tests/test_tpm2_ibmtss2
+++ b/tests/test_tpm2_ibmtss2
@@ -4,6 +4,16 @@ if [ ${SWTPM_TEST_EXPENSIVE:-0} -eq 0 ]; then
 	exit 77
 fi
 
+if [ -z "$(type openssl)" ]; then
+	echo "Openssl command line tool is required."
+	exit 1
+fi
+
+if [ -n "$(openssl version | grep -E "^OpenSSL 3")" ]; then
+	echo "IBMTSS2 v1.6 test suite does not work with OpenSSL 3.0"
+	exit 77
+fi
+
 ROOT=${abs_top_builddir:-$(pwd)/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 ABSTESTDIR=$(cd ${TESTDIR} &>/dev/null;echo ${PWD})


### PR DESCRIPTION
Add CFLAGS="-DOPENSSL_SUPPRESS_DEPRECATED=1" to the configure line
to avoid compile-time errors when building the TPM 1.2 test with
OpenSSL 3.0.

IBM TSS2 v1.6 test does not currently work with OpenSSL 3.0, so
skip it.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>