### PR TITLE
swtpm_ioctl: Only close file descriptor if >= 0 (Coverity)

### DIFF
--- a/src/swtpm_ioctl/tpm_ioctl.c
+++ b/src/swtpm_ioctl/tpm_ioctl.c
@@ -1316,7 +1316,8 @@ int main(int argc, char *argv[])
 
 exit:
     free(tcp_hostname);
-    close(fd);
+    if (fd >= 0)
+        close(fd);
 
     return ret;
 }


### PR DESCRIPTION
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>