### PR TITLE
swtpm: Implement function reporting error when choosing unsupported TPM

### DIFF
--- a/src/swtpm/cuse_tpm.c
+++ b/src/swtpm/cuse_tpm.c
@@ -1621,9 +1621,7 @@ int swtpm_cuse_main(int argc, char **argv, const char *prgname, const char *ifac
         goto exit;
     }
 
-    if (TPMLIB_ChooseTPMVersion(tpmversion) != TPM_SUCCESS) {
-        logprintf(STDERR_FILENO,
-                  "Error: Could not choose TPM version.\n");
+    if (tpmlib_choose_tpm_version(tpmversion) != TPM_SUCCESS) {
         ret = EXIT_FAILURE;
         goto exit;
     }

--- a/src/swtpm/swtpm.c
+++ b/src/swtpm/swtpm.c
@@ -437,11 +437,8 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
         exit(ret ? EXIT_FAILURE : EXIT_SUCCESS);
     }
 
-    if (TPMLIB_ChooseTPMVersion(mlp.tpmversion) != TPM_SUCCESS) {
-        logprintf(STDERR_FILENO,
-                  "Error: Could not choose TPM version.\n");
+    if (tpmlib_choose_tpm_version(mlp.tpmversion) != TPM_SUCCESS)
         exit(EXIT_FAILURE);
-    }
 
     if (handle_ctrlchannel_options(ctrlchdata, &mlp.cc) < 0 ||
         handle_server_options(serverdata, &server) < 0) {

--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -491,11 +491,8 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
         exit(ret ? EXIT_FAILURE : EXIT_SUCCESS);
     }
 
-    if (TPMLIB_ChooseTPMVersion(mlp.tpmversion) != TPM_SUCCESS) {
-        logprintf(STDERR_FILENO,
-                  "Error: Could not choose TPM version.\n");
+    if (tpmlib_choose_tpm_version(mlp.tpmversion) != TPM_SUCCESS)
         exit(EXIT_FAILURE);
-    }
 
     tpmstate_set_version(mlp.tpmversion);
 

--- a/src/swtpm/tpmlib.c
+++ b/src/swtpm/tpmlib.c
@@ -89,15 +89,27 @@ TPM_RESULT tpmlib_register_callbacks(struct libtpms_callbacks *cbs)
     return res;
 }
 
-TPM_RESULT tpmlib_start(uint32_t flags, TPMLIB_TPMVersion tpmversion)
+TPM_RESULT tpmlib_choose_tpm_version(TPMLIB_TPMVersion tpmversion)
 {
     TPM_RESULT res;
 
     if ((res = TPMLIB_ChooseTPMVersion(tpmversion)) != TPM_SUCCESS) {
+        const char *version = "TPM 1.2";
+
+        if (tpmversion == TPMLIB_TPM_VERSION_2)
+            version = "TPM 2";
         logprintf(STDERR_FILENO,
-                  "Error: Could not choose TPM 2 implementation.\n");
-        return res;
+                  "Error: %s is not supported by libtpms.\n", version);
     }
+    return res;
+}
+
+TPM_RESULT tpmlib_start(uint32_t flags, TPMLIB_TPMVersion tpmversion)
+{
+    TPM_RESULT res;
+
+    if ((res = tpmlib_choose_tpm_version(tpmversion)) != TPM_SUCCESS)
+        return res;
 
     if ((res = TPMLIB_MainInit()) != TPM_SUCCESS) {
         logprintf(STDERR_FILENO,

--- a/src/swtpm/tpmlib.h
+++ b/src/swtpm/tpmlib.h
@@ -46,6 +46,7 @@
 const char *tpmlib_get_blobname(uint32_t blobtype);
 enum TPMLIB_StateType tpmlib_blobtype_to_statetype(uint32_t blobtype);
 TPM_RESULT tpmlib_register_callbacks(struct libtpms_callbacks *cbs);
+TPM_RESULT tpmlib_choose_tpm_version(TPMLIB_TPMVersion tpmversion);
 TPM_RESULT tpmlib_start(uint32_t flags, TPMLIB_TPMVersion tpmversion);
 int tpmlib_get_tpm_property(enum TPMLIB_TPMProperty prop);
 bool tpmlib_is_request_cancelable(TPMLIB_TPMVersion tpmversion,


### PR DESCRIPTION
Implement tpmlib_choose_tpm_version() that reports an error when an un-
supported version is chosen. Have it used by existing code where possible.

If TPM 1.2 is not supported by libtpms, the following message is now
displayed:

swtpm: Error: TPM 1.2 is not supported by libtpms.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2024583
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>