### PR TITLE
swtpm: Also send TPM2_Shutdown when swtpm terminates by signal 

### DIFF
--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -611,6 +611,8 @@ int ctrlchannel_process_fd(int fd,
 
         TPMLIB_Terminate();
 
+        *tpm_running = false;
+
         *res_p = htobe32(TPM_SUCCESS);
         out_len = sizeof(ptm_res);
 

--- a/src/swtpm/cuse_tpm.c
+++ b/src/swtpm/cuse_tpm.c
@@ -1208,6 +1208,8 @@ static void ptm_ioctl(fuse_req_t req, int cmd, void *arg,
         res = TPM_SUCCESS;
         TPMLIB_Terminate();
 
+        tpm_running = false;
+
         free(ptm_response);
         ptm_response = NULL;
 

--- a/src/swtpm/mainloop.c
+++ b/src/swtpm/mainloop.c
@@ -366,6 +366,9 @@ skip_process:
             break;
     }
 
+    if (tpm_running && !mlp->disable_auto_shutdown)
+        tpmlib_maybe_send_tpm2_shutdown(mlp->tpmversion, &mlp->lastCommand);
+
     free(rbuffer);
     free(command);
 

--- a/src/swtpm/tpmlib.c
+++ b/src/swtpm/tpmlib.c
@@ -514,7 +514,7 @@ void tpmlib_maybe_send_tpm2_shutdown(TPMLIB_TPMVersion tpmversion,
     for (i = 0; i < ARRAY_LEN(shutdownTypes); i++) {
 #if 0
         logprintf(STDERR_FILENO,
-                  "Need to send TPM2_Shutdown(%s); previous command: 0x08x\n",
+                  "Need to send TPM2_Shutdown(%s); previous command: 0x%08x\n",
                   shutdownTypes[i] == TPM2_SU_STATE ? "SU_STATE" : "SU_CLEAR",
                   *lastCommand);
 #endif


### PR DESCRIPTION
Also send TPM2_Shutdown when swtpm is terminated by a signal or due to
lost connection. Previously supported reasons for sending the TPM2_Shutdown
were primarily related to commands sent via the command channel.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>
