### PR TITLE
swtpm: Fix compilation error on 32bit machines

### DIFF
--- a/src/swtpm/swtpm_nvstore_linear_file.c
+++ b/src/swtpm/swtpm_nvstore_linear_file.c
@@ -55,7 +55,7 @@ SWTPM_NVRAM_LinearFile_Mmap(void)
         goto fail;
     }
 
-    if (st.st_size >= (uint32_t)sizeof(struct nvram_linear_hdr)) {
+    if (st.st_size >= (off_t)sizeof(struct nvram_linear_hdr)) {
         /* valid regular file-ish */
         mmap_state.size = st.st_size;
         mmap_state.can_truncate = true;

--- a/tests/test_swtpm_setup_create_cert
+++ b/tests/test_swtpm_setup_create_cert
@@ -115,11 +115,15 @@ if [ -z "$($CERTTOOL --inder --infile "${certfile}" -i | grep "2048 bits")" ]; t
 fi
 
 expiration="$($CERTTOOL --inder --infile "${certfile}" -i | grep "Not After:")"
-expected="Not After: Fri Dec 31 23:59:59 UTC 9999"
-if [ -z "$(echo "${expiration}" | grep "${expected}")" ]; then
-	echo "Error: EK file '${certfile}' does not expire in 9999"
-	echo "actual:   ${expiration}"
-	echo "expected: ${expected}"
+expected1="Not After: Fri Dec 31 23:59:59 UTC 9999"
+# 32bit machines
+expected2="Not After: Thu Dec 31 23:23:23 UTC 2037"
+if [ -z "$(echo "${expiration}" | grep "${expected1}")" ] && \
+   [ -z "$(echo "${expiration}" | grep "${expected2}")" ]; then
+	echo "Error: EK file '${certfile}' does not expire in 9999 or 2037"
+	echo "actual   : ${expiration}"
+	echo "expected1: ${expected1}"
+	echo "expected2: ${expected2} (32 bit machines)"
 	exit 1
 fi
 


### PR DESCRIPTION
Fix the following compilation error occurring on 32bit machines:

swtpm_nvstore_linear_file.c: In function 'SWTPM_NVRAM_LinearFile_Mmap':
swtpm_nvstore_linear_file.c:58:20: error: comparison of integer expressions of different signedness: '__off_t' {aka 'long int'} and 'unsigned int' [-Werror=sign-compare]
   58 |     if (st.st_size >= (uint32_t)sizeof(struct nvram_linear_hdr)) {
      |                    ^~

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>