### PR TITLE
Couple of trivial fixes

### DIFF
--- a/man/man8/Makefile.am
+++ b/man/man8/Makefile.am
@@ -24,8 +24,12 @@ man8_generated_MANS = \
 	swtpm-create-tpmca.8
 
 man8_static_MANS = \
-	swtpm_cuse.8 \
 	swtpm-localca.8
+
+if WITH_CUSE
+man8_static_MANS += \
+	swtpm_cuse.8
+endif
 
 man8_MANS = \
 	$(man8_generated_MANS) \
@@ -38,5 +42,9 @@ man8_MANS = \
 		--section=8 $< > $@
 
 EXTRA_DIST = $(man8_static_MANS) $(man8_PODS)
+if !WITH_CUSE
+EXTRA_DIST += \
+	swtpm_cuse.8
+endif
 
 CLEANFILES = $(man8_generated_MANS)

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -937,7 +937,7 @@ static int get_swtpm_capabilities(gchar **swtpm_prg_l, gboolean is_tpm2,
     gchar *my_argv[] = { "--print-capabilities", is_tpm2 ? "--tpm2" : NULL, NULL };
     g_autofree gchar *logop = NULL;
     g_autoptr(GError) error = NULL;
-    g_autofree gchar **argv;
+    g_autofree gchar **argv = NULL;
     int exit_status = 0;
     gboolean success;
     int ret = 1;


### PR DESCRIPTION
These stem mostly from what fedora's spec file is doing. Except for the swtpm_cuse man page. Handling the installation of the file properly benefits other distros as well.