### PR TITLE
tests: Move swtpm_open_cmddev into swtpm_cmd_tx

### DIFF
--- a/tests/_test_encrypted_state
+++ b/tests/_test_encrypted_state
@@ -78,7 +78,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Startup the TPM
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0C\x00\x00\x00\x99\x00\x01')
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -97,7 +96,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Read PCR 17
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 97 e9 76 e4 f2 2c d6 d2 4a fd 21 20 85 ad 7a 86 64 7f 2a e5'
 if [ "$RES" != "$exp" ]; then
@@ -139,7 +137,6 @@ if [ "$tmp" != " 0x1" ]; then
 fi
 
 # Shut the TPM down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} -s
 if [ $? -ne 0 ]; then
 	echo "Error: Could not shut down the ${SWTPM_INTERFACE} TPM."
@@ -188,7 +185,6 @@ if [ -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Read the PCR again ...
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 97 e9 76 e4 f2 2c d6 d2 4a fd 21 20 85 ad 7a 86 64 7f 2a e5'
 if [ "$RES" != "$exp" ]; then
@@ -232,7 +228,6 @@ if [ -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Read the PCR again ...
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 97 e9 76 e4 f2 2c d6 d2 4a fd 21 20 85 ad 7a 86 64 7f 2a e5'
 if [ "$RES" != "$exp" ]; then
@@ -244,7 +239,6 @@ fi
 
 
 # Final shut down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} -s
 if [ $? -ne 0 ]; then
 	echo "Error: Could not shut down the ${SWTPM_INTERFACE} TPM."

--- a/tests/_test_hashing
+++ b/tests/_test_hashing
@@ -55,7 +55,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Startup the TPM
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0C\x00\x00\x00\x99\x00\x01')
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -86,7 +85,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Read PCR 17
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 97 e9 76 e4 f2 2c d6 d2 4a fd 21 20 85 ad 7a 86 64 7f 2a e5'
 if [ "$RES" != "$exp" ]; then
@@ -118,7 +116,6 @@ if [ $? -ne -0 ]; then
 fi
 
 # \x40 or \x0B seems to confuse 'normal' echo
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0A\x40\x00\x00\x0B')
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -154,7 +151,6 @@ dd if=/dev/zero bs=1024 count=1024 2>/dev/null| \
 	run_swtpm_ioctl ${SWTPM_INTERFACE} -h -
 
 # Read PCR 17
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 d8 0e 7a 7b 3c 37 88 7d b4 c2 88 08 1d a7 53 f6 4b 11 3a 9c'
 if [ "$RES" != "$exp" ]; then

--- a/tests/_test_hashing2
+++ b/tests/_test_hashing2
@@ -57,7 +57,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Startup the TPM
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0C\x00\x00\x00\x99\x00\x01')
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -88,7 +87,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Read PCR 17
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 97 e9 76 e4 f2 2c d6 d2 4a fd 21 20 85 ad 7a 86 64 7f 2a e5'
 if [ "$RES" != "$exp" ]; then
@@ -144,7 +142,6 @@ for ((l = 0; l <= 2; l++)); do
 		exit 1
 	fi
 	# Have to use external echo command
-	swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 	RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0a\x40\x00\x00\x0b')
 	exp=' 00 c4 00 00 00 0a 00 00 00 3d'
 	if [ "$RES" != "$exp" ]; then
@@ -162,7 +159,6 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0a\x40\x00\x00\x0b')
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -187,7 +183,6 @@ dd if=/dev/zero bs=1024 count=1024 2>/dev/null |\
 	run_swtpm_ioctl ${SWTPM_INTERFACE} -h -
 
 # Read PCR 17
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 d8 0e 7a 7b 3c 37 88 7d b4 c2 88 08 1d a7 53 f6 4b 11 3a 9c'
 if [ "$RES" != "$exp" ]; then

--- a/tests/_test_locality
+++ b/tests/_test_locality
@@ -84,7 +84,6 @@ fi
 
 
 # Startup the TPM
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0C\x00\x00\x00\x99\x00\x01')
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -95,7 +94,6 @@ if [ "$RES" != "$exp" ]; then
 fi
 
 # Reset PCR 20
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0F\x00\x00\x00\xC8\x00\x03\x00\x00\x10')
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then

--- a/tests/_test_migration_key
+++ b/tests/_test_migration_key
@@ -77,7 +77,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Read PCR 10
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x0a')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 c7 8a 6e 94 c7 3c 4d 7f c3 05 c8 a6 6b bf 15 45 f4 ed b7 a5'
 if [ "$RES" != "$exp" ]; then
@@ -88,7 +87,6 @@ if [ "$RES" != "$exp" ]; then
 fi
 
 # Assert physical presence
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0C\x40\x00\x00\x0A\x00\x20')
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -106,7 +104,6 @@ tmp+='\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 tmp+='\x00\x00\x00\x00\x00\x17\x00\x01\x00\x01\x00\x00\x00\x00\x00\x0f'
 tmp+='\xa0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 tmp+='\x00\x00\x00\x00\x00'
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} $tmp)
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -182,7 +179,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Read PCR 10
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x0a')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 c7 8a 6e 94 c7 3c 4d 7f c3 05 c8 a6 6b bf 15 45 f4 ed b7 a5'
 if [ "$RES" != "$exp" ]; then
