### PR TITLE
Send a TPM2_Shutdown before TPMLIB_Terminate() in case client did not send it

### DIFF
--- a/man/man8/swtpm.pod
+++ b/man/man8/swtpm.pod
@@ -406,6 +406,19 @@ Display usage info.
 
 =back
 
+=head1 NOTES
+
+If a TPM 2 is used, the user is typically required to send a TPM2_Shutdown()
+command to a TPM 2 to avoid possibly increasing the TPM_PT_LOCKOUT_COUNTER
+that may lead to a dictionary attack (DA) lockout upon next startup
+(TPM2_Startup()) of the TPM 2. Whether the TPM_PT_LOCKOUT_COUNTER is
+increased depends on previous commands sent to the TPM 2 as well as
+internal state of the TPM 2. One example that will trigger the counter to
+increase is the omission of a password when trying to access a
+password-protected object or NVRAM location that has the DA attribute set,
+followed by termination of swtpm without sending TPM2_Shutdown(). To avoid
+a DA lockout swtpm will make a best-effort and send a TPM2_Shutdown(SU_STATE)
+or TPM2_Shutdown(SU_CLEAR) if found necessary.
 
 =head1 SEE ALSO
 

--- a/man/man8/swtpm.pod
+++ b/man/man8/swtpm.pod
@@ -277,7 +277,7 @@ The I<log> action is only available if libseccomp supports logging.
 This option is only available on Linux and only if swtpm was compiled with
 libseccomp support.
 
-=item B<--flags [not-need-init] [,startup-clear|startup-state|startup-deactivated|startup-none]>
+=item B<--flags [not-need-init][,startup-clear|startup-state|startup-deactivated|startup-none][,disable-auto-shutdown]>
 
 The I<not-need-init> flag enables the TPM to accept TPM commands right after
 start without requiring an INIT to be sent to it through the command channel
@@ -290,6 +290,13 @@ I<startup-none> option, which results in no command being sent.
 
 If I<--vtpm-proxy> is used, I<startup-clear> is automatically chosen but
 this can be changed with this option.
+
+The I<disable-auto-shutdown> flag prevents swtpm from automatically sending a
+TPM2_Shutdown() before the reset of a TPM 2 or before the swtpm process
+is terminated. When this flag is not provide swtpm will send this command to
+avoid increasing the dictionary attack (DA) lockout counter and ulimately
+a DA lockout by the TPM 2 due to omission of sending a required TPM2_Shutdown()
+before TPM 2 reset or swtpm process termination.
 
 =item B<--print-capabilities> (since v0.2)
 
@@ -309,6 +316,7 @@ may contain the following:
         "nvram-backend-file",
         "tpm-send-command-header",
         "flags-opt-startup",
+        "flags-opt-disable-auto-shutdown",
         "rsa-keysize-1024",
         "rsa-keysize-2048",
         "rsa-keysize-3072"
@@ -368,6 +376,10 @@ The TPM 2 will respond by preprending a 4-byte response indicator and a
 =item B<flags-opt-startup> (since v0.3)
 
 The I<--flags> option supports the I<startup-...> options.
+
+=item B<flags-opt-disable-auto-shutdown> (since v0.8)
+
+The I<--flags> option supports the I<disable-auto-shutdown> flag.
 
 =item B<rsa-keysize-2048> (since v0.4)
 

--- a/src/swtpm/capabilities.c
+++ b/src/swtpm/capabilities.c
@@ -146,7 +146,7 @@ int capabilities_print_json(bool cusetpm, TPMLIB_TPMVersion tpmversion)
          "{ "
          "\"type\": \"swtpm\", "
          "\"features\": [ "
-             "%s%s%s%s%s%s%s%s%s%s%s"
+             "%s%s%s%s%s%s%s%s%s%s%s%s"
           " ], "
          "\"version\": \"" VERSION "\" "
          "}",
@@ -154,6 +154,7 @@ int capabilities_print_json(bool cusetpm, TPMLIB_TPMVersion tpmversion)
          with_tpm2,
          !cusetpm     ? "\"tpm-send-command-header\", ": "",
          true         ? "\"flags-opt-startup\", "      : "",
+         true         ? "\"flags-opt-disable-auto-shutdown\", ": "",
          cmdarg_seccomp,
          true         ? "\"cmdarg-key-fd\", "          : "",
          true         ? "\"cmdarg-pwd-fd\", "          : "",

