### PR TITLE
Travis: Update from focal to jammy and from bionic to focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
   - secure: mcAXlw5k/1yOP2RMKWEtvU2SnsuHo5Idoi5zZ+hLj2CzdvT77Wh8HWQ7NRsiamL+3dMPxzzy60IYNZQ8F29y3rvN7gASVsYn31G5UkmfvpPLiucuPADM1rNm8FYNlia0GFW4keP+LwMrBo6KDK9k0T8w4lquXBwMmNzhvCYVwkBIM5YwhXW5nk1dOJtf6zAb6gDH/VNEYTXXRKjA5Jvln7+EVHY61pEx6rJGa2GU0A49ms5UMJVzv85FraiHwlCPnNhQWGJ6sStqxsd5i6VBTCrkwMqnnA+ZBosqIJkBXp4OkudfPWE9vsn7TtuYdbheOkUIv6GRPFJNG3Vm3Wh/IwvSOILS5xAmsB3MxyK3BlILOYcsywiSzV5J4+s5Vnih4FaRQ3xx46Fq2ldatuk7npIxfdd3Co5V1KZh1pq3ckAdKlY2PEsQc0Kh72Lxf2N0XVw4s0H7gzrFk4/ghIvoCmAWBRSrN+R7wleEcmxDRgUZHP6Qc2ZNP+kljhBLqzinW2jyxPAqQS17g5Tb01+WfqkG/T5jboyIIe/OEQ5XbQp3/d8rUA8STpJxD25lwKKqlIqU3ZFWYfRT+pA0x83AdiTm53CJSQqFyCLtZCqK0XSZbLfmFzjZJ7I8FQxZoF2o03DDkL1Xs0z0sj87i3UnsYzxGdSrcU2JDK7qRIn39sM=
 sudo: required
 language: c
-dist: bionic
+dist: focal
 addons:
   apt:
       packages:
@@ -30,6 +30,7 @@ addons:
         - gnutls-bin
         - softhsm2
         - libseccomp-dev
+        - tss2
   coverity_scan:
     project:
       name: swtpm
@@ -77,7 +78,7 @@ matrix:
            CONFIG="--with-openssl --prefix=${PREFIX}"
            CHECK="distcheck"
            RUN_TEST="1"
-    - dist: focal
+    - dist: jammy
       env: PREFIX="/usr"
            CONFIG="--with-openssl --prefix=/usr --enable-test-coverage"
            SUDO="sudo"
@@ -85,7 +86,7 @@ matrix:
            SWTPM_TEST_IBMTSS2="1"
            SWTPM_TEST_STORE_VOLATILE="1"
       before_script:
-      - sudo apt-get -y install tss2
+      - sudo apt-get -y install libtpm2-pkcs11-tools
       - sudo pip install cpp-coveralls
       - p=$PWD; while [ "$PWD" != "/" ]; do chmod o+x . &>/dev/null ; cd .. ; done; cd $p
         && sudo mkdir src/swtpm/.libs


### PR DESCRIPTION
Since the tss2 package is commonly available in focal and jammy move it into to the general list of packages to installed.

libtpm2-pkcs11-tools is available since jammy, so installed it there to enable the TPM 2 pkcs11 tests.