### PR TITLE
swtpm: Add support for termination of swtpm upon control channel connection loss

### DIFF
--- a/man/man8/swtpm.pod
+++ b/man/man8/swtpm.pod
@@ -126,7 +126,7 @@ For the socket interface, this option automatically assumes -t.
 
 Daemonize the process.
 
-=item B<--ctrl type=[unixio|tcp][,path=E<lt>pathE<gt>] [,port=E<lt>portE<gt>[,bindaddr=E<lt>addressE<gt>[,ifname=E<lt>ifnameE<gt>]]] [,fd=E<lt>filedescriptorE<gt>|clientfd=E<lt>filedescriptorE<gt>] [,mode=E<lt>0...E<gt>][,uid=E<lt>uidE<gt>][,gid=E<lt>gidE<gt>] >
+=item B<--ctrl type=[unixio|tcp][,path=E<lt>pathE<gt>] [,port=E<lt>portE<gt>[,bindaddr=E<lt>addressE<gt>[,ifname=E<lt>ifnameE<gt>]]] [,fd=E<lt>filedescriptorE<gt>|clientfd=E<lt>filedescriptorE<gt>] [,mode=E<lt>0...E<gt>][,uid=E<lt>uidE<gt>][,gid=E<lt>gidE<gt>][,terminate] >
 
 This option adds a control channel to the TPM. The control channel can either use a UnixIO socket with
 a given I<path> or I<filedescriptor> or it can use a TCP socket on the given I<port> or I<filedescriptor>.
@@ -135,10 +135,16 @@ can be provided as well; the default bind address is 127.0.0.1. If a link
 local IPv6 address is provided, the name of the interface to bind to must be
 provided with I<ifname>.
 
-The mode parameter allows a user to set the file mode bits of the UnixIO path.
+The I<mode> parameter allows a user to set the file mode bits of the UnixIO path.
 The mode bits value must be given as an octal number starting with a '0'.
-The default value is 0770. uid and gid set the ownership of the UnixIO socket's path.
+The default value is 0770. I<uid> and I<gid> set the ownership of the UnixIO socket's path.
 This operation requires root privileges.
+
+The I<terminate> parameter enables the automatic termination of swtpm when the
+control channel connection has been lost. This is useful in scenarios where
+the control channel connection is held permanently, such as by QEMU, and
+swtpm should terminate upon abnormal termination of the client that could
+not send a CMD_SHUTDOWN via the control channel anymore.
 
 The control channel enables out-of-band control of the TPM, such as resetting the TPM.
 

--- a/src/swtpm/capabilities.c
+++ b/src/swtpm/capabilities.c
@@ -146,7 +146,7 @@ int capabilities_print_json(bool cusetpm, TPMLIB_TPMVersion tpmversion)
          "{ "
          "\"type\": \"swtpm\", "
          "\"features\": [ "
-             "%s%s%s%s%s%s%s%s%s%s%s%s%s%s"
+             "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s"
           " ], "
          "\"version\": \"" VERSION "\" "
          "}",
@@ -155,6 +155,7 @@ int capabilities_print_json(bool cusetpm, TPMLIB_TPMVersion tpmversion)
          !cusetpm     ? "\"tpm-send-command-header\", ": "",
          true         ? "\"flags-opt-startup\", "      : "",
          true         ? "\"flags-opt-disable-auto-shutdown\", ": "",
+         true         ? "\"ctrl-opt-terminate\", "     : "",
          cmdarg_seccomp,
          true         ? "\"cmdarg-key-fd\", "          : "",
          true         ? "\"cmdarg-pwd-fd\", "          : "",

--- a/src/swtpm/common.h
+++ b/src/swtpm/common.h
@@ -49,7 +49,8 @@ int handle_migration_key_options(char *options);
 int handle_pid_options(char *options);
 int handle_tpmstate_options(char *options);
 struct ctrlchannel;
-int handle_ctrlchannel_options(char *options, struct ctrlchannel **cc);
+int handle_ctrlchannel_options(char *options, struct ctrlchannel **cc,
+                               uint32_t *mainloop_flag);
 struct server;
 int handle_server_options(char *options, struct server **s);
 int handle_locality_options(char *options, uint32_t *flags);

--- a/src/swtpm/mainloop.c
+++ b/src/swtpm/mainloop.c
@@ -260,6 +260,10 @@ int mainLoop(struct mainLoopParams *mlp,
                                                     &mainloop_terminate,
                                                     &locality, &tpm_running,
                                                     mlp);
