### PR TITLE
swtpm.spec: Reflect minimal gnutls version

### DIFF
--- a/swtpm.spec
+++ b/swtpm.spec
@@ -29,7 +29,7 @@ BuildRequires:  softhsm
 BuildRequires:  trousers >= 0.3.9
 %endif
 %if %{with gnutls}
-BuildRequires:  gnutls >= 3.1.0
+BuildRequires:  gnutls >= 3.4.0
 BuildRequires:  gnutls-devel
 BuildRequires:  gnutls-utils
 BuildRequires:  libtasn1-devel

--- a/swtpm.spec.in
+++ b/swtpm.spec.in
@@ -29,7 +29,7 @@ BuildRequires:  softhsm
 BuildRequires:  trousers >= 0.3.9
 %endif
 %if %{with gnutls}
-BuildRequires:  gnutls >= 3.1.0
+BuildRequires:  gnutls >= 3.4.0
 BuildRequires:  gnutls-devel
 BuildRequires:  gnutls-utils
 BuildRequires:  libtasn1-devel


### PR DESCRIPTION
The configure script requires at least gnutls-3.4.0 but this is not reflected in the spec file.

Signed-off-by: Michal Privoznik <mprivozn@redhat.com>