### PR TITLE
build-sys: Bump up version to 0.8.0 at beginning of dev cycle

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@
 #       This file is derived from tpm-tool's configure.in.
 #
 
-AC_INIT([swtpm],[0.7.0])
+AC_INIT([swtpm],[0.8.0])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+swtpm (0.8.0~dev1) UNRELEASED; urgency=medium
+
+  * Developer release 1
+
+ -- Stefan Berger <stefanb@linux.ibm.com>  Fri, 19 Nov 2021 11:14:00 -0500
+
 swtpm (0.7.0) RELEASED; urgency=medium
 
   * Stable release

--- a/swtpm.spec
+++ b/swtpm.spec
@@ -8,7 +8,7 @@
 
 Summary: TPM Emulator
 Name:           swtpm
-Version:        0.7.0
+Version:        0.8.0
 Release:        1%{?dist}
 License:        BSD
 Url:            https://github.com/stefanberger/swtpm


### PR DESCRIPTION
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>