### PR TITLE
tests: Pass --verify-profile=medium to certtool if supported

### DIFF
--- a/tests/test_tpm2_swtpm_localca
+++ b/tests/test_tpm2_swtpm_localca
@@ -24,6 +24,10 @@ PATH=${TOPBUILD}/src/swtpm_cert:$PATH
 
 source ${TESTDIR}/common
 
+if [ -n "$(${CERTTOOL} --help | grep -E "\-\-verify-profile")" ]; then
+	verify_profile="--verify-profile=medium"
+fi
+
 trap "cleanup" SIGTERM EXIT
 
 function cleanup()
@@ -125,6 +129,7 @@ do
 
   ${CERTTOOL} \
     --verify \
+    ${verify_profile} \
     --load-ca-certificate "${ISSUERCERT}" \
     --infile "${workdir}/ek.pem"
   if [ $? -ne 0 ]; then

--- a/tests/test_tpm2_swtpm_localca_pkcs11.test
+++ b/tests/test_tpm2_swtpm_localca_pkcs11.test
@@ -35,6 +35,10 @@ PATH=${TOPBUILD}/src/swtpm_cert:$PATH
 
 source ${TESTDIR}/common
 
+if [ -n "$(${CERTTOOL} --help | grep -E "\-\-verify-profile")" ]; then
+	verify_profile="--verify-profile=medium"
+fi
+
 trap "cleanup" SIGTERM EXIT
 
 function cleanup()
@@ -214,6 +218,7 @@ do
 
   GNUTLS_PIN=${PIN} ${CERTTOOL} \
     --verify \
+    ${verify_profile} \
     --load-ca-certificate ${ISSUERCERT} \
     --infile ${workdir}/ek.pem
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
certtool emits the following message if --verify-profile is not passed:

Note that no verification profile was selected. In the future the medium profile will be enabled by default. Use --verify-profile low to apply the default verification of NORMAL priority string.

Pass the --verify-profile option if certtool supports it (since ~3.6.12).

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>