--- a/src/swtpm/common.c
+++ b/src/swtpm/common.c
@@ -246,6 +246,9 @@ static const OptionDesc flags_opt_desc[] = {
     }, {
         .name = "startup-deactivated",
         .type = OPT_TYPE_BOOLEAN,
+    }, {
+        .name = "disable-auto-shutdown",
+        .type = OPT_TYPE_BOOLEAN,
     },
     END_OPTION_DESC
 };
@@ -1234,7 +1237,7 @@ int handle_locality_options(char *options, uint32_t *flags)
 }
 
 static int parse_flags_options(char *options, bool *need_init_cmd,
-                               uint16_t *startupType)
+                               uint16_t *startupType, bool *disable_auto_shutdown)
 {
     OptionValues *ovs = NULL;
     char *error = NULL;
@@ -1247,6 +1250,8 @@ static int parse_flags_options(char *options, bool *need_init_cmd,
 
     if (option_get_bool(ovs, "not-need-init", false))
         *need_init_cmd = false;
+    if (option_get_bool(ovs, "disable-auto-shutdown", false))
+        *disable_auto_shutdown = true;
 
     if (option_get_bool(ovs, "startup-clear", false))
         *startupType = TPM_ST_CLEAR;
@@ -1280,12 +1285,13 @@ error:
  * Returns 0 on success, -1 on failure.
  */
 int handle_flags_options(char *options, bool *need_init_cmd,
-                         uint16_t *startupType)
+                         uint16_t *startupType, bool *disable_auto_shutdown)
 {
     if (!options)
         return 0;
 
-    if (parse_flags_options(options, need_init_cmd, startupType) < 0)
+    if (parse_flags_options(options, need_init_cmd, startupType,
+                            disable_auto_shutdown) < 0)
         return -1;
 
     return 0;

--- a/src/swtpm/common.h
+++ b/src/swtpm/common.h
@@ -54,7 +54,7 @@ struct server;
 int handle_server_options(char *options, struct server **s);
 int handle_locality_options(char *options, uint32_t *flags);
 int handle_flags_options(char *options, bool *need_init_cmd,
-                         uint16_t *startupType);
+                         uint16_t *startupType, bool *disable_auto_shutdown);
 #ifdef WITH_SECCOMP
 int handle_seccomp_options(char *options, unsigned int *seccomp_action);
 #else

--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -554,6 +554,10 @@ int ctrlchannel_process_fd(int fd,
         if (n != (ssize_t)sizeof(ptm_init)) /* r/w */
             goto err_bad_input;
 
+        if (*tpm_running)
+            tpmlib_maybe_send_tpm2_shutdown(mlp->tpmversion,
+                                            &mlp->lastCommand);
+
         init_p = (ptm_init *)input.body;
 
         TPMLIB_Terminate();
@@ -576,6 +580,10 @@ int ctrlchannel_process_fd(int fd,
         if (n != 0) /* wo */
             goto err_bad_input;
 
+        if (*tpm_running)
+            tpmlib_maybe_send_tpm2_shutdown(mlp->tpmversion,
+                                            &mlp->lastCommand);
+
         TPMLIB_Terminate();
 
         *tpm_running = false;
@@ -587,6 +595,10 @@ int ctrlchannel_process_fd(int fd,
     case CMD_SHUTDOWN:
         if (n != 0) /* wo */
             goto err_bad_input;
+
+        if (*tpm_running)
+            tpmlib_maybe_send_tpm2_shutdown(mlp->tpmversion,
+                                            &mlp->lastCommand);
 
         TPMLIB_Terminate();
 

--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -554,7 +554,7 @@ int ctrlchannel_process_fd(int fd,
         if (n != (ssize_t)sizeof(ptm_init)) /* r/w */
             goto err_bad_input;
 
-        if (*tpm_running)
+        if (*tpm_running && !mlp->disable_auto_shutdown)
             tpmlib_maybe_send_tpm2_shutdown(mlp->tpmversion,
                                             &mlp->lastCommand);
 
@@ -580,7 +580,7 @@ int ctrlchannel_process_fd(int fd,
         if (n != 0) /* wo */
             goto err_bad_input;
 
-        if (*tpm_running)
+        if (*tpm_running && !mlp->disable_auto_shutdown)
             tpmlib_maybe_send_tpm2_shutdown(mlp->tpmversion,
                                             &mlp->lastCommand);
 
@@ -596,7 +596,7 @@ int ctrlchannel_process_fd(int fd,
         if (n != 0) /* wo */
             goto err_bad_input;
 
-        if (*tpm_running)
+        if (*tpm_running && !mlp->disable_auto_shutdown)
             tpmlib_maybe_send_tpm2_shutdown(mlp->tpmversion,
                                             &mlp->lastCommand);
 

--- a/src/swtpm/cuse_tpm.c
+++ b/src/swtpm/cuse_tpm.c
@@ -1091,6 +1091,10 @@ static void ptm_ioctl(fuse_req_t req, int cmd, void *arg,
 
             worker_thread_end();
 
+            if (tpm_running)
+                tpmlib_maybe_send_tpm2_shutdown(tpmversion,
+                                                &g_lastCommand);
+
             TPMLIB_Terminate();
 
             tpm_running = false;
@@ -1108,6 +1112,9 @@ static void ptm_ioctl(fuse_req_t req, int cmd, void *arg,
     case PTM_STOP:
         worker_thread_end();
 
+        if (tpm_running)
+            tpmlib_maybe_send_tpm2_shutdown(tpmversion, &g_lastCommand);
+
         res = TPM_SUCCESS;
         TPMLIB_Terminate();
 
@@ -1122,6 +1129,9 @@ static void ptm_ioctl(fuse_req_t req, int cmd, void *arg,
 
     case PTM_SHUTDOWN:
         worker_thread_end();
+
+        if (tpm_running)
+            tpmlib_maybe_send_tpm2_shutdown(tpmversion, &g_lastCommand);
 
         res = TPM_SUCCESS;
         TPMLIB_Terminate();

--- a/src/swtpm/mainloop.h
+++ b/src/swtpm/mainloop.h
@@ -60,6 +60,7 @@ struct mainLoopParams {
     uint32_t locality_flags;
     TPMLIB_TPMVersion tpmversion;
     uint16_t startupType; /* use TPM 1.2 types */
+    uint32_t lastCommand; /* last Command sent to TPM */
 };
 
 int mainLoop(struct mainLoopParams *mlp,

--- a/src/swtpm/mainloop.h
+++ b/src/swtpm/mainloop.h
@@ -61,6 +61,7 @@ struct mainLoopParams {
     TPMLIB_TPMVersion tpmversion;
     uint16_t startupType; /* use TPM 1.2 types */
     uint32_t lastCommand; /* last Command sent to TPM */
+    bool disable_auto_shutdown;   /* TPM2_Shutdown() will NOT be sent by swtpm */
 };
 
 int mainLoop(struct mainLoopParams *mlp,

--- a/src/swtpm/swtpm.c
+++ b/src/swtpm/swtpm.c
@@ -215,6 +215,7 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
         .locality_flags = 0,
         .tpmversion = TPMLIB_TPM_VERSION_1_2,
         .startupType = _TPM_ST_NONE,
+        .lastCommand = TPM_ORDINAL_NONE,
     };
     struct server *server = NULL;
     unsigned long val;

--- a/src/swtpm/swtpm.c
+++ b/src/swtpm/swtpm.c
@@ -168,10 +168,12 @@ static void usage(FILE *file, const char *prgname, const char *iface)
     "                   mode allows a user to set the file mode bits of the socket; the\n"
     "                   value must be given in octal number format;\n"
     "                   uid and gid set the ownership of the Unixio socket's file;\n"
-    "--flags [not-need-init][,startup-clear|startup-state|startup-deactivated|startup-none]\n"
+    "--flags [not-need-init][,startup-clear|startup-state|startup-deactivated|startup-none][,disable-auto-shutdown]\n"
     "                 : not-need-init: commands can be sent without needing to\n"
     "                   send an INIT via control channel;\n"
     "                   startup-...: send Startup command with this type;\n"
+    "                   disable-auto-shutdown disables automatic sending of\n"
+    "                   TPM2_Shutdown before TPM 2 reset or swtpm termination;\n"
     "-r|--runas <user>: change to the given user\n"
     "--tpm2           : choose TPM2 functionality\n"
 #ifdef WITH_SECCOMP
@@ -216,6 +218,7 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
         .tpmversion = TPMLIB_TPM_VERSION_1_2,
         .startupType = _TPM_ST_NONE,
         .lastCommand = TPM_ORDINAL_NONE,
+        .disable_auto_shutdown = false,
     };
     struct server *server = NULL;
     unsigned long val;
@@ -469,7 +472,7 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
         handle_tpmstate_options(tpmstatedata) < 0 ||
         handle_seccomp_options(seccompdata, &seccomp_action) < 0 ||
         handle_flags_options(flagsdata, &need_init_cmd,
-                             &mlp.startupType) < 0) {
+                             &mlp.startupType, &mlp.disable_auto_shutdown) < 0) {
         goto exit_failure;
     }
 

--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -274,6 +274,7 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
         .locality_flags = 0,
         .tpmversion = TPMLIB_TPM_VERSION_1_2,
         .startupType = _TPM_ST_NONE,
+        .lastCommand = TPM_ORDINAL_NONE,
     };
     unsigned long val;
     char *end_ptr;

--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -189,12 +189,14 @@ static void usage(FILE *file, const char *prgname, const char *iface)
     "--locality [reject-locality-4][,allow-set-locality]\n"
     "                 : reject-locality-4: reject any command in locality 4\n"
     "                   allow-set-locality: accept SetLocality command\n"
-    "--flags [not-need-init][,startup-clear|startup-state|startup-deactivated|startup-none]\n"
+    "--flags [not-need-init][,startup-clear|startup-state|startup-deactivated|startup-none][,disable-auto-shutdown]\n"
     "                 : not-need-init: commands can be sent without needing to\n"
     "                   send an INIT via control channel; not needed when using\n"
     "                   --vtpm-proxy\n"
     "                   startup-...: send Startup command with this type;\n"
     "                   when --vtpm-proxy is used, startup-clear is used\n"
+    "                   disable-auto-shutdown disables automatic sending of\n"
+    "                   TPM2_Shutdown before TPM 2 reset or swtpm termination;\n"
     "--tpm2           : choose TPM2 functionality\n"
 #ifdef WITH_SECCOMP
 # ifndef SCMP_ACT_LOG
@@ -275,6 +277,7 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
         .tpmversion = TPMLIB_TPM_VERSION_1_2,
         .startupType = _TPM_ST_NONE,
         .lastCommand = TPM_ORDINAL_NONE,
+        .disable_auto_shutdown = false,
     };
     unsigned long val;
     char *end_ptr;
@@ -532,7 +535,7 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
         handle_tpmstate_options(tpmstatedata) < 0 ||
         handle_seccomp_options(seccompdata, &seccomp_action) < 0 ||
         handle_flags_options(flagsdata, &need_init_cmd,
-                             &mlp.startupType) < 0) {
+                             &mlp.startupType, &mlp.disable_auto_shutdown) < 0) {
         goto exit_failure;
     }
 

--- a/src/swtpm/tpmlib.c
+++ b/src/swtpm/tpmlib.c
@@ -169,14 +169,11 @@ uint32_t tpmlib_get_cmd_ordinal(const unsigned char *request, size_t req_len)
 bool tpmlib_is_request_cancelable(TPMLIB_TPMVersion tpmversion,
                                   const unsigned char *request, size_t req_len)
 {
-    struct tpm_req_header *hdr;
-    uint32_t ordinal;
 
-    if (req_len < sizeof(struct tpm_req_header))
+    uint32_t ordinal = tpmlib_get_cmd_ordinal(request, req_len);
+
+    if (ordinal == TPM_ORDINAL_NONE)
         return false;
-
-    hdr = (struct tpm_req_header *)request;
-    ordinal = be32toh(hdr->ordinal);
 
     if (tpmversion == TPMLIB_TPM_VERSION_2)
         return (ordinal == TPMLIB_TPM2_CC_CreatePrimary ||

--- a/src/swtpm/tpmlib.c
+++ b/src/swtpm/tpmlib.c
@@ -155,6 +155,17 @@ int tpmlib_get_tpm_property(enum TPMLIB_TPMProperty prop)
     return result;
 }
 
+uint32_t tpmlib_get_cmd_ordinal(const unsigned char *request, size_t req_len)
+{
+    struct tpm_req_header *hdr;
+
+    if (req_len < sizeof(struct tpm_req_header))
+        return TPM_ORDINAL_NONE;
+
+    hdr = (struct tpm_req_header *)request;
+    return be32toh(hdr->ordinal);
+}
+
 bool tpmlib_is_request_cancelable(TPMLIB_TPMVersion tpmversion,
                                   const unsigned char *request, size_t req_len)
 {

--- a/src/swtpm/tpmlib.h
+++ b/src/swtpm/tpmlib.h
@@ -49,6 +49,7 @@ TPM_RESULT tpmlib_register_callbacks(struct libtpms_callbacks *cbs);
 TPM_RESULT tpmlib_choose_tpm_version(TPMLIB_TPMVersion tpmversion);
 TPM_RESULT tpmlib_start(uint32_t flags, TPMLIB_TPMVersion tpmversion);
 int tpmlib_get_tpm_property(enum TPMLIB_TPMProperty prop);
+uint32_t tpmlib_get_cmd_ordinal(const unsigned char *request, size_t req_len);
 bool tpmlib_is_request_cancelable(TPMLIB_TPMVersion tpmversion,
                                   const unsigned char *request, size_t req_len);
 void tpmlib_write_fatal_error_response(unsigned char **rbuffer,
@@ -141,5 +142,8 @@ struct tpm_startup {
 /* TPM 2 startup types */
 #define TPM2_SU_CLEAR                  0x0000
 #define TPM2_SU_STATE                  0x0001
+
+/* common */
+#define TPM_ORDINAL_NONE               0x00000000
 
 #endif /* _SWTPM_TPMLIB_H_ */

--- a/src/swtpm/tpmlib.h
+++ b/src/swtpm/tpmlib.h
@@ -80,6 +80,9 @@ uint32_t tpmlib_create_startup_cmd(uint16_t startupType,
                                    unsigned char *buffer,
                                    uint32_t buffersize);
 
+void tpmlib_maybe_send_tpm2_shutdown(TPMLIB_TPMVersion tpmversion,
+                                     uint32_t *lastCommand);
+
 struct tpm_req_header {
     uint16_t tag;
     uint32_t size;
@@ -131,12 +134,14 @@ struct tpm_startup {
 
 /* TPM 2 error codes */
 #define TPM_RC_INSUFFICIENT 0x09a
+#define TPM_RC_INITIALIZE   0x100
 #define TPM_RC_FAILURE      0x101
 #define TPM_RC_LOCALITY     0x107
 
 /* TPM 2 commands */
 #define TPMLIB_TPM2_CC_CreatePrimary   0x00000131
 #define TPMLIB_TPM2_CC_Startup         0x00000144
+#define TPMLIB_TPM2_CC_Shutdown        0x00000145
 #define TPMLIB_TPM2_CC_Create          0x00000153
 
 /* TPM 2 startup types */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -46,6 +46,7 @@ TESTS += \
 	test_swtpm_setup_misc
 
 TESTS += \
+	test_tpm2_avoid_da_lockout \
 	test_tpm2_ctrlchannel2 \
 	test_tpm2_derived_keys \
 	test_tpm2_encrypted_state \
@@ -184,6 +185,7 @@ EXTRA_DIST=$(TESTS) \
 	_test_setbuffersize \
 	_test_swtpm_bios \
 	_test_tpm_probe \
+	_test_tpm2_avoid_da_lockout \
 	_test_tpm2_derived_keys \
 	_test_tpm2_encrypted_state \
 	_test_tpm2_file_permissions \

--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -25,7 +25,7 @@ if [ "${SWTPM_IFACE}" != "cuse" ]; then
 	noncuse='"tpm-send-command-header", '
 fi
 
-exp='\{ "type": "swtpm", "features": \[ "tpm-1.2",( "tpm-2.0",)? '${noncuse}'"flags-opt-startup", '${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd", "cmdarg-print-states", "nvram-backend-dir", "nvram-backend-file" \], "version": "[^"]*" \}'
+exp='\{ "type": "swtpm", "features": \[ "tpm-1.2",( "tpm-2.0",)? '${noncuse}'"flags-opt-startup", "flags-opt-disable-auto-shutdown", '${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd", "cmdarg-print-states", "nvram-backend-dir", "nvram-backend-file" \], "version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-capabilities:"
 	echo "Actual   : ${msg}"

--- a/tests/_test_tpm2_avoid_da_lockout
+++ b/tests/_test_tpm2_avoid_da_lockout
@@ -1,0 +1,164 @@
+#!/bin/bash
+
+# For the license, see the LICENSE file in the root directory.
+#set -x
+
+ROOT=${abs_top_builddir:-$(pwd)/..}
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+
+VTPM_NAME="vtpm-test-tpm2-avoid-da-lockout"
+SWTPM_DEV_NAME="/dev/${VTPM_NAME}"
+export TPM_PATH="$(mktemp -d)" || exit 1
+LOG_FILE=$TPM_PATH/tpm-00.log
+SWTPM_CMD_UNIX_PATH=${TPM_PATH}/unix-cmd.sock
+SWTPM_CTRL_UNIX_PATH=${TPM_PATH}/unix-ctrl.sock
+
+function cleanup()
+{
+	pid=${SWTPM_PID}
+	if [ -n "$pid" ]; then
+		kill_quiet -9 $pid
+	fi
+	rm -rf $TPM_PATH
+}
+
+trap "cleanup" EXIT
+
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source ${TESTDIR}/test_cuse
+source ${TESTDIR}/common
+source ${TESTDIR}/test_common
+
+run_swtpm ${SWTPM_INTERFACE} \
+	--tpm2 \
+	--log file=$LOG_FILE,level=20 \
+	--flags not-need-init,startup-clear
+
+kill_quiet -0 ${SWTPM_PID}
+if [ $? -ne 0 ]; then
+	echo "Error: ${SWTPM_INTERFACE} TPM did not start."
+	exit 1
+fi
+
+# Define password-protected NV space with DA attribute set: tssnvdefinespace -ha 01000000 -hi o -pwdn test -sz 1 -at da
+cmd='\x80\x02\x00\x00\x00\x31\x00\x00\x01\x2a\x40\x00\x00\x01\x00\x00\x00\x09\x40\x00\x00\x09\x00\x00\x00\x00\x00\x00\x04\x74\x65\x73\x74\x00\x0e\x01\x00\x00\x00\x00\x0b\x00\x04\x00\x04\x00\x00\x00\x01'
+RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} ${cmd})
+exp=' 80 02 00 00 00 13 00 00 00 00 00 00 00 00 00 00 01 00 00'
+if [ "$RES" != "$exp" ]; then
+	echo "Error: Did not get expected result from TPM2_NV_DefineSpace"
+	echo "expected: $exp"
+	echo "received: $RES"
+	exit 1
+fi
+
+# Write to NV space without password: tssnvwrite -ha 01000000 -ic A
+cmd='\x80\x02\x00\x00\x00\x24\x00\x00\x01\x37\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x09\x40\x00\x00\x09\x00\x00\x00\x00\x00\x00\x01\x41\x00\x00'
+RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} ${cmd})
+exp=' 80 01 00 00 00 0a 00 00 09 22'
+if [ "$RES" != "$exp" ]; then
+	echo "Error: Did not get expected result from TPM2_NV_Write"
+	echo "expected: $exp"
+	echo "received: $RES"
+	exit 1
+fi
+
+# The TPM_PT_LOCKOUT_COUNTER must be 0 now: tssgetcapability -cap 6 -pr 0x20e -pc 1
+cmd='\x80\x01\x00\x00\x00\x16\x00\x00\x01\x7a\x00\x00\x00\x06\x00\x00\x02\x0e\x00\x00\x00\x01'
+RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} ${cmd})
+exp=' 80 01 00 00 00 1b 00 00 00 00 01 00 00 00 06 00 00 00 01 00 00 02 0e 00 00 00 00'
+if [ "$RES" != "$exp" ]; then
+	echo "Error: Did not get expected result from TPM2_GetCapability(TPM_PT_LOCKOUT_COUNTER)"
+	echo "expected: $exp"
+	echo "received: $RES"
+	exit 1
+fi
+
+# Abruptly init the TPM: swtpm will internally send TPM2_Shutdown()
+run_swtpm_ioctl ${SWTPM_INTERFACE} -i
+if [ $? -ne 0 ]; then
+	echo "Error: Could not initialize the ${SWTPM_INTERFACE} TPM."
+	exit 1
+fi
+
+# send TPM2_Startup(SU_CLEAR)
+cmd='\x80\x01\x00\x00\x00\x0c\x00\x00\x01\x44\x00\x00'
+RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} ${cmd})
+exp=' 80 01 00 00 00 0a 00 00 00 00'
+if [ "$RES" != "$exp" ]; then
+	echo "Error: Did not get expected result from TPM2_Startup(SU_CLEAR)"
+	echo "expected: $exp"
+	echo "received: $RES"
+	exit 1
+fi
+
+# The TPM_PT_LOCKOUT_COUNTER must still be '0' now: tssgetcapability -cap 6 -pr 0x20e -pc 1
+# Without swtpm sending TPM2_Shutdown, it would be '1' now
+cmd='\x80\x01\x00\x00\x00\x16\x00\x00\x01\x7a\x00\x00\x00\x06\x00\x00\x02\x0e\x00\x00\x00\x01'
+RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} ${cmd})
+exp=' 80 01 00 00 00 1b 00 00 00 00 01 00 00 00 06 00 00 00 01 00 00 02 0e 00 00 00 00'
+if [ "$RES" != "$exp" ]; then
+	echo "Error: Did not get expected result from TPM2_GetCapability(TPM_PT_LOCKOUT_COUNTER)"
+	echo "expected: $exp"
+	echo "received: $RES"
+	exit 1
+fi
+
+# Again write to NV space without password: tssnvwrite -ha 01000000 -ic A
+cmd='\x80\x02\x00\x00\x00\x24\x00\x00\x01\x37\x01\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x09\x40\x00\x00\x09\x00\x00\x00\x00\x00\x00\x01\x41\x00\x00'
+RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} ${cmd})
+exp=' 80 01 00 00 00 0a 00 00 09 22'
+if [ "$RES" != "$exp" ]; then
+	echo "Error: Did not get expected result from TPM2_NV_Write"
+	echo "expected: $exp"
+	echo "received: $RES"
+	exit 1
+fi
+
+# CMD_STOP: swtpm will internally send TPM2_Shutdown()
+run_swtpm_ioctl ${SWTPM_INTERFACE} -s
+if [ $? -ne 0 ]; then
+	echo "Error: Could not shut down the ${SWTPM_INTERFACE} TPM."
+	exit 1
+fi
+
+if wait_process_gone ${SWTPM_PID} 4; then
+	echo "Error: ${SWTPM_INTERFACE} TPM should not be running anymore."
+	exit 1
+fi
+
+run_swtpm ${SWTPM_INTERFACE} \
+	--tpm2 \
+	--log file=$LOG_FILE,level=20 \
+	--flags not-need-init,startup-clear
+
+kill_quiet -0 ${SWTPM_PID}
+if [ $? -ne 0 ]; then
+	echo "Error: ${SWTPM_INTERFACE} TPM did not start."
+	exit 1
+fi
+
+# The TPM_PT_LOCKOUT_COUNTER must still be '0' now: tssgetcapability -cap 6 -pr 0x20e -pc 1
+# Without swtpm sending TPM2_Shutdown, it would be '2' now
+cmd='\x80\x01\x00\x00\x00\x16\x00\x00\x01\x7a\x00\x00\x00\x06\x00\x00\x02\x0e\x00\x00\x00\x01'
+RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} ${cmd})
+exp=' 80 01 00 00 00 1b 00 00 00 00 01 00 00 00 06 00 00 00 01 00 00 02 0e 00 00 00 00'
+if [ "$RES" != "$exp" ]; then
+	echo "Error: Did not get expected result from TPM2_GetCapability(TPM_PT_LOCKOUT_COUNTER)"
+	echo "expected: $exp"
+	echo "received: $RES"
+	exit 1
+fi
+
+run_swtpm_ioctl ${SWTPM_INTERFACE} -s
+if [ $? -ne 0 ]; then
+	echo "Error: Could not shut down the ${SWTPM_INTERFACE} TPM."
+	exit 1
+fi
+
+if wait_process_gone ${SWTPM_PID} 4; then
+	echo "Error: ${SWTPM_INTERFACE} TPM should not be running anymore."
+	exit 1
+fi
+
+echo "OK"
+
+exit 0

