### PR TITLE
Use unsigned int for tcp port number parsing to avoid negative port numbers being used

### DIFF
--- a/src/swtpm_bios/tpm_bios.c
+++ b/src/swtpm_bios/tpm_bios.c
@@ -69,11 +69,12 @@
 static char *tpm_device; /* e.g., /dev/tpm0 */
 
 static char *tcp_hostname;
-static int tcp_port = DEFAULT_TCP_PORT;
+static unsigned int tcp_port = DEFAULT_TCP_PORT;
 
 static char *unix_path;
 
-static int parse_tcp_optarg(char *optarg, char **tcp_hostname, int *tcp_port)
+static int parse_tcp_optarg(char *optarg, char **tcp_hostname,
+                            unsigned int *tcp_port)
 {
 	char *pos = strrchr(optarg, ':');
 	int n;
@@ -131,7 +132,7 @@ static int parse_tcp_optarg(char *optarg, char **tcp_hostname, int *tcp_port)
 }
 
 static int open_connection(char *devname, char *tcp_device_hostname,
-                           int tcp_device_port, const char *unix_path)
+                           unsigned int tcp_device_port, const char *unix_path)
 {
 	int fd = -1;
 	char *tcp_device_port_string = NULL;
@@ -477,7 +478,7 @@ static int tpm12_bios(int do_more, int contselftest, unsigned char startupparm,
 		      int unassert_pp, int ensure_activated)
 {
 	int ret = 0;
-	int tpm_errcode;
+	int tpm_errcode = 0;
 	int tpm_error = 0;
 	unsigned short physical_presence;
 	struct tpm_get_capability_permflags_res perm_flags;
@@ -595,7 +596,7 @@ static int tpm2_bios(int contselftest, unsigned char startupparm,
 		     int set_password)
 {
 	int ret = 0;
-	int tpm_errcode;
+	int tpm_errcode = 0;
 	int tpm_error = 0;
 
 	if (ret == 0) {

--- a/src/swtpm_ioctl/tpm_ioctl.c
+++ b/src/swtpm_ioctl/tpm_ioctl.c
@@ -799,7 +799,8 @@ static int open_connection(const char *devname, char *tcp_hostname,
     return fd;
 }
 
-static int parse_tcp_optarg(char *optarg, char **tcp_hostname, int *tcp_port)
+static int parse_tcp_optarg(char *optarg, char **tcp_hostname,
+                            unsigned int *tcp_port)
 {
     char *pos = strrchr(optarg, ':');
     int n;
@@ -949,7 +950,7 @@ int main(int argc, char *argv[])
     char *tcp_hostname = NULL;
     unsigned int locality = 0;
     unsigned int tpmbuffersize = 0;
-    int tcp_port = -1;
+    unsigned int tcp_port = 0;
     bool is_chardev;
     unsigned long int info_flags = 0;
     char *endptr = NULL;


### PR DESCRIPTION
This PR fixes swtpm_ioctl and swtpm_bios so that for the tcp_port number parsing an unsigned int is being used so that negative port numbers can be reported back to the user as an error.