### PR TITLE
Use SHA-256 rather than SHA-1 in swtpm_bios and test case

### DIFF
--- a/src/swtpm_bios/tpm_bios.c
+++ b/src/swtpm_bios/tpm_bios.c
@@ -422,7 +422,7 @@ static int TPM2_IncrementalSelfTest(int *tpm_errcode)
 		.to_test = {
 			.num_entries = htobe32(1),
 			.algids = {
-				htobe16(TPM2_ALG_SHA1),
+				htobe16(TPM2_ALG_SHA256),
 			},
 		},
 	};
@@ -613,7 +613,7 @@ static int tpm2_bios(int contselftest, unsigned char startupparm,
 		ret = TPM2_IncrementalSelfTest(&tpm_errcode);
 		if (tpm_errcode != 0) {
 			tpm_error = 1;
-			printf("TPM2_ImcrementalSelfTest returned error "
+			printf("TPM2_IncrementalSelfTest returned error "
 			       "code 0x%08x\n", tpm_errcode);
 		}
 	}

--- a/src/swtpm_bios/tpm_bios.h
+++ b/src/swtpm_bios/tpm_bios.h
@@ -130,7 +130,7 @@ struct tpm_get_capability_permflags_res {
 #define TPM2_SU_CLEAR    0x0000
 #define TPM2_SU_STATE    0x0001
 
-#define TPM2_ALG_SHA1    0x0004
+#define TPM2_ALG_SHA256  0x000b
 
 #define TPM2_RS_PW       0x40000009
 #define TPM2_RH_PLATFORM 0x4000000c

--- a/tests/test_tpm2_swtpm_setup_create_cert
+++ b/tests/test_tpm2_swtpm_setup_create_cert
@@ -133,7 +133,7 @@ function swtpm_setup_reconfigure() {
 	local PERMALL_FILE="${workdir}/tpm2-00.permall"
 	local permall_size=$(get_filesize "${PERMALL_FILE}")
 
-	for pcrbanks in "sha1" "sha1,sha256" "sha1,sha256,sha384,sha512"; do
+	for pcrbanks in "sha256" "sha256,sha384" "sha256,sha384,sha512"; do
 		# hash must change between before and after
 		permall_hash=$(get_sha1_file "${PERMALL_FILE}")
 


### PR DESCRIPTION
Use SHA-256 in swtpm_bios when sending TPM2_IncrementalSefTest() rather than SHA-1.
Do not use the SHA-1 PCR bank in swtpm_setup test cases but the SHA-256 bank instead.