@@ -270,7 +266,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Read PCR 10
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x0a')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 c7 8a 6e 94 c7 3c 4d 7f c3 05 c8 a6 6b bf 15 45 f4 ed b7 a5'
 if [ "$RES" != "$exp" ]; then

--- a/tests/_test_resume_volatile
+++ b/tests/_test_resume_volatile
@@ -62,7 +62,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Read PCR 10 (extend -ix 10 -ic test)
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x0a')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 c7 8a 6e 94 c7 3c 4d 7f c3 05 c8 a6 6b bf 15 45 f4 ed b7 a5'
 if [ "$RES" != "$exp" ]; then
@@ -84,7 +83,6 @@ if [ ! -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Shut the TPM down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} -s
 
 echo "Test 1: Ok"
@@ -119,7 +117,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Read PCR 10 (extend -ix 10 -ic test)
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x0a')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 c7 8a 6e 94 c7 3c 4d 7f c3 05 c8 a6 6b bf 15 45 f4 ed b7 a5'
 if [ "$RES" != "$exp" ]; then
@@ -141,7 +138,6 @@ if [ ! -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Shut the TPM down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} -s
 if [ $? -ne 0 ]; then
 	echo "Error: Could not shut down the ${SWTPM_INTERFACE} TPM."
@@ -179,7 +175,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Read PCR 10
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x0a')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 c7 8a 6e 94 c7 3c 4d 7f c3 05 c8 a6 6b bf 15 45 f4 ed b7 a5'
 if [ "$RES" != "$exp" ]; then
@@ -201,7 +196,6 @@ if [ ! -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Shut the TPM down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} -s
 if [ $? -ne 0 ]; then
 	echo "Error: Could not shut down the ${SWTPM_INTERFACE} TPM."

--- a/tests/_test_save_load_encrypted_state
+++ b/tests/_test_save_load_encrypted_state
@@ -73,7 +73,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Startup the TPM
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0C\x00\x00\x00\x99\x00\x01')
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -92,7 +91,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Read PCR 17
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 97 e9 76 e4 f2 2c d6 d2 4a fd 21 20 85 ad 7a 86 64 7f 2a e5'
 if [ "$RES" != "$exp" ]; then
@@ -103,7 +101,6 @@ if [ "$RES" != "$exp" ]; then
 fi
 
 # Assert physical presence
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0C\x40\x00\x00\x0A\x00\x20')
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -121,7 +118,6 @@ tmp+='\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 tmp+='\x00\x00\x00\x00\x00\x17\x00\x01\x00\x01\x00\x00\x00\x00\x00\x0f'
 tmp+='\xa0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 tmp+='\x00\x00\x00\x00\x00'
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} $tmp)
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -168,7 +164,6 @@ echo "Saved volatile state."
 rm -f $VOLATILE_STATE_FILE $STATE_FILE
 
 # Stop the TPM; this will not shut it down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} --stop
 if [ $? -ne 0 ]; then
 	echo "Error (2): Could not stop the ${SWTPM_INTERFACE} TPM"
@@ -225,7 +220,6 @@ if [ -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Read the PCR again ...
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 97 e9 76 e4 f2 2c d6 d2 4a fd 21 20 85 ad 7a 86 64 7f 2a e5'
 if [ "$RES" != "$exp" ]; then
@@ -268,7 +262,6 @@ if [ -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Read the PCR again ...
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 97 e9 76 e4 f2 2c d6 d2 4a fd 21 20 85 ad 7a 86 64 7f 2a e5'
 if [ "$RES" != "$exp" ]; then
@@ -436,7 +429,6 @@ fi
 echo "Test 3: Ok"
 
 # Final shut down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} -s
 if [ $? -ne 0 ]; then
 	echo "Error: Could not shut down the ${SWTPM_INTERFACE} TPM."

--- a/tests/_test_save_load_state
+++ b/tests/_test_save_load_state
@@ -75,7 +75,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Startup the TPM
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0C\x00\x00\x00\x99\x00\x01')
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -94,7 +93,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Read PCR 17
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 97 e9 76 e4 f2 2c d6 d2 4a fd 21 20 85 ad 7a 86 64 7f 2a e5'
 if [ "$RES" != "$exp" ]; then
@@ -105,7 +103,6 @@ if [ "$RES" != "$exp" ]; then
 fi
 
 # Assert physical presence
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0C\x40\x00\x00\x0A\x00\x20')
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -123,7 +120,6 @@ tmp+='\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 tmp+='\x00\x00\x00\x00\x00\x17\x00\x01\x00\x01\x00\x00\x00\x00\x00\x0f'
 tmp+='\xa0\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 tmp+='\x00\x00\x00\x00\x00'
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} $tmp)
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -134,7 +130,6 @@ if [ "$RES" != "$exp" ]; then
 fi
 
 # Send SaveState command
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0a\x00\x00\x00\x98')
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -262,7 +257,6 @@ if [ -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Read the PCR again ...
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 97 e9 76 e4 f2 2c d6 d2 4a fd 21 20 85 ad 7a 86 64 7f 2a e5'
 if [ "$RES" != "$exp" ]; then
@@ -306,7 +300,6 @@ if [ -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Read the PCR again ...
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 97 e9 76 e4 f2 2c d6 d2 4a fd 21 20 85 ad 7a 86 64 7f 2a e5'
 if [ "$RES" != "$exp" ]; then

--- a/tests/_test_tpm2_derived_keys
+++ b/tests/_test_tpm2_derived_keys
@@ -70,7 +70,6 @@ function tx_cmd()
 		fi
 	fi
 	if [ "$startup" != "0" ]; then
-		swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 		RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x0c\x00\x00\x01\x44\x00\x00')
 		tmp=' 80 01 00 00 00 0a 00 00 00 00'
 		if [ "$RES" != "$tmp" ]; then
@@ -79,10 +78,8 @@ function tx_cmd()
 			echo "received: $RES"
 			return 1
 		fi
-		exec 100>&-
 	fi
 
-	swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 	RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} ${cmd})
 	if [ "$RES" == "$allowed_error" ]; then
 		echo "Skip: Encountered allowed error response ($allowed_error)"
