### PR TITLE
tests: Patch IBM TSS2 test suite for OpenSSL 3.x

### DIFF
--- a/tests/patches/0001-Deactivate-test-cases-accessing-rootcerts.txt.patch
+++ b/tests/patches/0001-Deactivate-test-cases-accessing-rootcerts.txt.patch
@@ -1,19 +1,39 @@
-From 850ce946fc5ba79f03d46e8cb7695dcadb5f397d Mon Sep 17 00:00:00 2001
+From 498b847b8c0b70c7b92142305a9fddfec9d40ad5 Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Fri, 26 Feb 2021 18:45:57 -0500
-Subject: [PATCH 1/9] Deactivate test cases accessing rootcerts.txt
+Subject: [PATCH 1/6] Deactivate test cases accessing rootcerts.txt
 
 rootcerts.txt contains files in a drive we don't have access to
 ---
- utils/regtests/testcredential.sh | 18 +++++++++---------
+ utils/regtests/testcredential.sh | 23 +++++++++++++----------
  utils/regtests/testunseal.sh     |  4 ++--
- 2 files changed, 11 insertions(+), 11 deletions(-)
+ 2 files changed, 15 insertions(+), 12 deletions(-)
 
 diff --git a/utils/regtests/testcredential.sh b/utils/regtests/testcredential.sh
-index cb9fec0..16fd66a 100755
+index cb9fec0..772a8ac 100755
 --- a/utils/regtests/testcredential.sh
 +++ b/utils/regtests/testcredential.sh
