### PR TITLE
swtpm: Use uint64_t to avoid integer wrap-around when adding a uint32_t

### DIFF
--- a/src/swtpm/tlv.c
+++ b/src/swtpm/tlv.c
@@ -72,8 +72,8 @@ tlv_data_append(unsigned char **buffer, uint32_t *buffer_len,
 {
     size_t i;
     tlv_header tlv;
-    uint32_t totlen;
-    size_t addlen = 0;
+    uint64_t totlen;
+    uint64_t addlen = 0;
     unsigned char *ptr;
     unsigned char *tmp;
 
@@ -85,7 +85,13 @@ tlv_data_append(unsigned char **buffer, uint32_t *buffer_len,
     else
         totlen = addlen;
 
-    tmp = realloc(*buffer, totlen);
+    if (totlen > 0xffffffff) {
+        /* can only happen if tlv.length or *buffer_len were excessive */
+        logprintf(STDERR_FILENO, "%s: Excessive buffer size error.\n", __func__);
+        return TPM_FAIL;
+    }
+
+    tmp = realloc(*buffer, (size_t)totlen);
     if (!tmp) {
          logprintf(STDERR_FILENO, "Could not allocate %u bytes.\n", totlen);
          return TPM_FAIL;

--- a/src/swtpm/tlv.c
+++ b/src/swtpm/tlv.c
@@ -126,7 +126,7 @@ const unsigned char *
 tlv_data_find_tag(const unsigned char *buffer, uint32_t buffer_len,
                   uint16_t tag, tlv_data *td)
 {
-    uint32_t offset = 0;
+    uint64_t offset = 0; /* uint64_t to prevent integer overflow */
 
     while (offset < buffer_len) {
         if (offset + sizeof(td->tlv) > buffer_len)


### PR DESCRIPTION
To avoid an integer wrap-around use uint64_t for 'offset' so that adding
an untrusted 32-bit number will allow for comparison against the trusted
'buffer_len' 32-bit number:

        if (offset + td->tlv.length > buffer_len)
            return NULL;

This avoids possible out-of-bound accesses and crashes when reading
specially crafted input data that have a tlv.length causing an integer
overflow.