@@ -92,7 +89,6 @@ function tx_cmd()
 		echo "received: $RES"
 		return 1
 	fi
-	exec 100>&-
 
 	return 0
 }

--- a/tests/_test_tpm2_encrypted_state
+++ b/tests/_test_tpm2_encrypted_state
@@ -79,7 +79,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Startup the TPM
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x0c\x00\x00\x01\x44\x00\x00')
 exp=' 80 01 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -98,7 +97,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Read PCR 17
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
 exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
 if [ "$RES" != "$exp" ]; then
@@ -140,7 +138,6 @@ if [ "$tmp" != " 0x1" ]; then
 fi
 
 # Shut the TPM down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} -s
 if [ $? -ne 0 ]; then
 	echo "Error: Could not shut down the ${SWTPM_INTERFACE} TPM."
@@ -190,7 +187,6 @@ if [ -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Read the PCR again ...
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
 exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
 if [ "$RES" != "$exp" ]; then
@@ -234,7 +230,6 @@ if [ -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Read the PCR again ...
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
 exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
 if [ "$RES" != "$exp" ]; then
@@ -246,7 +241,6 @@ fi
 
 
 # Final shut down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} -s
 if [ $? -ne 0 ]; then
 	echo "Error: Could not shut down the ${SWTPM_INTERFACE} TPM."

--- a/tests/_test_tpm2_file_permissions
+++ b/tests/_test_tpm2_file_permissions
@@ -139,8 +139,6 @@ if [ "$(cat "${PIDFILE}")" != "${SWTPM_PID}" ]; then
 	exit 1
 fi
 
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
-
 # Read PCR 10 (from pcrextend -ha 10 -ic test)
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x04\x00')
 exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 16 00 00 00 01 00 0b 03 00 04 00 00 00 00 01 00 20 f6 85 98 e5 86 8d e6 8b 97 29 99 60 f2 71 7d 17 67 89 a4 2f 9a ae a8 c7 b7 aa 79 a8 62 56 c1 de'

--- a/tests/_test_tpm2_hashing
+++ b/tests/_test_tpm2_hashing
@@ -56,7 +56,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Startup the TPM2
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x0c\x00\x00\x01\x44\x00\x00')
 exp=' 80 01 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -87,7 +86,6 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 # Read PCR 17
 #                                                    length         CC            count       hashalg         sz
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE}'\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
@@ -148,7 +146,6 @@ fi
 dd if=/dev/zero bs=1024 count=1024 2>/dev/null| \
 	run_swtpm_ioctl ${SWTPM_INTERFACE} -h -
 
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 # Read PCR 17
 #                                                      length         CC            count       hashalg         sz
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')

--- a/tests/_test_tpm2_hashing2
+++ b/tests/_test_tpm2_hashing2
@@ -54,7 +54,6 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 # Startup the TPM
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x0c\x00\x00\x01\x44\x00\x00')
 exp=' 80 01 00 00 00 0a 00 00 00 00'
@@ -86,7 +85,6 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 # Read PCR 17
 #                                                     length         CC            count       hashalg         sz
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
@@ -163,7 +161,6 @@ fi
 dd if=/dev/zero bs=1024 count=1024 2>/dev/null| \
 	run_swtpm_ioctl ${SWTPM_INTERFACE} -h -
 
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 # Read PCR 17
 #                                                     length         CC            count       hashalg         sz
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')

--- a/tests/_test_tpm2_hashing3
+++ b/tests/_test_tpm2_hashing3
@@ -55,7 +55,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # We do NOT need to startup the TPM; Hashing will affect PCR 0
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 
 # Check the TPM Established bit before the hashing
 RES=$(run_swtpm_ioctl ${SWTPM_INTERFACE} -e)
@@ -89,7 +88,6 @@ if [ "$RES" != "$exp" ]; then
 	exit 1
 fi
 
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 # Read PCR 0
 #                                                     length         CC            count       hashalg         sz
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x01\x00\x00')

--- a/tests/_test_tpm2_locality
+++ b/tests/_test_tpm2_locality
@@ -91,7 +91,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Startup the TPM
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x0c\x00\x00\x01\x44\x00\x00')
 exp=' 80 01 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -109,7 +108,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Reset PCR 20
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x02\x00\x00\x00\x1b\x00\x00\x01\x3d\x00\x00\x00\x14\x00\x00\x00\x09\x40\x00\x00\x09\x00\x00\x00\x00\x00')
 exp=' 80 02 00 00 00 13 00 00 00 00 00 00 00 00 00 00 01 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -127,7 +125,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Reset PCR 20
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x02\x00\x00\x00\x1b\x00\x00\x01\x3d\x00\x00\x00\x14\x00\x00\x00\x09\x40\x00\x00\x09\x00\x00\x00\x00\x00')
 exp=' 80 01 00 00 00 0a 00 00 09 07'
 if [ "$RES" != "$exp" ]; then

--- a/tests/_test_tpm2_migration_key
+++ b/tests/_test_tpm2_migration_key
@@ -78,14 +78,6 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
-
-ECHO=$(which echo)
-if [ -z "$ECHO" ]; then
-	echo "Could not find NON-bash builtin echo tool."
-	exit 1
-fi
-
 # Read PCR 10 (from pcrextend -ha 10 -ic test)
 RES=$(swtpm_cmd_tx "${SWTPM_INTERFACE}" '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x04\x00' 100)
 exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 16 00 00 00 01 00 0b 03 00 04 00 00 00 00 01 00 20 f6 85 98 e5 86 8d e6 8b 97 29 99 60 f2 71 7d 17 67 89 a4 2f 9a ae a8 c7 b7 aa 79 a8 62 56 c1 de'
@@ -166,8 +158,6 @@ if [ $? -ne 0 ]; then
 	echo "Error: Initializing the ${SWTPM_INTERFACE} TPM failed."
 	exit 1
 fi
-
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 
 # Read PCR 10
 RES=$(swtpm_cmd_tx "${SWTPM_INTERFACE}" '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x04\x00' 100)
@@ -268,8 +258,6 @@ if [ $? -ne 0 ]; then
 	echo "Error: Could not initialize the ${SWTPM_INTERFACE} TPM."
 	exit 1
 fi
-
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 
 # Read PCR 10
 RES=$(swtpm_cmd_tx "${SWTPM_INTERFACE}" '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x04\x00' 100)

--- a/tests/_test_tpm2_probe
+++ b/tests/_test_tpm2_probe
@@ -49,9 +49,6 @@ if [ "${SWTPM_INTERFACE}" != "cuse" ]; then
 	fi
 fi
 
-# Open access to the TPM
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
-
 # Before TPM_INIT: Read PCR 17 -- this gives a fatal error
 #                                                     length         CC            count       hashalg         sz
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
@@ -71,7 +68,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Read PCR 17 -- this should give TPM_INVALID_POSTINIT
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
 exp=' 80 01 00 00 00 0a 00 00 01 00'
 if [ "$RES" != "$exp" ]; then

--- a/tests/_test_tpm2_resume_volatile
+++ b/tests/_test_tpm2_resume_volatile
@@ -61,8 +61,6 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
-
 # Read PCR 10 (from pcrextend -ha 10 -ic test)
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x04\x00')
 exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 16 00 00 00 01 00 0b 03 00 04 00 00 00 00 01 00 20 f6 85 98 e5 86 8d e6 8b 97 29 99 60 f2 71 7d 17 67 89 a4 2f 9a ae a8 c7 b7 aa 79 a8 62 56 c1 de'
@@ -85,7 +83,6 @@ if [ ! -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Shut the TPM down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} -s
 
 echo "Test 1: Ok"
@@ -119,12 +116,6 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
-if [ $? -ne 0 ]; then
-	echo "Error: Could not open command interface."
-	ext 1
-fi
-
 # Read PCR 10  (from pcrextend -ha 10 -ic test)
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x04\x00')
 exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 16 00 00 00 01 00 0b 03 00 04 00 00 00 00 01 00 20 f6 85 98 e5 86 8d e6 8b 97 29 99 60 f2 71 7d 17 67 89 a4 2f 9a ae a8 c7 b7 aa 79 a8 62 56 c1 de'
@@ -147,7 +138,6 @@ if [ ! -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Shut the TPM down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} -s
 if [ $? -ne 0 ]; then
 	echo "Error: Could not shut down the CUSE TPM."
@@ -185,12 +175,6 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
-if [ $? -ne 0 ]; then
-	echo "Error: Could not open command interface."
-	ext 1
-fi
-
 # Read PCR 10  (from pcrextend -ha 10 -ic test)
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x04\x00')
 exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 16 00 00 00 01 00 0b 03 00 04 00 00 00 00 01 00 20 f6 85 98 e5 86 8d e6 8b 97 29 99 60 f2 71 7d 17 67 89 a4 2f 9a ae a8 c7 b7 aa 79 a8 62 56 c1 de'
@@ -213,7 +197,6 @@ if [ ! -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Shut the TPM down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} -s
 if [ $? -ne 0 ]; then
 	echo "Error: Could not shut down the CUSE TPM."

--- a/tests/_test_tpm2_save_load_encrypted_state
+++ b/tests/_test_tpm2_save_load_encrypted_state
@@ -72,7 +72,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Startup the TPM (SU_CLEAR)
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x0c\x00\x00\x01\x44\x00\x00')
 exp=' 80 01 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -91,7 +90,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Read PCR 17
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
 exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
 if [ "$RES" != "$exp" ]; then
@@ -138,7 +136,6 @@ echo "Saved volatile state."
 rm -f $VOLATILE_STATE_FILE $STATE_FILE
 
 # Stop the TPM; this will not shut it down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} --stop
 
 kill_quiet -0 ${SWTPM_PID}
@@ -189,7 +186,6 @@ if [ -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Read the PCR again ...
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
 exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
 if [ "$RES" != "$exp" ]; then
@@ -232,7 +228,6 @@ if [ -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Read the PCR again ...
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
 exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
 if [ "$RES" != "$exp" ]; then
@@ -394,7 +389,6 @@ fi
 echo "Test 3: Ok"
 
 # Final shut down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} -s
 if [ $? -ne 0 ]; then
 	echo "Error: Could not shut down the ${SWTPM_INTERFACE} TPM."

--- a/tests/_test_tpm2_save_load_state
+++ b/tests/_test_tpm2_save_load_state
@@ -68,7 +68,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Startup the TPM
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x0c\x00\x00\x01\x44\x00\x00')
 exp=' 80 01 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -86,7 +85,6 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 # Read PCR 17
 #                                                  length         CC            count       hashalg         sz
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
@@ -135,7 +133,6 @@ echo "Saved volatile state."
 rm -f $VOLATILE_STATE_FILE $STATE_FILE
 
 # Stop the TPM; this will not shut it down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} --stop
 if [ $? -ne 0 ]; then
 	echo "Error: Could not stop the ${SWTPM_INTERFACE} TPM."
@@ -191,7 +188,6 @@ if [ -r $VOLATILE_STATE_FILE ]; then
 	exit 1
 fi
 
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 # Read the PCR again ...
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
 exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
@@ -236,7 +232,6 @@ if [ -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Read the PCR again ...
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
 exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
 if [ "$RES" != "$exp" ]; then
@@ -247,7 +242,6 @@ if [ "$RES" != "$exp" ]; then
 fi
 
 # Final shut down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} -s
 if [ $? -ne 0 ]; then
 	echo "Error: Could not shut down the ${SWTPM_INTERFACE} TPM."

--- a/tests/_test_tpm2_save_load_state_da_timeout
+++ b/tests/_test_tpm2_save_load_state_da_timeout
@@ -69,7 +69,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Startup the TPM
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x0c\x00\x00\x01\x44\x00\x00')
 exp=' 80 01 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -80,7 +79,6 @@ if [ "$RES" != "$exp" ]; then
 fi
 
 # Create an NVRAM location: nvdefinespace -hi o -ha 01000000 -pwdn nnn  -sz 16 -at da
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x02\x00\x00\x00\x30\x00\x00\x01\x2a\x40\x00\x00\x01\x00\x00\x00\x09\x40\x00\x00\x09\x00\x00\x00\x00\x00\x00\x03\x6e\x6e\x6e\x00\x0e\x01\x00\x00\x00\x00\x0b\x00\x04\x00\x04\x00\x00\x00\x10')
 exp=' 80 02 00 00 00 13 00 00 00 00 00 00 00 00 00 00 01 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -99,7 +97,6 @@ NVWRITE_BAD='\x80\x02\x00\x00\x00\x29\x00\x00\x01\x37\x01\x00\x00\x00\x01\x00\x0
 # Write some data into the NVRAM area: nvwrite -ha 01000000 -ic test -pwdn nnn
 # Due to -at da being used on TPM2_NV_DefineSpace, the first time the command will request a retry
 for ((i = 0; i < 2; i++)); do
-	swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 	RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} ${NVWRITE_GOOD})
 	exp=' 80 02 00 00 00 13 00 00 00 00 00 00 00 00 00 00 01 00 00'
 	if [ $i -eq 1 ] && [ "$RES" != "$exp" ]; then
@@ -111,7 +108,6 @@ for ((i = 0; i < 2; i++)); do
 done
 
 # Set the dictionary attack parameters: dictionaryattackparameters -lr 6 -nrt 6
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x02\x00\x00\x00\x27\x00\x00\x01\x3a\x40\x00\x00\x0a\x00\x00\x00\x09\x40\x00\x00\x09\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x06\x00\x00\x00\x06')
 exp=' 80 02 00 00 00 13 00 00 00 00 00 00 00 00 00 00 01 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -124,7 +120,6 @@ fi
 timenow=$(date +%s)
 timeout=$((timenow + 6))
 # Send TPM2_NV_Write with wrong password
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} ${NVWRITE_BAD})
 exp=' 80 01 00 00 00 0a 00 00 09 8e'
 if [ "$RES" != "$exp" ]; then