-@@ -300,9 +300,9 @@ NVNAME=(
+@@ -300,12 +300,15 @@ NVNAME=(
+ 	${PREFIX}createek -high -pwde eee -pwdk kkk ${CALG[i]} -cp -noflush > run.out
+ 	checkSuccess $?
+ 
+-	echo "Validate the ${CALG[i]} EK certificate against the root"
+-	${PREFIX}createek -high ${CALG[i]} -root certificates/rootcerts.txt > run.out
+-	checkSuccess $?
++	#echo "Validate the ${CALG[i]} EK certificate against the root"
++	#${PREFIX}createek -high ${CALG[i]} -root certificates/rootcerts.txt > run.out
++	#checkSuccess $?
+ 
+ 	echo "Create a signing key under the ${CALG[i]} EK using the password"
+-	${PREFIX}create -hp 80000001 -si -pwdp kkk > run.out
++	# May need to repeat command due to this here:
++	# https://github.com/stefanberger/libtpms/blob/stable-0.9/src/tpm2/SessionProcess.c#L1204
++	${PREFIX}create -hp 80000001 -si -pwdp kkk > run.out || \
++		${PREFIX}create -hp 80000001 -si -pwdp kkk > run.out
+ 	checkSuccess $?
+ 
+ 	echo "Start a ${HALG[i]} policy session"
+@@ -402,9 +405,9 @@ NVNAME=(
  	${PREFIX}createek -high -pwde eee -pwdk kkk ${CALG[i]} -cp -noflush > run.out
  	checkSuccess $?
  
@@ -26,20 +46,7 @@ index cb9fec0..16fd66a 100755
  
  	echo "Create a signing key under the ${CALG[i]} EK using the password"
  	${PREFIX}create -hp 80000001 -si -pwdp kkk > run.out
-@@ -402,9 +402,9 @@ NVNAME=(
- 	${PREFIX}createek -high -pwde eee -pwdk kkk ${CALG[i]} -cp -noflush > run.out
- 	checkSuccess $?
- 
--	echo "Validate the ${CALG[i]} EK certificate against the root"
--	${PREFIX}createek -high ${CALG[i]} -root certificates/rootcerts.txt > run.out
--	checkSuccess $?
-+	#echo "Validate the ${CALG[i]} EK certificate against the root"
-+	#${PREFIX}createek -high ${CALG[i]} -root certificates/rootcerts.txt > run.out
-+	#checkSuccess $?
- 
- 	echo "Create a signing key under the ${CALG[i]} EK using the password"
- 	${PREFIX}create -hp 80000001 -si -pwdp kkk > run.out
-@@ -540,9 +540,9 @@ NVNAME=(
+@@ -540,9 +543,9 @@ NVNAME=(
  	${PREFIX}createek ${ALG} -pwde eee -cp -noflush > run.out
  	checkSuccess $?
  
@@ -68,5 +75,5 @@ index aae3d4e..1755740 100755
  fi
  checkSuccess $?
 -- 
-2.26.2
+2.36.0
 

--- a/tests/patches/0010-Adjust-test-cases-for-OpenSSL-3.patch
+++ b/tests/patches/0010-Adjust-test-cases-for-OpenSSL-3.patch
@@ -1,0 +1,257 @@
+From c351a11bfb60d9cf5caa3e267f5ce935655401f2 Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.ibm.com>
+Date: Tue, 3 May 2022 10:26:06 -0400
+Subject: [PATCH 6/6] Adjust test cases for OpenSSL 3
+
+1) Some openssl command lines need -traditional when converting a key
+   from PEM to DER format.
+
+2) Some x509 tests need to be disabled to avoid this type of failure:
+
+Signing Key Self Certify CA Root sha256 -rsa 2048 rsa2048
+ ERROR:
+createPartialCertificate: Adding issuer, size 7
+createPartialCertificate: Adding subject (issuer), size 7
+createPartialCertificate: Adding extensions
+ERROR: convertX509ToDer: Error in certificate serialization i2d_X509()
+certifyx509: failed, rc 000b007e
+TSS_RC_X509_ERROR - X509 parse error
+---
+ utils/regtests/testrsa.sh  |   2 +-
+ utils/regtests/testsalt.sh |   2 +-
+ utils/regtests/testsign.sh |   2 +-
+ utils/regtests/testx509.sh | 109 +++++++++++++++++++------------------
+ 4 files changed, 59 insertions(+), 56 deletions(-)
+
+diff --git a/utils/regtests/testrsa.sh b/utils/regtests/testrsa.sh
+index 4f76522..c78566c 100755
+--- a/utils/regtests/testrsa.sh
++++ b/utils/regtests/testrsa.sh
+@@ -62,7 +62,7 @@ if   [ ${CRYPTOLIBRARY} == "openssl" ]; then
+ 	openssl genrsa -out tmpkeypairrsa${BITS}.pem -aes256 -passout pass:rrrr ${BITS} > run.out 2>&1
+ 
+ 	echo "Convert key pair to plaintext DER format"
+-	openssl rsa -inform pem -outform der -in tmpkeypairrsa${BITS}.pem -out tmpkeypairrsa${BITS}.der -passin pass:rrrr > run.out 2>&1
++	openssl rsa -traditional -inform pem -outform der -in tmpkeypairrsa${BITS}.pem -out tmpkeypairrsa${BITS}.der -passin pass:rrrr > run.out 2>&1
+ 
+     done
+ 
+diff --git a/utils/regtests/testsalt.sh b/utils/regtests/testsalt.sh
+index 1bdc1a7..34fe97b 100755
+--- a/utils/regtests/testsalt.sh
++++ b/utils/regtests/testsalt.sh
+@@ -98,7 +98,7 @@ openssl ecparam -name prime256v1 -genkey -noout -out tmpkeypairecc.pem > run.out
+ 
+ echo "Convert key pair to plaintext DER format"
+ 
+-openssl rsa -inform pem -outform der -in tmpkeypairrsa.pem -out tmpkeypairrsa.der -passin pass:rrrr > run.out 2>&1
++openssl rsa -traditional -inform pem -outform der -in tmpkeypairrsa.pem -out tmpkeypairrsa.der -passin pass:rrrr > run.out 2>&1
+ openssl ec -inform pem -outform der -in tmpkeypairecc.pem -out tmpkeypairecc.der -passin pass:rrrr > run.out 2>&1
+ 
+ for HALG in ${ITERATE_ALGS}
+diff --git a/utils/regtests/testsign.sh b/utils/regtests/testsign.sh
+index edfa014..1730e85 100755
+--- a/utils/regtests/testsign.sh
++++ b/utils/regtests/testsign.sh
+@@ -51,7 +51,7 @@ do
+     openssl genrsa -out tmpkeypairrsa${BITS}.pem -aes256 -passout pass:rrrr 2048 > run.out 2>&1
+ 
+     echo "Convert RSA $BITS key pair to plaintext DER format"
+-    openssl rsa -inform pem -outform der -in tmpkeypairrsa${BITS}.pem -out tmpkeypairrsa${BITS}.der -passin pass:rrrr > run.out 2>&1
++    openssl rsa -traditional -inform pem -outform der -in tmpkeypairrsa${BITS}.pem -out tmpkeypairrsa${BITS}.der -passin pass:rrrr > run.out 2>&1
+ 
+     echo "Load the RSA $BITS signing key under the primary key"
+     ${PREFIX}load -hp 80000000 -ipr signrsa${BITS}priv.bin -ipu signrsa${BITS}pub.bin -pwdp sto > run.out
+diff --git a/utils/regtests/testx509.sh b/utils/regtests/testx509.sh
+index 813085f..06e7cce 100755
+--- a/utils/regtests/testx509.sh
++++ b/utils/regtests/testx509.sh
+@@ -68,9 +68,9 @@ do
+     ${PREFIX}load -hp 80000000 -ipr sign${SKEY[i]}priv.bin -ipu sign${SKEY[i]}pub.bin -pwdp sto > run.out
+     checkSuccess $?
+ 
+-    echo "Signing Key Self Certify CA Root ${HALG[i]} ${SALG[i]} ${SKEY[i]}"
+-    ${PREFIX}certifyx509 -hk 80000001 -ho 80000001 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart1.bin -os tmpsig1.bin -oa tmpadd1.bin -otbs tmptbs1.bin -ocert tmpx5091.bin ${SALG[i]} -sub -v -iob 00050472 > run.out
+-    checkSuccess $?
++    #echo "Signing Key Self Certify CA Root ${HALG[i]} ${SALG[i]} ${SKEY[i]}"
++    #${PREFIX}certifyx509 -hk 80000001 -ho 80000001 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart1.bin -os tmpsig1.bin -oa tmpadd1.bin -otbs tmptbs1.bin -ocert tmpx5091.bin ${SALG[i]} -sub -v -iob 00050472 > run.out
++    #checkSuccess $?
+ 
+ 
+     # dumpasn1 -a -l -d     tmpx509i.bin > tmpx509i1.dump
+@@ -87,14 +87,14 @@ do
+     openssl x509 -inform der -in tmpx5091.bin -out tmpx5091.pem > run.out 2>&1
+     echo " INFO:"
+ 
+-    echo "Verify ${SALG[i]} self signed issuer root" 
+-    openssl verify -CAfile tmpx5091.pem tmpx5091.pem > run.out 2>&1
+-    grep -q OK run.out
+-    checkSuccess $?
++    #echo "Verify ${SALG[i]} self signed issuer root"
++    #openssl verify -CAfile tmpx5091.pem tmpx5091.pem > run.out 2>&1
++    #grep -q OK run.out
++    #checkSuccess $?
+ 
+-    echo "Signing Key Certify ${HALG[i]} ${SALG[i]}"
+-    ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -iob 00040472 > run.out
+-    checkSuccess $?
++    #echo "Signing Key Certify ${HALG[i]} ${SALG[i]}"
++    #${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -iob 00040472 > run.out
++    #checkSuccess $?
+ 
+     # dumpasn1 -a -l -d     tmpx509i.bin > tmpx509i2.dump
+     # dumpasn1 -a -l -d -hh tmpx509i.bin > tmpx509i2.dumphh
+@@ -110,10 +110,10 @@ do
+     openssl x509 -inform der -in tmpx5092.bin -out tmpx5092.pem > run.out 2>&1
+     echo " INFO:"
+ 
+-    echo "Verify ${SALG[i]} subject against issuer" 
+-    openssl verify -CAfile tmpx5091.pem tmpx5092.pem > run.out 2>&1
+-    grep -q OK run.out
+-    checkSuccess $?
++    #echo "Verify ${SALG[i]} subject against issuer"
++    #openssl verify -CAfile tmpx5091.pem tmpx5092.pem > run.out 2>&1
++    #grep -q OK run.out
++    #checkSuccess $?
+ 
+     echo "Signing Key Certify ${SALG[i]} with bad OID"
+     ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -iob ffffffff > run.out
+@@ -156,13 +156,13 @@ do
+     ${PREFIX}load -hp 80000000 -ipr sign${SKEY[i]}priv.bin -ipu sign${SKEY[i]}pub.bin -pwdp sto > run.out
+     checkSuccess $?
+ 
+-    echo "Signing Key Certify ${SALG[i]} digitalSignature"
+-    ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,digitalSignature > run.out
+-    checkSuccess $?
++    #echo "Signing Key Certify ${SALG[i]} digitalSignature"
++    #${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,digitalSignature > run.out
++    #checkSuccess $?
+ 
+-    echo "Signing Key Certify ${SALG[i]} nonRepudiation"
+-    ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,nonRepudiation > run.out
+-    checkSuccess $?
++    #echo "Signing Key Certify ${SALG[i]} nonRepudiation"
++    #${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,nonRepudiation > run.out
++    #checkSuccess $?
+ 
+     echo "Signing Key Certify ${SALG[i]} keyEncipherment"
+     ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,keyEncipherment > run.out
+@@ -176,13 +176,13 @@ do
+     ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,keyAgreement > run.out
+     checkFailure $?
+ 
+-    echo "Signing Key Certify ${SALG[i]} keyCertSign"
+-    ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,keyCertSign > run.out
+-    checkSuccess $?
++    #echo "Signing Key Certify ${SALG[i]} keyCertSign"
++    #${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,keyCertSign > run.out
++    #checkSuccess $?
+ 
+-    echo "Signing Key Certify ${SALG[i]} cRLSign"
+-    ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,cRLSign > run.out
+-    checkSuccess $?
++    #echo "Signing Key Certify ${SALG[i]} cRLSign"
++    #${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,cRLSign > run.out
++    #checkSuccess $?
+ 
+     echo "Signing Key Certify ${SALG[i]} encipherOnly"
+     ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,encipherOnly > run.out
+@@ -217,9 +217,9 @@ do
+     ${PREFIX}load -hp 80000000 -ipr sign${SKEY[i]}nfpriv.bin -ipu sign${SKEY[i]}nfpub.bin -pwdp sto > run.out
+     checkSuccess $?
+ 
+-    echo "Signing Key Certify ${SALG[i]} digitalSignature"
+-    ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,digitalSignature > run.out
+-    checkSuccess $?
++    #echo "Signing Key Certify ${SALG[i]} digitalSignature"
++    #${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,digitalSignature > run.out
++    #checkSuccess $?
+ 
+     echo "Signing Key Certify ${SALG[i]} nonRepudiation"
+     ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,nonRepudiation > run.out
+@@ -237,13 +237,13 @@ do
+     ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,keyAgreement > run.out
+     checkFailure $?
+ 
+-    echo "Signing Key Certify ${SALG[i]} keyCertSign"
+-    ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,keyCertSign > run.out
+-    checkSuccess $?
++    #echo "Signing Key Certify ${SALG[i]} keyCertSign"
++    #${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,keyCertSign > run.out
++    #checkSuccess $?
+ 
+-    echo "Signing Key Certify ${SALG[i]} cRLSign"
+-    ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,cRLSign > run.out
+-    checkSuccess $?
++    #echo "Signing Key Certify ${SALG[i]} cRLSign"
++    #${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,cRLSign > run.out
++    #checkSuccess $?
+ 
+     echo "Signing Key Certify ${SALG[i]} encipherOnly"
+     ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,encipherOnly > run.out
+@@ -282,21 +282,21 @@ do
+     ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sto -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,digitalSignature > run.out
+     checkFailure $?
+ 
+-    echo "Signing Key Certify ${SALG[i]} nonRepudiation"
+-    ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sto -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,nonRepudiation > run.out
+-    checkSuccess $?
++    #echo "Signing Key Certify ${SALG[i]} nonRepudiation"
++    #${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sto -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,nonRepudiation > run.out
++    #checkSuccess $?
+ 
+-    echo "Signing Key Certify ${SALG[i]} keyEncipherment"
+-    ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sto -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,keyEncipherment > run.out
+-    checkSuccess $?
++    #echo "Signing Key Certify ${SALG[i]} keyEncipherment"
++    #${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sto -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,keyEncipherment > run.out
++    #checkSuccess $?
+ 
+-    echo "Signing Key Certify ${SALG[i]} dataEncipherment"
+-    ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sto -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,dataEncipherment > run.out
+-    checkSuccess $?
++    #echo "Signing Key Certify ${SALG[i]} dataEncipherment"
++    #${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sto -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,dataEncipherment > run.out
++    #checkSuccess $?
+ 
+-    echo "Signing Key Certify ${SALG[i]} keyAgreement"
+-    ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sto -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,keyAgreement > run.out
+-    checkSuccess $?
++    #echo "Signing Key Certify ${SALG[i]} keyAgreement"
++    #${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sto -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,keyAgreement > run.out
++    #checkSuccess $?
+ 
+     echo "Signing Key Certify ${SALG[i]} keyCertSign"
+     ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sto -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,keyCertSign > run.out
+@@ -306,13 +306,13 @@ do
+     ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sto -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,cRLSign > run.out
+     checkFailure $?
+ 
+-    echo "Signing Key Certify ${SALG[i]} encipherOnly"
+-    ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sto -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,encipherOnly > run.out
+-    checkSuccess $?
++    #echo "Signing Key Certify ${SALG[i]} encipherOnly"
++    #${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sto -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,encipherOnly > run.out
++    #checkSuccess $?
+ 
+-    echo "Signing Key Certify ${SALG[i]} decipherOnly"
+-    ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sto -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,decipherOnly > run.out
+-    checkSuccess $?
++    #echo "Signing Key Certify ${SALG[i]} decipherOnly"
++    #${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sto -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,decipherOnly > run.out
++    #checkSuccess $?
+ 
+     echo "Flush the root CA issuer signing key"
+     ${PREFIX}flushcontext -ha 80000001 > run.out
+@@ -340,5 +340,8 @@ rm -r tmptbs2.bin
+ rm -r tmpsig2.bin
+ rm -r tmpx5092.bin
+ 
++# finish with $?=0
++true
++
+ # openssl only
+ fi
+-- 
+2.36.0
+

--- a/tests/test_tpm2_ibmtss2
+++ b/tests/test_tpm2_ibmtss2
@@ -9,11 +9,6 @@ if [ -z "$(type openssl)" ]; then
 	exit 1
 fi
 
-if [ -n "$(openssl version | grep -E "^OpenSSL 3")" ]; then
-	echo "IBMTSS2 v1.6 test suite does not work with OpenSSL 3.0"
-	exit 77
-fi
-
 ROOT=${abs_top_builddir:-$(pwd)/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 ABSTESTDIR=$(cd ${TESTDIR} &>/dev/null;echo ${PWD})
@@ -102,6 +97,10 @@ if [ $revision -lt 155 ]; then
 	git am < ${PATCHESDIR}/0007-Disable-rev155-test-cases.patch
 	git am < ${PATCHESDIR}/0008-Disable-x509-test-cases.patch
 	git am < ${PATCHESDIR}/0009-Disable-getcapability-TPM_CAP_ACT.patch
+fi
+
+if [ -n "$(openssl version | grep -E "^OpenSSL 3")" ]; then
+	git am < ${PATCHESDIR}/0010-Adjust-test-cases-for-OpenSSL-3.patch
 fi
 
 autoreconf --force --install


### PR DESCRIPTION
Apply a patch to the IBM TSS2 v1.6 test suite when OpenSSL 3.x is de-
tected.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>