+                if (ctrlclntfd < 0 &&
+                    mlp->flags & MAIN_LOOP_FLAG_CTRL_END_ON_HUP)
+                    mainloop_terminate = true;
+
                 if (mainloop_terminate)
                     break;
             }
@@ -268,6 +272,11 @@ int mainLoop(struct mainLoopParams *mlp,
                 if (ctrlclntfd >= 0)
                     close(ctrlclntfd);
                 ctrlclntfd = -1;
+                /* unixio gets this signal, not tcp */
+                if (mlp->flags & MAIN_LOOP_FLAG_CTRL_END_ON_HUP) {
+                    mainloop_terminate = true;
+                    break;
+                }
             }
 
             if (!(pollfds[DATA_CLIENT_FD].revents & POLLIN))

--- a/src/swtpm/mainloop.h
+++ b/src/swtpm/mainloop.h
@@ -50,10 +50,11 @@ extern bool tpm_running;
 
 struct mainLoopParams {
     uint32_t flags;
-#define MAIN_LOOP_FLAG_TERMINATE  (1 << 0)
-#define MAIN_LOOP_FLAG_USE_FD     (1 << 1)
-#define MAIN_LOOP_FLAG_KEEP_CONNECTION (1 << 2)
-#define MAIN_LOOP_FLAG_END_ON_HUP (1 << 3)
+#define MAIN_LOOP_FLAG_TERMINATE        (1 << 0)
+#define MAIN_LOOP_FLAG_USE_FD           (1 << 1)
+#define MAIN_LOOP_FLAG_KEEP_CONNECTION  (1 << 2)
+#define MAIN_LOOP_FLAG_END_ON_HUP       (1 << 3)
+#define MAIN_LOOP_FLAG_CTRL_END_ON_HUP  (1 << 4) /* terminate on ctrl ch. client loss (QEMU) */
 
     int fd;
     struct ctrlchannel *cc;

--- a/src/swtpm/swtpm.c
+++ b/src/swtpm/swtpm.c
@@ -108,7 +108,7 @@ static void usage(FILE *file, const char *prgname, const char *iface)
     "-t|--terminate   : terminate the TPM once the data channel connection (TCP)\n"
     "                   has been lost\n"
     "-d|--daemon      : daemonize the TPM\n"
-    "--ctrl type=[unixio|tcp][,path=<path>][,port=<port>[,bindaddr=address[,ifname=ifname]]][,fd=<filedescriptor>|clientfd=<filedescriptor>][,mode=0...][,uid=uid][,gid=gid]\n"
+    "--ctrl type=[unixio|tcp][,path=<path>][,port=<port>[,bindaddr=address[,ifname=ifname]]][,fd=<filedescriptor>|clientfd=<filedescriptor>][,mode=0...][,uid=uid][,gid=gid][,terminate]\n"
     "                 : TPM control channel using either UnixIO or TCP sockets;\n"
     "                   the path is only valid for Unixio channels; the port must\n"
     "                   be given in case the type is TCP; the TCP socket is bound\n"
@@ -122,6 +122,7 @@ static void usage(FILE *file, const char *prgname, const char *iface)
     "                   mode allows a user to set the file mode bits of a Unixio socket;\n"
     "                   the value must be given in octal number format\n"
     "                   uid and gid set the ownership of the Unixio socket's file;\n"
+    "                   terminate terminates on ctrl channel connection loss;\n"
     "--migration-key file=<path>|fd=<fd>[,mode=aes-cbc|aes-256-cbc][,format=hex|binary][,remove=[true|false]]\n"
     "                 : use an AES key for the encryption of the TPM's state\n"
     "                   when it is retrieved from the TPM via ioctls;\n"
@@ -469,7 +470,7 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
     if (tpmlib_choose_tpm_version(mlp.tpmversion) != TPM_SUCCESS)
         exit(EXIT_FAILURE);
 
-    if (handle_ctrlchannel_options(ctrlchdata, &mlp.cc) < 0 ||
+    if (handle_ctrlchannel_options(ctrlchdata, &mlp.cc, &mlp.flags) < 0 ||
         handle_server_options(serverdata, &server) < 0) {
         goto exit_failure;
     }

--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -136,7 +136,7 @@ static void usage(FILE *file, const char *prgname, const char *iface)
     "                 : use the given character device\n"
     "-f|--fd <fd>     : use the given character device file descriptor\n"
     "-d|--daemon      : daemonize the TPM\n"
-    "--ctrl type=[unixio|tcp][,path=<path>][,port=<port>[,bindaddr=address[,ifname=ifname]]][,fd=<filedescriptor|clientfd=<filedescriptor>][,mode=0...][,uid=uid][,gid=gid]\n"
+    "--ctrl type=[unixio|tcp][,path=<path>][,port=<port>[,bindaddr=address[,ifname=ifname]]][,fd=<filedescriptor|clientfd=<filedescriptor>][,mode=0...][,uid=uid][,gid=gid][,terminate]\n"
     "                 : TPM control channel using either UnixIO or TCP sockets;\n"
     "                   the path is only valid for Unixio channels; the port must\n"
     "                   be given in case the type is TCP; the TCP socket is bound\n"
@@ -150,6 +150,7 @@ static void usage(FILE *file, const char *prgname, const char *iface)
     "                   mode allows a user to set the file mode bits of a Unixio socket;\n"
     "                   the value must be given in octal number format\n"
     "                   uid and gid set the ownership of the Unixio socket's file;\n"
+    "                   terminate terminates on ctrl channel connection loss;\n"
     "--migration-key file=<path>|fd=<fd>[,mode=aes-cbc|aes-256-cbc][,format=hex|binary][,remove=[true|false]]\n"
     "                 : use an AES key for the encryption of the TPM's state\n"
     "                   when it is retrieved from the TPM via ioctls;\n"
@@ -550,7 +551,7 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
         exit(EXIT_FAILURE);
     }
 
-    if (handle_ctrlchannel_options(ctrlchdata, &mlp.cc) < 0) {
+    if (handle_ctrlchannel_options(ctrlchdata, &mlp.cc, &mlp.flags) < 0) {
         goto exit_failure;
     }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -51,6 +51,7 @@ TESTS += \
 	test_tpm2_chroot_chardev \
 	test_tpm2_chroot_cuse \
 	test_tpm2_ctrlchannel2 \
+	test_tpm2_ctrlchannel3 \
 	test_tpm2_derived_keys \
 	test_tpm2_encrypted_state \
 	test_tpm2_init \

--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -25,7 +25,7 @@ if [ "${SWTPM_IFACE}" != "cuse" ]; then
 	noncuse='"tpm-send-command-header", '
 fi
 
-exp='\{ "type": "swtpm", "features": \[ "tpm-1.2",( "tpm-2.0",)? '${noncuse}'"flags-opt-startup", "flags-opt-disable-auto-shutdown", '${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd", "cmdarg-print-states", "cmdarg-chroot", "cmdarg-migration", "nvram-backend-dir", "nvram-backend-file" \], "version": "[^"]*" \}'
+exp='\{ "type": "swtpm", "features": \[ "tpm-1.2",( "tpm-2.0",)? '${noncuse}'"flags-opt-startup", "flags-opt-disable-auto-shutdown", "ctrl-opt-terminate", '${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd", "cmdarg-print-states", "cmdarg-chroot", "cmdarg-migration", "nvram-backend-dir", "nvram-backend-file" \], "version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-capabilities:"
 	echo "Actual   : ${msg}"

--- a/tests/_test_tpm2_print_capabilities
+++ b/tests/_test_tpm2_print_capabilities
@@ -26,7 +26,7 @@ if [ "${SWTPM_IFACE}" != "cuse" ]; then
 fi
 
 # The rsa key size reporting is variable, so use a regex
-exp='\{ "type": "swtpm", "features": \[( "tpm-1.2",)? "tpm-2.0", '${noncuse}'"flags-opt-startup", "flags-opt-disable-auto-shutdown", '${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd", "cmdarg-print-states", "cmdarg-chroot", "cmdarg-migration", "nvram-backend-dir", "nvram-backend-file"(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")? \], "version": "[^"]*" \}'
+exp='\{ "type": "swtpm", "features": \[( "tpm-1.2",)? "tpm-2.0", '${noncuse}'"flags-opt-startup", "flags-opt-disable-auto-shutdown", "ctrl-opt-terminate", '${seccomp}'"cmdarg-key-fd", "cmdarg-pwd-fd", "cmdarg-print-states", "cmdarg-chroot", "cmdarg-migration", "nvram-backend-dir", "nvram-backend-file"(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")? \], "version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then
 	echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-capabilities:"
 	echo "Actual   : ${msg}"

--- a/tests/test_ctrlchannel3
+++ b/tests/test_ctrlchannel3
@@ -55,6 +55,11 @@ if [ $res -ne 0 ]; then
 	exit 1
 fi
 
+if wait_process_gone ${PID} 4; then
+	echo "Error: TPM should not be running anymore."
+	exit 1
+fi
+
 echo "OK"
 
 exit 0

--- a/tests/test_ctrlchannel3
+++ b/tests/test_ctrlchannel3
@@ -10,56 +10,132 @@ SWTPM_CTRL_UNIX_PATH=$TPMDIR/sock
 PID_FILE=$TPMDIR/swtpm.pid
 LOG_FILE=$TPMDIR/swtpm.log
 
-source ${TESTDIR}/test_common
+SWTPM_SERVER_PORT=65472
+SWTPM_CTRL_PORT=65473
+
+source "${TESTDIR}/test_common"
 
 trap "cleanup" SIGTERM EXIT
 
 function cleanup()
 {
-	rm -rf $TPMDIR
-	if [ -n "$PID" ]; then
-		kill_quiet -SIGTERM $PID 2>/dev/null
+	rm -rf "${TPMDIR}"
+	if [ -n "${SWTPM_PID}" ]; then
+		kill_quiet -SIGTERM "${SWTPM_PID}" 2>/dev/null
 	fi
 }
 
-source ${TESTDIR}/common
+source "${TESTDIR}/common"
 skip_test_no_tpm12 "${SWTPM_EXE}"
+
 
 if ! [[ "$(uname -s)" =~ Linux ]]; then
 	echo "Need Linux to run UnixIO test for CMD_SET_DATAFD."
-	exit 77
+	echo "Test 1: Skipped"
+else
+
+	# Test CMD_SET_DATAFD
+	cp "${TESTDIR}/data/tpmstate1/"* "${TPMDIR}"
+	$SWTPM_EXE socket \
+		--flags not-need-init \
+		--ctrl "type=unixio,path=${SWTPM_CTRL_UNIX_PATH}" \
+		--tpmstate dir="${TPMDIR}" \
+		-t \
+		--pid "file=${PID_FILE}" \
+		--log "file=${LOG_FILE},level=20" \
+		${SWTPM_TEST_SECCOMP_OPT} &
+	SWTPM_PID=$!
+
+	if wait_for_file "${PID_FILE}" 3; then
+		echo "Error: Socket TPM did not write pidfile."
+		exit 1
+	fi
+
+	LOG=$(SOCK_PATH=${SWTPM_CTRL_UNIX_PATH} exec "${TESTDIR}/test_setdatafd.py")
+	res=$?
+
+	if [ $res -ne 0 ]; then
+		echo "Error: CMD_SET_DATAFD failed: $LOG"
+		exit 1
+	fi
+
+	if wait_process_gone ${SWTPM_PID} 4; then
+		echo "Error: TPM should not be running anymore after data channel loss."
+		exit 1
+	fi
+
+	echo "Test 1: OK"
 fi
 
-# Test CMD_SET_DATAFD
-cp ${TESTDIR}/data/tpmstate1/* ${TPMDIR}
-$SWTPM_EXE socket \
-	--flags not-need-init \
-	--ctrl type=unixio,path=$SWTPM_CTRL_UNIX_PATH \
-	--tpmstate dir=$TPMDIR \
-	-t \
-	--pid file=$PID_FILE \
-	--log file=$LOG_FILE,level=20 \
-	${SWTPM_TEST_SECCOMP_OPT} &
-PID=$!
+# Test that loss of control channel terminates swtpm
 
-if wait_for_file $PID_FILE 3; then
+$SWTPM_EXE socket \
+	--ctrl "type=unixio,path=${SWTPM_CTRL_UNIX_PATH},terminate" \
+	--server "type=tcp,port=${SWTPM_SERVER_PORT}" \
+	--tpmstate "dir=${TPMDIR}" \
+	--pid "file=${PID_FILE}" \
+	${SWTPM_TEST_SECCOMP_OPT} &
+SWTPM_PID=$!
+
+if wait_for_file "${PID_FILE}" 3; then
 	echo "Error: Socket TPM did not write pidfile."
 	exit 1
 fi
 
-LOG=$(SOCK_PATH=$SWTPM_CTRL_UNIX_PATH exec $TESTDIR/test_setdatafd.py)
-res=$?
+# Opening the data socket must NOT terminate it
+exec 100<>/dev/tcp/127.0.0.1/${SWTPM_SERVER_PORT}
+exec 100>&-
+sleep 1
 
-if [ $res -ne 0 ]; then
-	echo "Error: CMD_SET_DATAFD failed: $LOG"
+if ! kill -0 "${SWTPM_PID}"; then
+	echo "Error: Opening and closing data channel must not have terminated swtpm"
 	exit 1
 fi
 
-if wait_process_gone ${PID} 4; then
-	echo "Error: TPM should not be running anymore."
+if ! socat -T1 - "UNIX-CONNECT:${SWTPM_CTRL_UNIX_PATH}"; then
+	echo "Error: Socat failed"
 	exit 1
 fi
 
-echo "OK"
+if wait_process_gone "${SWTPM_PID}" 4; then
+	echo "Error: TPM should not be running anymore after control channel loss."
+	exit 1
+fi
+
+echo "Test 2: OK"
+
+$SWTPM_EXE socket \
+	--ctrl "type=tcp,port=${SWTPM_CTRL_PORT},terminate" \
+	--server "type=tcp,port=${SWTPM_SERVER_PORT}" \
+	--tpmstate "dir=${TPMDIR}" \
+	--pid "file=${PID_FILE}" \
+	${SWTPM_TEST_SECCOMP_OPT} &
+SWTPM_PID=$!
+
+if wait_for_file "${PID_FILE}" 3; then
+	echo "Error: Swtpm did not write pidfile."
+	exit 1
+fi
+
+# Opening the data socket must NOT terminate it
+exec 100<>/dev/tcp/127.0.0.1/${SWTPM_SERVER_PORT}
+exec 100>&-
+sleep 1
+
+if ! kill -0 "${SWTPM_PID}"; then
+	echo "Error: Opening and closing data channel must not have terminated swtpm"
+	exit 1
+fi
+
+# Opening the ctrl socket must be enough to terminate it
+exec 100<>/dev/tcp/127.0.0.1/${SWTPM_CTRL_PORT}
+exec 100>&-
+
+if wait_process_gone "${SWTPM_PID}" 4; then
+	echo "Error: TPM should not be running anymore after control channel loss."
+	exit 1
+fi
+
+echo "Test 3: OK"
 
 exit 0

--- a/tests/test_setdatafd.py
+++ b/tests/test_setdatafd.py
@@ -42,7 +42,7 @@ def test_ReadPCR10(fd):
 
 
 def test_SetDatafd():
-    fd, _fd = socket.socketpair(socket.AF_UNIX, socket.SOCK_DGRAM)
+    fd, _fd = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
     sock_path = os.getenv('SOCK_PATH')
     cmd_set_data_fd = bytearray([0x00, 0x00, 0x00, 0x10])
     expected_res = bytearray([0x00, 0x00, 0x00, 0x00])

--- a/tests/test_tpm2_ctrlchannel3
+++ b/tests/test_tpm2_ctrlchannel3
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+# For the license, see the LICENSE file in the root directory.
+
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+
+TPMDIR="$(mktemp -d)" || exit 1
+SWTPM_CTRL_UNIX_PATH=$TPMDIR/sock
+PID_FILE=$TPMDIR/swtpm.pid
+LOG_FILE=$TPMDIR/swtpm.log
+
+SWTPM_SERVER_PORT=65474
+SWTPM_CTRL_PORT=65475
+
+source "${TESTDIR}/test_common"
+
+trap "cleanup" SIGTERM EXIT
+
+function cleanup()
+{
+	rm -rf "${TPMDIR}"
+	if [ -n "${SWTPM_PID}" ]; then
+		kill_quiet -SIGTERM "${SWTPM_PID}" 2>/dev/null
+	fi
+}
+
+source "${TESTDIR}/common"
+skip_test_no_tpm12 "${SWTPM_EXE}"
+
+
+if ! [[ "$(uname -s)" =~ Linux ]]; then
+	echo "Need Linux to run UnixIO test for CMD_SET_DATAFD."
+	echo "Test 1: Skipped"
+else
+
+	# Test CMD_SET_DATAFD
+	cp "${TESTDIR}/data/tpmstate1/"* "${TPMDIR}"
+	$SWTPM_EXE socket \
+		--tpm2 \
+		--flags not-need-init \
+		--ctrl "type=unixio,path=${SWTPM_CTRL_UNIX_PATH}" \
+		--tpmstate dir="${TPMDIR}" \
+		-t \
+		--pid "file=${PID_FILE}" \
+		--log "file=${LOG_FILE},level=20" \
+		${SWTPM_TEST_SECCOMP_OPT} &
+	SWTPM_PID=$!
+
+	if wait_for_file "${PID_FILE}" 3; then
+		echo "Error: Socket TPM did not write pidfile."
+		exit 1
+	fi
+
+	LOG=$(SOCK_PATH=${SWTPM_CTRL_UNIX_PATH} exec "${TESTDIR}/test_setdatafd.py" --tpm2)
+	res=$?
+
+	if [ $res -ne 0 ]; then
+		echo "Error: CMD_SET_DATAFD failed: $LOG"
+		exit 1
+	fi
+
+	if wait_process_gone ${SWTPM_PID} 4; then
+		echo "Error: TPM should not be running anymore after data channel loss."
+		exit 1
+	fi
+
+	echo "Test 1: OK"
+fi
+
+# Test that loss of control channel terminates swtpm
+
+$SWTPM_EXE socket \
+	--tpm2 \
+	--ctrl "type=unixio,path=${SWTPM_CTRL_UNIX_PATH},terminate" \
+	--server "type=tcp,port=${SWTPM_SERVER_PORT}" \
+	--tpmstate "dir=${TPMDIR}" \
+	--pid "file=${PID_FILE}" \
+	${SWTPM_TEST_SECCOMP_OPT} &
+SWTPM_PID=$!
+
+if wait_for_file "${PID_FILE}" 3; then
+	echo "Error: Socket TPM did not write pidfile."
+	exit 1
+fi
+
+# Opening the data socket must NOT terminate it
+exec 100<>/dev/tcp/127.0.0.1/${SWTPM_SERVER_PORT}
+exec 100>&-
+sleep 1
+
+if ! kill -0 "${SWTPM_PID}"; then
+	echo "Error: Opening and closing data channel must not have terminated swtpm"
+	exit 1
+fi
+
+if ! socat -T1 - "UNIX-CONNECT:${SWTPM_CTRL_UNIX_PATH}"; then
+	echo "Error: Socat failed"
+	exit 1
+fi
+
+if wait_process_gone "${SWTPM_PID}" 4; then
+	echo "Error: TPM should not be running anymore after control channel loss."
+	exit 1
+fi
+
+echo "Test 2: OK"
+
+$SWTPM_EXE socket \
+	--tpm2 \
+	--ctrl "type=tcp,port=${SWTPM_CTRL_PORT},terminate" \
+	--server "type=tcp,port=${SWTPM_SERVER_PORT}" \
+	--tpmstate "dir=${TPMDIR}" \
+	--pid "file=${PID_FILE}" \
+	${SWTPM_TEST_SECCOMP_OPT} &
+SWTPM_PID=$!
+
+if wait_for_file "${PID_FILE}" 3; then
+	echo "Error: Swtpm did not write pidfile."
+	exit 1
+fi
+
+# Opening the data socket must NOT terminate it
+exec 100<>/dev/tcp/127.0.0.1/${SWTPM_SERVER_PORT}
+exec 100>&-
+sleep 1
+
+if ! kill -0 "${SWTPM_PID}"; then
+	echo "Error: Opening and closing data channel must not have terminated swtpm"
+	exit 1
+fi
+
+# Opening the ctrl socket must be enough to terminate it
+exec 100<>/dev/tcp/127.0.0.1/${SWTPM_CTRL_PORT}
+exec 100>&-
+
+if wait_process_gone "${SWTPM_PID}" 4; then
+	echo "Error: TPM should not be running anymore after control channel loss."
+	exit 1
+fi
+
+echo "Test 3: OK"
+
+exit 0


### PR DESCRIPTION
This PR adds support to swtpm upon loss of the control channel connection.

A swtpm command line may now look like this to enable automatic shutdown upon 
data channel connection loss (stream sockets, e.g. TCP) and Unix control channel:

```
swtpm socket \
    --tpmstate dir=/tmp/mytpm1
    --ctrl type=unixio,path=/tmp/mytpm1/swtpm-sock,terminate \
    --terminate \
    --tpm2 \
    --flags not-need-init
```