### PR TITLE
swtpm: Ignore error if TPMLIB_ChooseTPMVersion for printing caps fails

### DIFF
--- a/src/swtpm/capabilities.c
+++ b/src/swtpm/capabilities.c
@@ -130,10 +130,8 @@ int capabilities_print_json(bool cusetpm, TPMLIB_TPMVersion tpmversion)
     const char *nvram_backend_dir = "\"nvram-backend-dir\", ";
     const char *nvram_backend_file = "\"nvram-backend-file\"";
 
-    if (TPMLIB_ChooseTPMVersion(tpmversion) != TPM_SUCCESS) {
-        logprintf(STDERR_FILENO, "Could not choose TPM version.\n");
-        goto cleanup;
-    }
+    /* ignore errors */
+    TPMLIB_ChooseTPMVersion(tpmversion);
 
     ret = get_rsa_keysize_caps(&keysizecaps);
     if (ret < 0)


### PR DESCRIPTION
Revert the change from the previous patch that shows an error when
TPMLIB_ChooseTPMVersion fails but rather ignore the error as before.
If a TPM 2 is supported then tpm-2.0 capability verb will be shown
and if a TPM 1.2 is supported then tpm-1.2 will be shown, thus
allowing someone reading the JSON to determine what is supported.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>