### PR TITLE
swtpm: Check header size indicator against expected size (CID 375869)

### DIFF
--- a/src/swtpm/swtpm_nvfile.c
+++ b/src/swtpm/swtpm_nvfile.c
@@ -1266,6 +1266,7 @@ SWTPM_NVRAM_CheckHeader(unsigned char *data, uint32_t length,
                         uint8_t *hdrversion, bool quiet)
 {
     blobheader *bh = (blobheader *)data;
+    uint16_t hdrsize;
 
     if (length < sizeof(bh)) {
         if (!quiet)
@@ -1291,8 +1292,16 @@ SWTPM_NVRAM_CheckHeader(unsigned char *data, uint32_t length,
         return TPM_BAD_VERSION;
     }
 
+    hdrsize = ntohs(bh->hdrsize);
+    if (hdrsize != sizeof(blobheader)) {
+        logprintf(STDERR_FILENO,
+                  "bad header size: %u != %zu\n",
+                  hdrsize, sizeof(blobheader));
+        return TPM_BAD_DATASIZE;
+    }
+
     *hdrversion = bh->version;
-    *dataoffset = ntohs(bh->hdrsize);
+    *dataoffset = hdrsize;
     *hdrflags = ntohs(bh->flags);
 
     return TPM_SUCCESS;


### PR DESCRIPTION
This fix addresses Coverity issue CID 375869.

Check the header size indicated in the header of the state against the
expected size and return an error code in case the header size indicator
is different. There was only one header size so far since blobheader was
introduced, so we don't need to deal with different sizes.

Without this fix a specially craft header could have cause out-of-bounds
accesses on the byte array containing the swtpm's state.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>