@@ -140,7 +135,6 @@ timerecovery=$((timenow + 6))
 while :; do
 	timenow=$(date +%s)
 	echo "Writing with good password failed due to lockout until $timeout - now is $timenow."
-	swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 	RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} ${NVWRITE_GOOD})
 	exp=' 80 01 00 00 00 0a 00 00 09 21'
 	# busy systems may run the above at >= $timeout and get an unexpected result; check time again
@@ -163,7 +157,6 @@ done
 timenow_after=$(date +%s)
 echo "Time is now ${timenow_after} -- trying with good password should work now."
 # Now writing with the good password must work again
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} ${NVWRITE_GOOD})
 exp=' 80 02 00 00 00 13 00 00 00 00 00 00 00 00 00 00 01 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -181,7 +174,6 @@ fi
 timenow=$(date +%s)
 timeout=$((timenow + 6))
 # Again cause lockout: Send TPM2_NV_Write with wrong password
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} ${NVWRITE_BAD})
 exp=' 80 01 00 00 00 0a 00 00 09 8e'
 if [ "$RES" != "$exp" ]; then
@@ -228,7 +220,6 @@ echo "Saved volatile state."
 rm -f $VOLATILE_STATE_FILE $STATE_FILE
 
 # Stop the TPM; this will not shut it down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} --stop
 if [ $? -ne 0 ]; then
 	echo "Error: Could not stop the ${SWTPM_INTERFACE} TPM."
