### PR TITLE
swtpm: Also advertise the flags-opt-startup option for the CUSE inter…

### DIFF
--- a/src/swtpm/capabilities.c
+++ b/src/swtpm/capabilities.c
@@ -150,7 +150,7 @@ int capabilities_print_json(bool cusetpm)
          with_tpm1,
          with_tpm2,
          !cusetpm     ? "\"tpm-send-command-header\", ": "",
-         !cusetpm     ? "\"flags-opt-startup\", "      : "",
+         true         ? "\"flags-opt-startup\", "      : "",
          cmdarg_seccomp,
          true         ? "\"cmdarg-key-fd\", "          : "",
          true         ? "\"cmdarg-pwd-fd\", "          : "",

--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -22,10 +22,10 @@ if has_seccomp_support "${SWTPM_EXE}"; then
 	seccomp='"cmdarg-seccomp", '
 fi
 if [ "${SWTPM_IFACE}" != "cuse" ]; then
-	noncuse='"tpm-send-command-header", "flags-opt-startup", '
+	noncuse='"tpm-send-command-header", '
 fi
 
-exp='\{ "type": "swtpm", "features": \[ "tpm-1.2",( "tpm-2.0",)? '${noncuse}${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd", "cmdarg-print-states", "nvram-backend-dir", "nvram-backend-file" \], "version": "[^"]*" \}'
+exp='\{ "type": "swtpm", "features": \[ "tpm-1.2",( "tpm-2.0",)? '${noncuse}'"flags-opt-startup", '${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd", "cmdarg-print-states", "nvram-backend-dir", "nvram-backend-file" \], "version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-capabilities:"
 	echo "Actual   : ${msg}"

--- a/tests/_test_tpm2_print_capabilities
+++ b/tests/_test_tpm2_print_capabilities
@@ -22,11 +22,11 @@ if has_seccomp_support "${SWTPM_EXE}"; then
 	seccomp='"cmdarg-seccomp", '
 fi
 if [ "${SWTPM_IFACE}" != "cuse" ]; then
-	noncuse='"tpm-send-command-header", "flags-opt-startup", '
+	noncuse='"tpm-send-command-header", '
 fi
 
 # The rsa key size reporting is variable, so use a regex
-exp='\{ "type": "swtpm", "features": \[( "tpm-1.2",)? "tpm-2.0", '${noncuse}${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd", "cmdarg-print-states", "nvram-backend-dir", "nvram-backend-file"(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")? \], "version": "[^"]*" \}'
+exp='\{ "type": "swtpm", "features": \[( "tpm-1.2",)? "tpm-2.0", '${noncuse}'"flags-opt-startup", '${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd", "cmdarg-print-states", "nvram-backend-dir", "nvram-backend-file"(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")? \], "version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-capabilities:"
 	echo "Actual   : ${msg}"


### PR DESCRIPTION
…face

Commit 6559a902 implemented support for the startup-xyz flags for the CUSE
interface but the capability has not been advertised.

Adjust test cases to reflect the new verb being shown for
--print-capabilities.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>