### PR TITLE
swtpm: Add a chroot option

### DIFF
--- a/man/man8/swtpm.pod
+++ b/man/man8/swtpm.pod
@@ -267,6 +267,11 @@ has been opened for writing.
 
 Switch to the given user. This option can only be used when swtpm is started as root.
 
+=item B<-R|--chroot E<lt>path<gt>>
+
+Chroot to the given directory at startup. This option can only be used when swtpm is
+started as root.
+
 =item B<--seccomp action=none|log|kill> (since v0.2)
 
 This option allows a user to select the action to take by the seccomp profile when

--- a/src/swtpm/utils.c
+++ b/src/swtpm/utils.c
@@ -146,6 +146,23 @@ change_process_owner(const char *user)
     return 0;
 }
 
+int
+do_chroot(const char *path)
+{
+    if (chroot(path) < 0) {
+        logprintf(STDERR_FILENO, "chroot failed: %s\n",
+                  strerror(errno));
+        return -1;
+    }
+
+    if (chdir("/") < 0) {
+        logprintf(STDERR_FILENO, "chdir failed: %s\n",
+                  strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
 void tpmlib_debug_libtpms_parameters(TPMLIB_TPMVersion tpmversion)
 {
     switch (tpmversion) {

--- a/src/swtpm/utils.h
+++ b/src/swtpm/utils.h
@@ -61,6 +61,7 @@ typedef void (*sighandler_t)(int);
 int install_sighandlers(int pipefd[2], sighandler_t handler);
 void uninstall_sighandlers(void);
 int change_process_owner(const char *owner);
+int do_chroot(const char *path);
 
 void tpmlib_debug_libtpms_parameters(TPMLIB_TPMVersion);
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -47,6 +47,9 @@ TESTS += \
 
 TESTS += \
 	test_tpm2_avoid_da_lockout \
+	test_tpm2_chroot_socket \
+	test_tpm2_chroot_chardev \
+	test_tpm2_chroot_cuse \
 	test_tpm2_ctrlchannel2 \
 	test_tpm2_derived_keys \
 	test_tpm2_encrypted_state \

--- a/tests/test_tpm2_chroot_chardev
+++ b/tests/test_tpm2_chroot_chardev
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# For the license, see the LICENSE file in the root directory.
+
+if [ "$(id -u)" -ne 0 ]; then
+        echo "Need to be root to run this test."
+        exit 77
+fi
+
+if [ "$(uname -s)" != "Linux" ]; then
+	# Due to using /proc/<pid>/root
+	echo "This test only runs only Linux."
+	exit 77
+fi
+
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+
+SWTPM=swtpm
+SWTPM_EXE=${SWTPM_EXE:-$ROOT/src/swtpm/$SWTPM}
+PID_FILE=/${SWTPM}.pid
+
+source ${TESTDIR}/common
+source ${TESTDIR}/test_common
+skip_test_no_chardev "${SWTPM_EXE}"
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
+trap "cleanup" SIGTERM EXIT
+
+function cleanup()
+{
+	rm -rf $TPMDIR
+	if [ -n "$PID" ]; then
+		kill_quiet -SIGTERM $PID 2>/dev/null
+	fi
+}
+
+for OPTION in --chroot -R; do
+	TPMDIR="$(mktemp -d)" || exit 1
+	mkdir $TPMDIR/dev
+	mknod -m 0666 $TPMDIR/dev/urandom c 1 9
+
+	# use a pseudo terminal
+	exec 100<>/dev/ptmx
+	$SWTPM_EXE chardev \
+		--fd 100 \
+		"$OPTION" $TPMDIR \
+		--tpmstate dir=/ \
+		--pid file=$PID_FILE \
+		--tpm2 \
+		--flags not-need-init \
+		${SWTPM_TEST_SECCOMP_OPT} &
+	PID=$!
+
+	if wait_for_file $TPMDIR/$PID_FILE 3; then
+		echo "Error: Chardev TPM did not write pidfile."
+		exit 1
+	fi
+
+	validate_pidfile $PID $TPMDIR/$PID_FILE
+
+	if [ "$(readlink /proc/$PID/root)" != $TPMDIR ]; then
+		echo "Test 1 failed: Unexpected chroot dir"
+		exit 1
+	fi
+
+	if [ ! -f ${TPMDIR}/tpm2-00.permall ]; then
+		echo "Missing state file"
+		exit 1
+	fi
+
+	echo "Test $OPTION passed"
+	cleanup
+done

--- a/tests/test_tpm2_chroot_cuse
+++ b/tests/test_tpm2_chroot_cuse
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# For the license, see the LICENSE file in the root directory.
+
+if [ "$(id -u)" -ne 0 ]; then
+        echo "Need to be root to run this test."
+        exit 77
+fi
+
+if [ "$(uname -s)" != "Linux" ]; then
+	# Due to using /proc/<pid>/root
+	echo "This test only runs only Linux."
+	exit 77
+fi
+
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+
+SWTPM=swtpm
+SWTPM_EXE=${SWTPM_EXE:-$ROOT/src/swtpm/$SWTPM}
+PID_FILE=/${SWTPM}.pid
+VTPM_NAME="vtpm-test-chroot"
+SWTPM_DEV_NAME="/dev/${VTPM_NAME}"
+
+source ${TESTDIR}/common
+source ${TESTDIR}/test_common
+source ${TESTDIR}/test_cuse
+
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
+trap "cleanup" SIGTERM EXIT
+
+function cleanup()
+{
+	rm -rf $TPMDIR
+	if [ -n "$PID" ]; then
+		kill_quiet -SIGTERM $PID 2>/dev/null
+	fi
+}
+
+for OPTION in --chroot -R; do
+	TPMDIR="$(mktemp -d)" || exit 1
+	mkdir $TPMDIR/dev
+	mknod -m 0666 $TPMDIR/dev/urandom c 1 9
+	mknod -m 0666 $TPMDIR/dev/cuse c 10 203
+
+	$SWTPM_EXE cuse \
+		-n "$SWTPM_DEV_NAME" \
+		"$OPTION" $TPMDIR \
+		--tpmstate dir=/ \
+		--pid file=$PID_FILE \
+		--tpm2 \
+		--flags not-need-init \
+		${SWTPM_TEST_SECCOMP_OPT} &>/dev/null &
+
+	if wait_for_file $TPMDIR/$PID_FILE 3; then
+		echo "Error: CUSE TPM did not write pidfile."
+		exit 1
+	fi
+
+	PID=$(ps aux |
+		grep "cuse" |
+		grep " ${SWTPM_DEV_NAME}" |
+		grep -v grep |
+		gawk '{print $2}')
+
+	validate_pidfile $PID $TPMDIR/$PID_FILE
+
+	if [ "$(readlink /proc/$PID/root)" != $TPMDIR ]; then
+		echo "Test 1 failed: Unexpected chroot dir"
+		exit 1
+	fi
+
+	if [ ! -f ${TPMDIR}/tpm2-00.permall ]; then
+		echo "Missing state file"
+		exit 1
+	fi
+
+	echo "Test $OPTION passed"
+	cleanup
+done

--- a/tests/test_tpm2_chroot_socket
+++ b/tests/test_tpm2_chroot_socket
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# For the license, see the LICENSE file in the root directory.
+
+if [ "$(id -u)" -ne 0 ]; then
+        echo "Need to be root to run this test."
+        exit 77
+fi
+
+if [ "$(uname -s)" != "Linux" ]; then
+	# Due to using /proc/<pid>/root
+	echo "This test only runs only Linux."
+	exit 77
+fi
+
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+TESTDIR=${abs_top_testdir:=$(dirname "$0")}
+
+SWTPM=swtpm
+SWTPM_EXE=${SWTPM_EXE:-$ROOT/src/swtpm/$SWTPM}
+PID_FILE=/${SWTPM}.pid
+
+source ${TESTDIR}/common
+source ${TESTDIR}/test_common
+skip_test_no_chardev "${SWTPM_EXE}"
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
+trap "cleanup" SIGTERM EXIT
+
+function cleanup()
+{
+	rm -rf $TPMDIR
+	if [ -n "$PID" ]; then
+		kill_quiet -SIGTERM $PID 2>/dev/null
+	fi
+}
+
+PORT=65468
+
+export TCSD_TCP_DEVICE_HOSTNAME=localhost
+export TCSD_TCP_DEVICE_PORT=$PORT
+export TCSD_USE_TCP_DEVICE=1
+
+for OPTION in --chroot -R; do
+	TPMDIR="$(mktemp -d)" || exit 1
+	mkdir $TPMDIR/dev
+	mknod -m 0666 $TPMDIR/dev/urandom c 1 9
+
+	$SWTPM_EXE socket \
+		-p $PORT \
+		"$OPTION" $TPMDIR \
+		--tpmstate dir=/ \
+		--pid file=$PID_FILE \
+		--tpm2 \
+		--flags not-need-init \
+		${SWTPM_TEST_SECCOMP_OPT} &>/dev/null &
+	PID=$!
+
+	if wait_for_file $TPMDIR/$PID_FILE 3; then
+		echo "Error: socket TPM did not write pidfile."
+		exit 1
+	fi
+
+	validate_pidfile $PID $TPMDIR/$PID_FILE
+
+	if [ "$(readlink /proc/$PID/root)" != $TPMDIR ]; then
+		echo "Test 1 failed: Unexpected chroot dir"
+		exit 1
+	fi
+
+	if [ ! -f ${TPMDIR}/tpm2-00.permall ]; then
+		echo "Missing state file"
+		exit 1
+	fi
+
+	echo "Test $OPTION passed"
+	cleanup
+done


### PR DESCRIPTION
Add an option to enter a chroot after starting swtpm. This is useful for
sandboxing purposes. When this option is used, it is expected that swtpm
is started as root and the --runas option is used to subsequently drop
privileges (otherwise the chroot could be escaped).

Signed-off-by: Jennifer Herbert <jennifer.herbert@citrix.com>
Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>