### PR TITLE
Travis: Stop using ASAN for swtpm since one test case fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ matrix:
         - uidgid="$(id -nu):$(id -ng)" &&
           sudo chown -R ${uidgid} ./ &&
           cpp-coveralls --gcov-options '\-lp' -e libtpms
-    - env: CFLAGS="-fsanitize=address -g -fno-omit-frame-pointer -fno-sanitize-recover"
+    - env: _CFLAGS="-fsanitize=address -g -fno-omit-frame-pointer -fno-sanitize-recover"
            LIBTPMS_CFLAGS="-fsanitize=address -g -fno-omit-frame-pointer -fno-sanitize-recover"
            LIBS="-lasan"
            ASAN_OPTIONS="halt_on_error=1"
@@ -109,7 +109,7 @@ matrix:
            CONFIG="--with-openssl --prefix=${PREFIX} --without-seccomp"
            SUDO="sudo"
            CHECK="check"
-    - env: CFLAGS="-fsanitize=address -g -fno-omit-frame-pointer -fno-sanitize-recover"
+    - env: _CFLAGS="-fsanitize=address -g -fno-omit-frame-pointer -fno-sanitize-recover"
            LIBTPMS_CFLAGS="-fsanitize=address -g -fno-omit-frame-pointer -fno-sanitize-recover"
            LIBTPMS_CONFIG="--disable-use-openssl-functions"
            LIBS="-lasan"


### PR DESCRIPTION
It's not possible to recreate the issue with the failing test case
locally on Xenial, so just disable the ASAN usage on swtpm by disabling
the CFLAGS variable.

The one failing test case show this. All other ones work.

FAIL: test_parameters

=====================

Test 0: SUCCESS with parameters ''.
Test 1: SUCCESS with parameters '--createek'.
Test 2: ==27310==ASan runtime does not come first in initial library list; you should either link runtime to your application or manually preload it with LD_PRELOAD.
ERROR: Test with parameters '--take-ownership' failed.
FAIL test_parameters (exit status: 1)

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>