@@ -289,7 +280,6 @@ fi
 while :; do
 	timenow=$(date +%s)
 	echo "Writing with good password failed due to lockout until $timeout - now is $timenow."
-	swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 	RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} ${NVWRITE_GOOD})
 	exp=' 80 01 00 00 00 0a 00 00 09 21'
 	# busy systems may run the above at >= $timeout and get an unexpected result; check time again
@@ -312,7 +302,6 @@ done
 timenow_after=$(date +%s)
 echo "Time is now $timenow_after -- trying with good password should work now."
 # Now writing with the good password must work again
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} ${NVWRITE_GOOD})
 exp=' 80 02 00 00 00 13 00 00 00 00 00 00 00 00 00 00 01 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -327,9 +316,7 @@ if [ "$RES" != "$exp" ]; then
 	exit 1
 fi
 
-
 # Final shut down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} -s
 if [ $? -ne 0 ]; then
 	echo "Error: Could not shut down the ${SWTPM_INTERFACE} TPM."

--- a/tests/_test_tpm2_savestate
+++ b/tests/_test_tpm2_savestate
@@ -55,7 +55,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Startup the TPM2
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x0c\x00\x00\x01\x44\x00\x00')
 exp=' 80 01 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -66,7 +65,6 @@ if [ "$RES" != "$exp" ]; then
 fi
 
 # Extend PCR 10
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 req='\x80\x02\x00\x00\x00\x41\x00\x00\x01\x82\x00\x00\x00\x0a\x00\x00'
 req+='\x00\x09\x40\x00\x00\x09\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00'
 req+='\x0b\x68\x65\x6c\x6c\x6f\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
