### PR TITLE
swtpm: Do not chdir(/) when using --daemon

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@
 #       This file is derived from tpm-tool's configure.in.
 #
 
-AC_INIT([swtpm],[0.5.3])
+AC_INIT([swtpm],[0.5.4])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_HEADERS([config.h])

--- a/dist/swtpm.spec
+++ b/dist/swtpm.spec
@@ -11,7 +11,7 @@
 
 Summary: TPM Emulator
 Name:           swtpm
-Version:        0.5.3
+Version:        0.5.4
 Release:        0.%{gitdate}git%{gitshortcommit}%{?dist}
 License:        BSD
 Url:            http://github.com/stefanberger/swtpm

--- a/src/swtpm/swtpm.c
+++ b/src/swtpm/swtpm.c
@@ -460,9 +460,9 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
 
     if (daemonize) {
 #ifdef __APPLE__
-        if (0 != osx_daemon(0, 0)) {
+        if (0 != osx_daemon(1, 0)) {
 #else
-        if (0 != daemon(0, 0)) {
+        if (0 != daemon(1, 0)) {
 #endif
             logprintf(STDERR_FILENO, "Error: Could not daemonize.\n");
             goto exit_failure;

--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -499,9 +499,9 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
 
     if (daemonize) {
 #if defined __APPLE__
-       if (0 != osx_daemon(0, 0)) {
+       if (0 != osx_daemon(1, 0)) {
 #else
-       if (0 != daemon(0, 0)) {
+       if (0 != daemon(1, 0)) {
 #endif
            logprintf(STDERR_FILENO, "Error: Could not daemonize.\n");
            goto exit_failure;


### PR DESCRIPTION
With relative paths being used the chdir("/") in daemon() will
cause file access errors.

Resolves: https://github.com/stefanberger/swtpm/issues/671
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>