### PR TITLE
Refactor FIPS related code

### DIFF
--- a/src/swtpm/cuse_tpm.c
+++ b/src/swtpm/cuse_tpm.c
@@ -1722,11 +1722,6 @@ int swtpm_cuse_main(int argc, char **argv, const char *prgname, const char *ifac
         goto exit;
     }
 
-    if (disable_fips_mode() < 0) {
-        ret = -1;
-        goto exit;
-    }
-
     if (tpmlib_register_callbacks(&cbs) != TPM_SUCCESS) {
         ret = -1;
         goto exit;

--- a/src/swtpm/fips.c
+++ b/src/swtpm/fips.c
@@ -63,7 +63,7 @@ extern int FIPS_mode_set(int);
  * Returns < 0 on error, 0 otherwise.
  */
 #if defined(HAVE_OPENSSL_FIPS_H) || defined(HAVE_OPENSSL_FIPS_MODE_SET_API)
-int disable_fips_mode(void)
+int fips_mode_disable(void)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
     int mode = EVP_default_properties_is_fips_enabled(NULL);
@@ -93,7 +93,7 @@ int disable_fips_mode(void)
 }
 #else
 /* OpenBSD & DragonFlyBSD case */
-int disable_fips_mode(void)
+int fips_mode_disable(void)
 {
     return 0;
 }

--- a/src/swtpm/fips.h
+++ b/src/swtpm/fips.h
@@ -38,6 +38,9 @@
 #ifndef _SWTPM_FIPS_H_
 #define _SWTPM_FIPS_H_
 
+#include <stdbool.h>
+
+bool fips_mode_enabled(void);
 int fips_mode_disable(void);
 
 #endif /* _SWTPM_FIPS_H_ */

--- a/src/swtpm/fips.h
+++ b/src/swtpm/fips.h
@@ -35,9 +35,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _SWTPM_UTILS_H_
-#define _SWTPM_UTILS_H_
+#ifndef _SWTPM_FIPS_H_
+#define _SWTPM_FIPS_H_
 
-int disable_fips_mode(void);
+int fips_mode_disable(void);
 
-#endif /* _SWTPM_UTILS_H_ */
+#endif /* _SWTPM_FIPS_H_ */

--- a/src/swtpm/swtpm.c
+++ b/src/swtpm/swtpm.c
@@ -520,9 +520,6 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
         daemonize_finish();
     }
 
-    if (disable_fips_mode() < 0)
-        goto error_seccomp_profile;
-
     rc = mainLoop(&mlp, notify_fd[0]);
 
 error_seccomp_profile:

--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -572,9 +572,6 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
         daemonize_finish();
     }
 
-    if (disable_fips_mode() < 0)
-        goto error_seccomp_profile;
-
     rc = mainLoop(&mlp, notify_fd[0]);
 
 error_seccomp_profile:

--- a/src/swtpm/tpmlib.c
+++ b/src/swtpm/tpmlib.c
@@ -59,6 +59,7 @@
 #include "utils.h"
 #include "compiler_dependencies.h"
 #include "swtpm_utils.h"
+#include "fips.h"
 
 /*
  * convert the blobtype integer into a string that libtpms
@@ -130,6 +131,10 @@ TPM_RESULT tpmlib_start(uint32_t flags, TPMLIB_TPMVersion tpmversion)
             goto error_terminate;
         }
     }
+
+    if (fips_mode_disable() < 0)
+        goto error_terminate;
+
     return TPM_SUCCESS;
 
 error_terminate:

--- a/src/swtpm/tpmlib.c
+++ b/src/swtpm/tpmlib.c
@@ -132,7 +132,7 @@ TPM_RESULT tpmlib_start(uint32_t flags, TPMLIB_TPMVersion tpmversion)
         }
     }
 
-    if (fips_mode_disable() < 0)
+    if (fips_mode_enabled() && fips_mode_disable() < 0)
         goto error_terminate;
 
     return TPM_SUCCESS;

--- a/src/swtpm/utils.h
+++ b/src/swtpm/utils.h
@@ -71,6 +71,4 @@ ssize_t writev_full(int fd, const struct iovec *iov, int iovcnt);
 
 ssize_t read_eintr(int fd, void *buffer, size_t buflen);
 
-int disable_fips_mode(void);
-
 #endif /* _SWTPM_UTILS_H_ */


### PR DESCRIPTION
This PR renames `disable_fips_mode()` to `fips_mode_disable()` and moves it into `tpmlib_start()` after `TPMLIB_MainInit()` to consolidate the call in a single place. Refactor the code to create the new function `fips_mode_enabled()`.