@@ -81,7 +79,6 @@ if [ "$RES" != "$exp" ]; then
 	exit 1
 fi
 
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 # Read PCR 10
 #                         length         CC            count       hashalg         sz
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x04\x00')
@@ -93,7 +90,6 @@ if [ "$RES" != "$exp" ]; then
 	exit 1
 fi
 
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 # Shutdown(SU_STATE)
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x0c\x00\x00\x01\x45\x00\x01')
 exp=' 80 01 00 00 00 0a 00 00 00 00'
@@ -112,7 +108,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Startup(SU_STATE) the TPM2
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x0c\x00\x00\x01\x44\x00\x01')
 exp=' 80 01 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -122,7 +117,6 @@ if [ "$RES" != "$exp" ]; then
 	exit 1
 fi
 
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 # Read PCR 10
 #                                                   length         CC            count       hashalg         sz
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x04\x00')

--- a/tests/_test_tpm2_setbuffersize
+++ b/tests/_test_tpm2_setbuffersize
@@ -94,7 +94,6 @@ if [ "$ERR" != "$exp" ]; then
 fi
 
 # Startup the TPM2
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x0c\x00\x00\x01\x44\x00\x00')
 exp=' 80 01 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -105,7 +104,6 @@ if [ "$RES" != "$exp" ]; then
 fi
 
 # Read the Buffer sizes; we want to see '4000' (0xfa0) in the buffer sizes now
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x16\x00\x00\x01\x7a\x00\x00\x00\x06\x00\x00\x01\x1e\x00\x00\x00\x02')
 exp=' 80 01 00 00 00 23 00 00 00 00 01 00 00 00 06 00 00 00 02 00 00 01 1e 00 00 0f a0 00 00 01 1f 00 00 0f a0'
 if [ "$RES" != "$exp" ]; then

