### PR TITLE
swtpm: Do not chdir(/) when using --daemon

### DIFF
--- a/src/swtpm/daemonize.c
+++ b/src/swtpm/daemonize.c
@@ -274,12 +274,6 @@ daemonize_finish(void)
         return;
     }
 
-    if (chdir("/") == -1) {
-        fprintf(stderr, "Failed to change directory to /: %s\n",
-                strerror(errno));
-        fflush(stderr);
-        exit(1);
-    }
     if (dup2(devnullfd, STDOUT_FILENO) == -1) {
         fprintf(stderr, "Failed to redirect output stream to /dev/null: %s\n",
                 strerror(errno));


### PR DESCRIPTION
With relative paths being used the chdir("/") in daemonize_finish() will
cause file access errors.

Fixes: 98d1d12 ("swtpm: Make --daemon not racy")
Resolves: https://github.com/stefanberger/swtpm/issues/671
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>