### PR TITLE
Fixed typo `fs_mount` vs `fsmount`

### DIFF
--- a/src/swtpm/seccomp_profile.c
+++ b/src/swtpm/seccomp_profile.c
@@ -102,7 +102,7 @@ int create_seccomp_profile(bool cusetpm, unsigned int action)
         SCMP_SYS(fsconfig),
 #endif
 #ifdef __NR_fsmount
-        SCMP_SYS(fs_mount),
+        SCMP_SYS(fsmount),
 #endif
 #ifdef __NR_fspick
         SCMP_SYS(fspick),
@@ -115,14 +115,8 @@ int create_seccomp_profile(bool cusetpm, unsigned int action)
         SCMP_SYS(mount_setattr),
 #endif
         SCMP_SYS(umount2),
-#ifdef __NR_fsmount
-        SCMP_SYS(fsmount),
-#endif
 #ifdef __NR_open_tree
         SCMP_SYS(open_tree),
-#endif
-#ifdef __NR_move_mount
-        SCMP_SYS(move_mount),
 #endif
         SCMP_SYS(swapon),
         SCMP_SYS(swapoff),


### PR DESCRIPTION
I think there was a small typo with the seccomp profile creation.

The project wouldn't compile on my ubuntu 20.04.1 based system with the error message:
```
  CC       libswtpm_libtpms_la-seccomp_profile.lo
In file included from seccomp_profile.c:44:
seccomp_profile.c: In function ‘create_seccomp_profile’:
seccomp_profile.c:105:9: error: ‘__SNR_fs_mount’ undeclared (first use in this function)
  105 |         SCMP_SYS(fs_mount),
      |         ^~~~~~~~
seccomp_profile.c:105:9: note: each undeclared identifier is reported only once for each function it appears in
```

My guess is that this is simply a typo and `fs_mount` was supposed to be `fsmount`.

**Note:** I have no previous expertise with seccomp, so please double check. Maybe `fs_mount` is a valid name that is just not available on my non-cutting-edge system.

**Note 2:** There are some identifiers that are used multiple times in the SCMP_SYS macro, namely `fsmount` and `move_mount`. Is this intentional?