--- a/tests/_test_tpm2_volatilestate
+++ b/tests/_test_tpm2_volatilestate
@@ -55,7 +55,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Startup the TPM
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x0c\x00\x00\x01\x44\x00\x00')
 exp=' 80 01 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -73,7 +72,6 @@ fi
 
 # Read PCR 17
 #                                                  length         CC            count       hashalg         sz
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
 exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
 if [ "$RES" != "$exp" ]; then
@@ -106,7 +104,6 @@ if [ ! -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Shut the TPM down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} -s
 if [ $? -ne 0 ]; then
 	echo "Error: Could not shut down the ${SWTPM_INTERFACE} TPM."
@@ -136,9 +133,6 @@ if [ -r $VOLATILE_STATE_FILE ]; then
 	echo "Error: Volatile state file $VOLATILE_STATE_FILE still exists."
 	exit 1
 fi
-
-# Read the PCR again ...
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 
 #                                                      length         CC            count       hashalg         sz
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
@@ -185,9 +179,6 @@ if [ -r $VOLATILE_STATE_FILE ]; then
 	exit 1
 fi
 
-# Read the PCR again ...
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
-
 #                                                     length         CC            count       hashalg         sz
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
 exp=' 80 01 00 00 00 3e 00 00 00 00 00 00 00 18 00 00 00 01 00 0b 03 00 00 02 00 00 00 01 00 20 fc a5 d6 49 bf b0 c9 22 fd 33 0f 79 b2 00 43 28 9d af d6 0d 01 a4 c4 37 3c f2 8a db 56 c9 b4 54'
@@ -213,7 +204,6 @@ if [ "$RES" != "$exp" ]; then
 fi
 
 # Final shut down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} -s
 if [ $? -ne 0 ]; then
 	echo "Error: Could not shut down the ${SWTPM_INTERFACE} TPM."

--- a/tests/_test_tpm2_wrongorder
+++ b/tests/_test_tpm2_wrongorder
@@ -71,9 +71,6 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-# Open access to the TPM
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
-
 # Read PCR 17
 #                                                       length         CC            count       hashalg         sz
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x80\x01\x00\x00\x00\x14\x00\x00\x01\x7e\x00\x00\x00\x01\x00\x0b\x03\x00\x00\x02')
@@ -84,8 +81,6 @@ if [ "$RES" != "$exp" ]; then
 	echo "received: $RES"
 	exit 1
 fi
-
-exec 100>&-
 
 kill_quiet -0 ${SWTPM_PID}
 if [ $? -ne 0 ]; then

--- a/tests/_test_tpm_probe
+++ b/tests/_test_tpm_probe
@@ -41,9 +41,6 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-# Open access to the TPM
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
-
 # Before TPM_INIT: Read PCR 17 -- this gives a TPM_FAIL
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 0a 00 00 00 09'
@@ -58,7 +55,6 @@ fi
 run_swtpm_ioctl ${SWTPM_INTERFACE} -i
 
 # Read PCR 17 -- this should give TPM_INVALID_POSTINIT
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 0a 00 00 00 26'
 if [ "$RES" != "$exp" ]; then

--- a/tests/_test_volatilestate
+++ b/tests/_test_volatilestate
@@ -55,7 +55,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Startup the TPM
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0C\x00\x00\x00\x99\x00\x01')
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
 if [ "$RES" != "$exp" ]; then
@@ -72,7 +71,6 @@ if [ $? -ne 0 ]; then
 fi
 
 # Read PCR 17
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 97 e9 76 e4 f2 2c d6 d2 4a fd 21 20 85 ad 7a 86 64 7f 2a e5'
 if [ "$RES" != "$exp" ]; then
@@ -105,7 +103,6 @@ if [ ! -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Shut the TPM down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} -s
 if [ $? -ne 0 ]; then
 	echo "Error: Could not shut down the ${SWTPM_INTERFACE} TPM."
@@ -137,7 +134,6 @@ if [ -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Read the PCR again ...
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 97 e9 76 e4 f2 2c d6 d2 4a fd 21 20 85 ad 7a 86 64 7f 2a e5'
 if [ "$RES" != "$exp" ]; then
@@ -183,7 +179,6 @@ if [ -r $VOLATILE_STATE_FILE ]; then
 fi
 
 # Read the PCR again ...
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 1e 00 00 00 00 97 e9 76 e4 f2 2c d6 d2 4a fd 21 20 85 ad 7a 86 64 7f 2a e5'
 if [ "$RES" != "$exp" ]; then
@@ -208,7 +203,6 @@ if [ "$RES" != "$exp" ]; then
 fi
 
 # Final shut down
-exec 100>&-
 run_swtpm_ioctl ${SWTPM_INTERFACE} -s
 if [ $? -ne 0 ]; then
 	echo "Error: Could not shut down the ${SWTPM_INTERFACE} TPM."

--- a/tests/_test_wrongorder
+++ b/tests/_test_wrongorder
@@ -66,9 +66,7 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
-
 # Read PCR 17 -- this should give a fatal error response
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 RES=$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')
 exp=' 00 c4 00 00 00 0a 00 00 00 09'
 if [ "$RES" != "$exp" ]; then
@@ -77,8 +75,6 @@ if [ "$RES" != "$exp" ]; then
 	echo "received: $RES"
 	exit 1
 fi
-
-exec 100>&-
 
 kill_quiet -0 ${SWTPM_PID}
 if [ $? -ne 0 ]; then

--- a/tests/common
+++ b/tests/common
@@ -539,6 +539,7 @@ function swtpm_open_cmddev()
 			echo "SWTPM_DEV_NAME not defined"
 			exit 1
 		}