--- a/tests/_test_tpm2_print_capabilities
+++ b/tests/_test_tpm2_print_capabilities
@@ -26,7 +26,7 @@ if [ "${SWTPM_IFACE}" != "cuse" ]; then
 fi
 
 # The rsa key size reporting is variable, so use a regex
-exp='\{ "type": "swtpm", "features": \[( "tpm-1.2",)? "tpm-2.0", '${noncuse}'"flags-opt-startup", '${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd", "cmdarg-print-states", "nvram-backend-dir", "nvram-backend-file"(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")? \], "version": "[^"]*" \}'
+exp='\{ "type": "swtpm", "features": \[( "tpm-1.2",)? "tpm-2.0", '${noncuse}'"flags-opt-startup", "flags-opt-disable-auto-shutdown", '${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd", "cmdarg-print-states", "nvram-backend-dir", "nvram-backend-file"(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")? \], "version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-capabilities:"
 	echo "Actual   : ${msg}"

--- a/tests/test_tpm2_avoid_da_lockout
+++ b/tests/test_tpm2_avoid_da_lockout
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+source ${TESTDIR}/common
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
+cd "$(dirname "$0")"
+
+export SWTPM_IOCTL_BUFFERSIZE=100
+export SWTPM_INTERFACE=cuse
+bash _test_tpm2_avoid_da_lockout
+ret=$?
+[ $ret -ne 0  ] && [ $ret -ne 77 ] && exit $ret
+
+export SWTPM_INTERFACE=socket+socket
+export SWTPM_SERVER_NAME=localhost
+export SWTPM_SERVER_PORT=65464
+export SWTPM_CTRL_PORT=65465
+bash _test_tpm2_avoid_da_lockout
+ret=$?
+[ $ret -ne 0  ] && [ $ret -ne 77 ] && exit $ret
+
+export SWTPM_INTERFACE=socket+unix
+export SWTPM_SERVER_NAME=localhost
+export SWTPM_SERVER_PORT=65464
+bash _test_tpm2_avoid_da_lockout
+ret=$?
+[ $ret -ne 0  ] && [ $ret -ne 77 ] && exit $ret
+
+export SWTPM_INTERFACE=unix+unix
+bash _test_tpm2_avoid_da_lockout
+ret=$?
+[ $ret -ne 0  ] && [ $ret -ne 77 ] && exit $ret
+
+exit 0


