### PR TITLE
Use PKG_CHECK_MODULES to check libtpms version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -176,16 +176,12 @@ AC_SUBST([LIBTASN1_LIBS])
 
 PKG_CHECK_MODULES(
 	[LIBTPMS],
-	[libtpms],
+	[libtpms >= 0.6],
 	,
-	AC_MSG_ERROR("no libtpms.pc found; please set PKG_CONFIG_PATH to the directory where libtpms.pc is located")
+	AC_MSG_ERROR("libtpms >= 0.6 required or no libtpms.pc found; please set PKG_CONFIG_PATH to the directory where libtpms.pc is located")
 )
 LDFLAGS="$LDFLAGS $LIBTPMS_LIBS"
 CFLAGS="$CFLAGS $LIBTPMS_CFLAGS"
-AC_CHECK_LIB(tpms,
-             TPMLIB_ChooseTPMVersion,[true],
-             AC_MSG_ERROR("libtpms 0.6 or later is required")
-)
 AC_SUBST([LIBTPMS_LIBS])
 
 AC_CHECK_LIB(c, clock_gettime, LIBRT_LIBS="", LIBRT_LIBS="-lrt")


### PR DESCRIPTION
`PKG_CHECK_MODULES` allows to check the library version (https://autotools.info/pkgconfig/pkg_check_modules.html - section 3.3), so there should be no need for the `AC_CHECK_LIB` call below it.

I was messing with macros in `TPMBuildSwitches.h` and would run into configure failing on https://github.com/stefanberger/swtpm/blob/459f4e7dea7320b2691dc6c69eb19a51787786fc/configure.ac#L185

libtpms was at `0.9.5` and `TPMLIB_ChooseTPMVersion` was present in `libtpms.so.*`. So that message was a little misleading.
I also found that with removing the `AC_CHECK_LIB` for `TPMLIB_ChooseTPMVersion`, the make process would tell me explicitly where an issue was. I had an undefined reference to either a variable or a function.