+		exec 100>&-
 		exec 100<>${SWTPM_DEV_NAME}
 		return $?
 		;;
@@ -574,11 +575,13 @@ function swtpm_cmd_tx()
 
 	cmd_path=$(mktemp)
 
+	swtpm_open_cmddev "${iface}" 100
+
 	case "${iface}" in
 	cuse)
 		echo -en "$2" > ${cmd_path}
 		cat ${cmd_path} >&100
-		dd if=/proc/self/fd/100 2>/dev/null | \
+		cat <&100 | \
 		    od -t x1 -A n | \
 		    tr -s ' ' | \
 		    tr -d '\n' | \

--- a/tests/test_ctrlchannel
+++ b/tests/test_ctrlchannel
@@ -233,8 +233,6 @@ fi
 
 validate_pidfile $PID $PID_FILE
 
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
-
 # Get the capability bits: CMD_GET_CAPABILITY = 0x00 00 00 01
 res="$(swtpm_ctrl_tx ${SWTPM_INTERFACE} '\x00\x00\x00\x01')"
 if [[ "$(uname -s)" =~ (Linux|OpenBSD|FreeBSD|NetBSD|Darwin|DragonFly) ]]; then
@@ -361,7 +359,6 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # Read PCR 17
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 res="$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')"
 exp=' 00 c4 00 00 00 1e 00 00 00 00 c4 e1 e1 c9 81 c0 cd b1 e0 43 df 97 20 72 f9 5d a9 ff 06 ff'
 if [ "$res" != "$exp" ]; then
@@ -394,7 +391,6 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # Read PCR 17 -- should fail now
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 res="$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x11')"
 exp=' 00 c4 00 00 00 0a 00 00 00 09'
 if [ "$res" != "$exp" ]; then
@@ -461,7 +457,6 @@ fi
 validate_pidfile $PID $PID_FILE
 
 # Read PCR 10
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 res="$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x0a')"
 exp=' 00 c4 00 00 00 1e 00 00 00 00 c7 8a 6e 94 c7 3c 4d 7f c3 05 c8 a6 6b bf 15 45 f4 ed b7 a5'
 if [ "$res" != "$exp" ]; then
@@ -527,7 +522,6 @@ fi
 validate_pidfile $PID $PID_FILE
 
 # Read PCR 10 -- this should fail now
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 res="$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x0a')"
 exp=' 00 c4 00 00 00 0a 00 00 00 26'
 if [ "$res" != "$exp" ]; then
@@ -573,7 +567,6 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # Read PCR 10 -- has to return same result as before
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 res="$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0E\x00\x00\x00\x15\x00\x00\x00\x0a')"
 exp=' 00 c4 00 00 00 1e 00 00 00 00 c7 8a 6e 94 c7 3c 4d 7f c3 05 c8 a6 6b bf 15 45 f4 ed b7 a5'
 if [ "$res" != "$exp" ]; then
@@ -584,7 +577,6 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # Reset PCR 20 while in locality 0 -- should not work
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 res="$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0F\x00\x00\x00\xC8\x00\x03\x00\x00\x10')"
 exp=' 00 c4 00 00 00 0a 00 00 00 33'
 if [ "$res" != "$exp" ]; then
@@ -606,7 +598,6 @@ if [ "$res" != "$exp" ]; then
 fi
 
 # Reset PCR 20 while in locality 2 -- has to work
-swtpm_open_cmddev ${SWTPM_INTERFACE} 100
 res="$(swtpm_cmd_tx ${SWTPM_INTERFACE} '\x00\xC1\x00\x00\x00\x0F\x00\x00\x00\xC8\x00\x03\x00\x00\x10')"
 exp=' 00 c4 00 00 00 0a 00 00 00 00'
 if [ "$res" != "$exp" ]; then

--- a/tests/test_samples_create_tpmca
+++ b/tests/test_samples_create_tpmca
@@ -129,8 +129,6 @@ _EOF_
 		--flags not-need-init \
 		--tpmstate "dir=${workdir}"
 
-	swtpm_open_cmddev ${SWTPM_INTERFACE} 100
-
 	# Startup the TPM
 	res="$(swtpm_cmd_tx "${SWTPM_INTERFACE}" '\x00\xC1\x00\x00\x00\x0C\x00\x00\x00\x99\x00\x01')"
 	exp=' 00 c4 00 00 00 0a 00 00 00 00'


### PR DESCRIPTION
Move swtpm_open_cmddev call into swtpm_cmd_tx since the latter function is
always called in a subshell that previously inherited the file descriptor
opened by the test cases. Remove swtpm_cmd_tx from nearly all test cases
and also remove closing of file descriptor 100 via 'exec 100>&-' from test
cases since this is not necessary anymore.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>