### PR TITLE
swtpm: Restore logging to stderr on log open failure

### DIFF
--- a/src/swtpm/logging.c
+++ b/src/swtpm/logging.c
@@ -91,8 +91,10 @@ int log_init(const char *filename, bool truncate)
     }
 
     logfd = open(filename, flags, S_IRUSR|S_IWUSR);
-    if (logfd < 0)
+    if (logfd < 0) {
+        logfd = CONSOLE_LOGGING;
         return -1;
+    }
 
     log_prefix_clear();
 


### PR DESCRIPTION
When opening a log file fails (--log file=/some/path) for whatever reason the @logfd variable is left set to -1 (the retval of open()). And due to how _logprintf() is written, the subsequent attempt to log this failure (logprintf()) returns too early not printing the useful error.

Therefore, restore the original (CONSOLE_LOGGING) value.

Signed-off-by: Michal Privoznik <mprivozn@redhat.com>