### PR TITLE
swtpm: Avoid locking directory multiple times

### DIFF
--- a/src/swtpm/swtpm_nvstore_dir.c
+++ b/src/swtpm/swtpm_nvstore_dir.c
@@ -121,6 +121,9 @@ SWTPM_NVRAM_Lock_Dir(const char *tpm_state_path)
         .l_len = 0,
     };
 
+    if (lock_fd >= 0)
+        return 0;
+
     if (asprintf(&lockfile, "%s/.lock", tpm_state_path) < 0) {
         logprintf(STDERR_FILENO,
                   "SWTPM_NVRAM_Lock_Dir: Could not asprintf lock filename\n");


### PR DESCRIPTION
Commit https://github.com/stefanberger/swtpm/commit/2d3deaef291e045a2188287d18d42f2dd58173bf forgot to move the check for whether the lock file has
already been opened into the new function opening the lock file and there-
fore the lock file is now opened whenever swtpm gets a PTM_INIT. This fix
prevents the reopening of the lockfile if it has already been opened.
Otherwise many PTM_INIT's will lead to failure since no more files can
be opened.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>