### PR TITLE
tests: Fix shellcheck issue SC2115 by using "${var:?}"

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -240,9 +240,8 @@ syntax-check:
 # SC2001: See if you can use ${variable//search/replace} instead.
 # SC2009: Consider using pgrep instead of grepping ps output.
 # Sc2010: Don't use ls | grep. Use a glob or a for loop with a condition to allow non-alphanumeric filenames.
-# SC2115: Use "${var:?}" to ensure this never expands to /*.
 # SC2148: Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.
-	shellcheck -e SC2001,SC2009,SC2010,SC2115,SC2148 \
+	shellcheck -e SC2001,SC2009,SC2010,SC2148 \
 		$(TESTS) $(TEST_UTILS) $(filter _test_%,$(EXTRA_DIST))
 
 check: check-am check-display

--- a/tests/test_parameters
+++ b/tests/test_parameters
@@ -86,7 +86,7 @@ function cleanup()
 PATH=$PATH:$PWD
 
 for (( i=0; i<${#PARAMETERS[*]}; i++)); do
-	rm -rf "$TPMDIR"/*
+	rm -rf "${TPMDIR:?}"/*
 	echo -n "Test $i: "
 	params=${PARAMETERS[$i]}
 	if ! $TPMAUTHORING \

--- a/tests/test_samples_create_tpmca
+++ b/tests/test_samples_create_tpmca
@@ -92,7 +92,7 @@ function run_test() {
 
 	local params certinfo regex regexs fil i skip
 
-	rm -rf "${workdir}"/*
+	rm -rf "${workdir:?}"/*
 
 	cat <<_EOF_ > "${workdir}/swtpm_setup.conf"
 create_certs_tool=${SWTPM_LOCALCA}

--- a/tests/test_tpm2_parameters
+++ b/tests/test_tpm2_parameters
@@ -91,7 +91,7 @@ fi
 PATH=$PATH:$TESTDIR
 
 for (( i=0; i<${#PARAMETERS[*]}; i++)); do
-	rm -rf "$TPMDIR"/*
+	rm -rf "${TPMDIR:?}"/*
 	echo -n "Test $i: "
 	params=${PARAMETERS[$i]}
 	if ! $TPMAUTHORING \

--- a/tests/test_tpm2_samples_create_tpmca.test
+++ b/tests/test_tpm2_samples_create_tpmca.test
@@ -94,7 +94,7 @@ function run_test() {
 
 	local tmp params certinfo regex regexs fil i skip
 
-	rm -rf "${workdir}"/*
+	rm -rf "${workdir:?}"/*
 
 	cat <<_EOF_ > "${workdir}/swtpm_setup.conf"
 create_certs_tool=${SWTPM_LOCALCA}


### PR DESCRIPTION
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>