### PR TITLE
headers: Synchronize with header in QEMU project

### DIFF
--- a/include/swtpm/tpm_ioctl.h
+++ b/include/swtpm/tpm_ioctl.h
@@ -17,6 +17,10 @@
 #include <sys/types.h>
 #include <sys/ioctl.h>
 
+#ifdef HAVE_SYS_IOCCOM_H
+#include <sys/ioccom.h>
+#endif
+
 /*
  * Every response from a command involving a TPM command execution must hold
  * the ptm_res as the first element.
@@ -306,4 +310,4 @@ enum {
     CMD_GET_INFO,             /* 0x12 */
 };
 
-#endif /* _TPM_IOCTL_H */
+#endif /* _TPM_IOCTL_H_ */


### PR DESCRIPTION
QEMU has made a change to a copy of this header file with the following
reason:

On Solaris and Haiku, the _IO() macros are defined in <sys/ioccom.h>.
Add a proper check for this header to our build system, and make sure
to include the header in tpm_ioctl.h to fix a build failure on Solaris
and Haiku.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>