### PR DESCRIPTION
If necessary send a TPM2_Shutdown() command to libtpms before processing
CMD_INIT. However, this is only necessary for a TPM 2 and only if the
TPM2_Shutdown command has not been sent by the client (VM TPM driver) as
the last command as it should do under normal circumstances, for example
upon graceful VM shutdown.

This fixes a bug where abrupt VM resets may trigger the TPM 2's dictionary
attack lockout logic due to the TPM 2 not having received a TPM2_Shutdown
command before it was reset using CMD_INIT for example. An OS driver is
typically supposed to send a TPM2_Shutdown to the TPM 2 but an abrupt VM
reset prevents it.

There are 3 control commands where this needs to be done since they
call TPMLIB_Terminate():

- CMD_STOP:
   This command is typically called before setting the state blobs of the
   TPM or before configuring the buffer size [QEMU, test cases].

- CMD_INIT:
   This command is called for resetting and initializing the TPM 2.

- CMD_SHUTDOWN:
   This command is called for a graceful shutdown of the TPM 2.

There are no negative side effects to be expected if TPM2_Shutdown()
is sent before any of these. Also, since none of these are sent before
the state of the TPM is marshalled (for migration for example) migrated
state will not have a TPM2_Shutdown() applied to it (accidentally).

Edk2 sends a sequence of TPM2_Shutdown(SU_STATE) + TPM2_GetRandom()
before suspend-to-ram. Upon wake up a CMD_INIT is sent to the TPM to
reset it, which in this case now requires a TPM2_Shutdown(SU_STATE)
to be sent to the TPM 2 so that certain TPM 2 state is available
again upon resume. To avoid invaliding the SU_STATE, first send a
TPM2_Shutdown(SU_STATE) in *all cases* and only if this fails send a
TPM2_Shutdown(SU_CLEAR). This way the internal state is preserved and
the VM (or user) are expected to use TPM2_Startup(SU_CLEAR) when
staring up the TPM 2 and no previous state needs to be resumed.

Note: The TPM 2 spec describes the command as follows:

"This command is used to prepare the TPM for a power cycle. The
shutdownType parameter indicates how the subsequent TPM2_Startup() will be
processed.[...]
This command saves TPM state but does not change the state other than the
internal indication that the context has been saved. The TPM shall
continue to accept commands. If a subsequent command changes TPM state
saved by this command, then the effect of this command is nullified. The
TPM MAY nullify this command for any subsequent command rather than check
whether the command changed state saved by this command. If this command
is nullified and if no TPM2_Shutdown() occurs before the next
TPM2_Startup(), then the next TPM2_Startup() shall be
TPM2_Startup(CLEAR)."

Buglink: https://bugzilla.redhat.com/show_bug.cgi?id=2087538
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>