### PR TITLE
swtpm: Do 300 locking retries instead of only 100

### DIFF
--- a/src/swtpm/cuse_tpm.c
+++ b/src/swtpm/cuse_tpm.c
@@ -128,7 +128,7 @@ static bool g_release_lock_outgoing;
 /* how many times to retry locking; use for fallback after releasing
    the lock on outgoing migration. */
 static unsigned int g_locking_retries;
-#define DEFAULT_LOCKING_RETRIES  100
+#define DEFAULT_LOCKING_RETRIES  300 /* 300 * 10ms */
 
 #if GLIB_MAJOR_VERSION >= 2
 # if GLIB_MINOR_VERSION >= 32

--- a/src/swtpm/mainloop.h
+++ b/src/swtpm/mainloop.h
@@ -71,7 +71,7 @@ struct mainLoopParams {
     /* how many times to retry locking; use for fallback after releasing
        the lock on outgoing migration. */
     unsigned int locking_retries;
-#define DEFAULT_LOCKING_RETRIES  100
+#define DEFAULT_LOCKING_RETRIES  300 /* 300 * 10ms */
 };
 
 int mainLoop(struct mainLoopParams *mlp,


### PR DESCRIPTION
Increase the number of locking retries to 300 over 3 seconds instead of 100 over 1 second. This gives the failing side more time to release the lock.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>