### PR TITLE
debian: Add swtpm apparmor profile upstream from Ubuntu

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Priority: optional
 Standards-Version: 4.5.1
 Rules-Requires-Root: no
 Build-Depends: debhelper (>= 10),
+               dh-apparmor,
                expect,
                gawk,
                gnutls-bin,

--- a/debian/rules
+++ b/debian/rules
@@ -7,6 +7,11 @@ override_dh_auto_configure:
 	NOCONFIGURE=1 ./autogen.sh
 	dh_auto_configure -- --with-openssl --with-gnutls --without-cuse
 
+override_dh_install:
+	dh_install
+	# deploy swtpm's apparmor profile
+	dh_apparmor -pswtpm --profile-name=usr.bin.swtpm
+
 override_dh_auto_test:
 	SWTPM_TEST_SECCOMP_OPT="--seccomp action=none" make -j4 check VERBOSE=1
 

--- a/debian/swtpm.install
+++ b/debian/swtpm.install
@@ -1,2 +1,3 @@
 /usr/bin/swtpm
 /usr/share/man/man8/swtpm.8*
+debian/usr.bin.swtpm etc/apparmor.d/

--- a/debian/usr.bin.swtpm
+++ b/debian/usr.bin.swtpm
@@ -1,0 +1,38 @@
+# vim:syntax=apparmor
+# AppArmor policy for swtpm
+
+#include <tunables/global>
+
+profile swtpm /usr/bin/swtpm {
+  #include <abstractions/base>
+  #include <abstractions/openssl>
+
+  # Site-specific additions and overrides. See local/README for details.
+  #include <local/usr.bin.swtpm>
+
+  capability chown,
+  capability dac_override,
+  capability dac_read_search,
+  capability fowner,
+  capability fsetid,
+  capability setgid,
+  capability setuid,
+
+  network inet stream,
+  network inet6 stream,
+  unix (send) type=dgram addr=none peer=(addr=none),
+  unix (send, receive) type=stream addr=none peer=(label=libvirt-*),
+
+  /usr/bin/swtpm rm,
+
+  /tmp/** rwk,
+  owner @{HOME}/** rwk,
+  owner /var/lib/libvirt/swtpm/** rwk,
+  /run/libvirt/qemu/swtpm/*.sock rwk,
+  owner /var/log/swtpm/libvirt/qemu/*.log rwk,
+  owner /run/libvirt/qemu/swtpm/*.pid rwk,
+  owner /dev/vtpmx rw,
+  owner /etc/nsswitch.conf r,
+  owner /var/lib/swtpm/** rwk,
+  owner /run/swtpm/sock rw,
+}


### PR DESCRIPTION
Hello Stefan,

As a part of the inclusion of swtpm into Ubuntu Jammy Jellyfish I created an apparmor profile to limit unnecessary permissions. This pull request contains the profile and its changes from versions [0.6.1-0ubuntu6](https://launchpad.net/ubuntu/+source/swtpm/0.6.1-0ubuntu6), [0.6.3-0ubuntu1](https://launchpad.net/ubuntu/+source/swtpm/0.6.3-0ubuntu1), and [0.6.3-0ubuntu3](https://launchpad.net/ubuntu/+source/swtpm/0.6.3-0ubuntu3). I also created a [ppa](https://launchpad.net/~lvoytek/+archive/ubuntu/swtpm-upstream-apparmor-profile) for testing the profile alongside your current development release 0.8.0~dev1 in Jammy.

Thanks