### PR TITLE
swtpm: Move TPMLIB_ChooseTPMVersion into capabilities_print_json

### DIFF
--- a/src/swtpm/capabilities.c
+++ b/src/swtpm/capabilities.c
@@ -114,7 +114,7 @@ oom:
     goto cleanup;
 }
 
-int capabilities_print_json(bool cusetpm)
+int capabilities_print_json(bool cusetpm, TPMLIB_TPMVersion tpmversion)
 {
     char *string = NULL;
     int ret = -1;
@@ -129,6 +129,11 @@ int capabilities_print_json(bool cusetpm)
     char *keysizecaps = NULL;
     const char *nvram_backend_dir = "\"nvram-backend-dir\", ";
     const char *nvram_backend_file = "\"nvram-backend-file\"";
+
+    if (TPMLIB_ChooseTPMVersion(tpmversion) != TPM_SUCCESS) {
+        logprintf(STDERR_FILENO, "Could not choose TPM version.\n");
+        goto cleanup;
+    }
 
     ret = get_rsa_keysize_caps(&keysizecaps);
     if (ret < 0)

--- a/src/swtpm/capabilities.h
+++ b/src/swtpm/capabilities.h
@@ -40,6 +40,8 @@
 
 #include <stdbool.h>
 
-int capabilities_print_json(bool cusetpm);
+#include <libtpms/tpm_library.h>
+
+int capabilities_print_json(bool cusetpm, TPMLIB_TPMVersion tpmversion);
 
 #endif /* SWTPM_CAPABILITIES_H */

--- a/src/swtpm/cuse_tpm.c
+++ b/src/swtpm/cuse_tpm.c
@@ -1616,8 +1616,7 @@ int swtpm_cuse_main(int argc, char **argv, const char *prgname, const char *ifac
          * Choose the TPM version so that getting/setting buffer size works.
          * Ignore failure, for backward compatibility when TPM 1.2 is disabled.
          */
-        TPMLIB_ChooseTPMVersion(tpmversion);
-        ret = capabilities_print_json(true) ? EXIT_FAILURE : EXIT_SUCCESS;
+        ret = capabilities_print_json(true, tpmversion) ? EXIT_FAILURE : EXIT_SUCCESS;
         goto exit;
     }
 

--- a/src/swtpm/swtpm.c
+++ b/src/swtpm/swtpm.c
@@ -432,8 +432,7 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
          * Choose the TPM version so that getting/setting buffer size works.
          * Ignore failure, for backward compatibility when TPM 1.2 is disabled.
          */
-        TPMLIB_ChooseTPMVersion(mlp.tpmversion);
-        ret = capabilities_print_json(false);
+        ret = capabilities_print_json(false, mlp.tpmversion);
         exit(ret ? EXIT_FAILURE : EXIT_SUCCESS);
     }
 

--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -486,8 +486,7 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
          * Choose the TPM version so that getting/setting buffer size works.
          * Ignore failure, for backward compatibility when TPM 1.2 is disabled.
          */
-        TPMLIB_ChooseTPMVersion(mlp.tpmversion);
-        ret = capabilities_print_json(false);
+        ret = capabilities_print_json(false, mlp.tpmversion);
         exit(ret ? EXIT_FAILURE : EXIT_SUCCESS);
     }
 


### PR DESCRIPTION
All callers to capabilities_print_json() call TPMLIB_ChooseTPMVersion
right before. Move it into the function now and check the return
code.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>