### PR TITLE
debian: Do not remove swtpm_cuse.8 via clean file

### DIFF
--- a/debian/clean
+++ b/debian/clean
@@ -1,3 +1,10 @@
 include/swtpm/*.gch
 man/*/*.3
-man/*/*.8
+man/man8/swtpm.8
+man/man8/swtpm_bios.8
+man/man8/swtpm_cert.8
+man/man8/swtpm-create-tpmca.8
+man/man8/swtpm_ioctl.8
+man/man8/swtpm_localca.8
+man/man8/swtpm-localca.8
+man/man8/swtpm_setup.8


### PR DESCRIPTION
swtpm_cuse.8 is not generated anymore but its a static file now that must not be removed anymore via the debian/clean file.

Resolves: https://github.com/stefanberger/swtpm/issues/751
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>