### PR TITLE
selinux: Replace hardcoded install path with @Prefix@

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ Makefile
 /patches/*
 /include/swtpm.h
 /man/man3/*.3
+/man/man5/*.5
 /man/man8/*.8
 !/man/man8/swtpm-localca.8
 /samples/swtpm-create-user-config-files

--- a/.gitignore
+++ b/.gitignore
@@ -45,9 +45,11 @@ Makefile
 /samples/swtpm_setup.conf
 /src/selinux/*.pp.bz2
 /src/selinux/swtpm.pp
+/src/selinux/swtpm.fc
 /src/selinux/swtpm_svirt.fc
 /src/selinux/swtpm_svirt.if
 /src/selinux/swtpm_svirt.pp
+/src/selinux/swtpmcuse.fc
 /src/selinux/swtpmcuse.pp
 /src/selinux/tmp
 /src/swtpm/swtpm

--- a/configure.ac
+++ b/configure.ac
@@ -590,6 +590,8 @@ AC_CONFIG_FILES([Makefile                   \
 		include/swtpm.h             \
 		src/Makefile                \
 		src/selinux/Makefile        \
+		src/selinux/swtpm.fc        \
+		src/selinux/swtpmcuse.fc    \
 		src/swtpm/Makefile          \
 		src/swtpm_bios/Makefile     \
 		src/swtpm_cert/Makefile     \

--- a/src/selinux/Makefile.am
+++ b/src/selinux/Makefile.am
@@ -23,16 +23,19 @@ policiesconf_DATA = \
 
 swtpm.pp_FILES = \
 	$(addprefix $(top_srcdir)/src/selinux/,\
-	  swtpm.fc swtpm.if swtpm.te)
+	  swtpm.if swtpm.te) \
+	$(top_builddir)/src/selinux/swtpm.fc
 
 swtpm_svirt.pp_FILES = \
 	$(addprefix $(top_srcdir)/src/selinux/,\
-	  swtpm_svirt.te swtpm.fc swtpm.if swtpm.te)
+	  swtpm_svirt.te swtpm.if swtpm.te) \
+	$(top_builddir)/src/selinux/swtpm.fc
 
 if WITH_CUSE
 swtpmcuse.pp_FILES = \
 	$(addprefix $(top_srcdir)/src/selinux/,\
-	  swtpmcuse.te swtpmcuse.fc swtpmcuse.if)
+	  swtpmcuse.te swtpmcuse.if) \
+	$(top_builddir)/src/selinux/swtpmcuse.fc
 endif
 
 all: $(POLICIES_BZ2)
@@ -71,17 +74,14 @@ selinux-uninstall:
 	cp $^ ./ 2>/dev/null || true
 	make -f /usr/share/selinux/devel/Makefile $@
 	$(RM) -r ./tmp/
-	if test $(abspath $(shell pwd)) != $(abspath $(top_srcdir)/src/selinux); then \
-		$(RM) *.te *.fc *.if; \
-	fi
 
 EXTRA_DIST = \
-	swtpm.fc \
+	swtpm.fc.in \
 	swtpm.if \
 	swtpm.te \
 	swtpm_svirt.te \
-	swtpmcuse.fc \
+	swtpmcuse.fc.in \
 	swtpmcuse.if \
 	swtpmcuse.te
 
-CLEANFILES = *.pp *.pp.bz2
+CLEANFILES = *.pp *.pp.bz2 *.if *.te *.fc

--- a/src/selinux/swtpm.fc
+++ b/src/selinux/swtpm.fc
@@ -1,1 +1,0 @@
-/usr/bin/swtpm			--	gen_context(system_u:object_r:swtpm_exec_t,s0)

--- a/src/selinux/swtpm.fc.in
+++ b/src/selinux/swtpm.fc.in
@@ -1,0 +1,1 @@
+@prefix@/bin/swtpm			--	gen_context(system_u:object_r:swtpm_exec_t,s0)

--- a/src/selinux/swtpmcuse.fc
+++ b/src/selinux/swtpmcuse.fc
@@ -1,1 +1,0 @@
-/usr/bin/swtpm_cuse		--	gen_context(system_u:object_r:swtpmcuse_exec_t,s0)

--- a/src/selinux/swtpmcuse.fc.in
+++ b/src/selinux/swtpmcuse.fc.in
@@ -1,0 +1,1 @@
+@prefix@/bin/swtpm_cuse		--	gen_context(system_u:object_r:swtpmcuse_exec_t,s0)


### PR DESCRIPTION
Replace the hardcoded install path in src/selinux/swtpm.fc and
src/selinux/swtpmcuse.fc with @Prefix@ and append .in to these files so
that they are generated when running configure.

Add the selinux policy input files with their suffix to the CLEANFILES
variable so they get cleaned up and 'make distcheck' works.

Resolves: https://github.com/stefanberger/swtpm/issues/711
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>