### PR TITLE
tests: ibmtss2: Add patch to disable x509 test with older libtpms

### DIFF
--- a/tests/patches/0001-Deactivate-test-cases-accessing-rootcerts.txt.patch
+++ b/tests/patches/0001-Deactivate-test-cases-accessing-rootcerts.txt.patch
@@ -1,7 +1,7 @@
-From 703166812b8090669a0dd6f349eca97dec513fe4 Mon Sep 17 00:00:00 2001
+From 8c8ee0c35ca58afb74a11cf6e8753b3711bfc4b2 Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Fri, 26 Feb 2021 18:45:57 -0500
-Subject: [PATCH 01/12] Deactivate test cases accessing rootcerts.txt
+Subject: [PATCH 01/13] Deactivate test cases accessing rootcerts.txt
 
 rootcerts.txt contains files in a drive we don't have access to
 ---

--- a/tests/patches/0002-Implement-powerup-for-swtpm.patch
+++ b/tests/patches/0002-Implement-powerup-for-swtpm.patch
@@ -1,7 +1,7 @@
-From 6dd4bd7247a6ab0f02c69f5f495cf299c5c8702f Mon Sep 17 00:00:00 2001
+From 8162afd2316d2a374447a0e620d18cf5021d4fdb Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Sun, 28 Feb 2021 16:39:51 -0500
-Subject: [PATCH 02/12] Implement powerup for swtpm
+Subject: [PATCH 02/13] Implement powerup for swtpm
 
 ---
  utils/reg.sh                   | 12 ++++++++++++

--- a/tests/patches/0003-Set-CRYPTOLIBRARY-to-openssl.patch
+++ b/tests/patches/0003-Set-CRYPTOLIBRARY-to-openssl.patch
@@ -1,7 +1,7 @@
-From a3feeb63145506e3d77be99e1dd214247ebabe1a Mon Sep 17 00:00:00 2001
+From 5c20ae7439608644d66ead780c76aa2890f9fcd1 Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Sun, 28 Feb 2021 16:35:56 -0500
-Subject: [PATCH 03/12] Set CRYPTOLIBRARY to openssl
+Subject: [PATCH 03/13] Set CRYPTOLIBRARY to openssl
 
 ---
  utils/reg.sh | 2 +-

--- a/tests/patches/0004-Store-and-restore-volatile-state-at-every-step.patch
+++ b/tests/patches/0004-Store-and-restore-volatile-state-at-every-step.patch
@@ -1,7 +1,7 @@
-From fe645b76d6eee78c4e7bce3a422be10f42abb757 Mon Sep 17 00:00:00 2001
+From 85c5c7576c9e10f5b7c37573311aaf96353eee07 Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Sun, 28 Feb 2021 16:42:11 -0500
-Subject: [PATCH 04/12] Store and restore volatile state at every step
+Subject: [PATCH 04/13] Store and restore volatile state at every step
 
 ---
  utils/reg.sh | 14 +++++++++++++-

--- a/tests/patches/0005-Disable-tests-related-to-events.patch
+++ b/tests/patches/0005-Disable-tests-related-to-events.patch
@@ -1,7 +1,7 @@
-From 0ada56485cca1b6f9e6c5fa9c79f07682fc86c46 Mon Sep 17 00:00:00 2001
+From 0c129c17aad8114f5b03ee5b9cd03b0e2a5e9dc6 Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Sun, 28 Feb 2021 16:33:02 -0500
-Subject: [PATCH 05/12] Disable tests related to 'events'
+Subject: [PATCH 05/13] Disable tests related to 'events'
 
 ---
  utils/regtests/testevent.sh | 1 +

--- a/tests/patches/0006-Disable-testing-with-RSA-3072.patch
+++ b/tests/patches/0006-Disable-testing-with-RSA-3072.patch
@@ -1,7 +1,7 @@
-From 9ef419cfb2f0b47a6d4fb989c18f401b06dad1fe Mon Sep 17 00:00:00 2001
+From d49c9dbdeb62a1e04cc427d559a5c5bb66dba3d3 Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Sun, 28 Feb 2021 16:35:02 -0500
-Subject: [PATCH 06/12] Disable testing with RSA 3072
+Subject: [PATCH 06/13] Disable testing with RSA 3072
 
 ---
  utils/reg.sh                       |  2 +-

--- a/tests/patches/0007-Disable-rev155-test-cases.patch
+++ b/tests/patches/0007-Disable-rev155-test-cases.patch
@@ -1,7 +1,7 @@
-From 8c5314c6de0853d0b1e29d08ddbd998e4e4f3a60 Mon Sep 17 00:00:00 2001
+From 85a7cdc22a6a7d8ad7788e0b074ab05071521cae Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Sun, 28 Feb 2021 16:36:53 -0500
-Subject: [PATCH 07/12] Disable rev155 test cases
+Subject: [PATCH 07/13] Disable rev155 test cases
 
 ---
  utils/regtests/testattest155.sh | 1 +

--- a/tests/patches/0008-Disable-x509-test-cases.patch
+++ b/tests/patches/0008-Disable-x509-test-cases.patch
@@ -1,7 +1,7 @@
-From 0f1f04cef51f4e72807980e21c17d06b3a9995a7 Mon Sep 17 00:00:00 2001
+From 737f062890fff5b97e0e704da76886738339422c Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Sun, 28 Feb 2021 16:37:27 -0500
-Subject: [PATCH 08/12] Disable x509 test cases
+Subject: [PATCH 08/13] Disable x509 test cases
 
 ---
  utils/regtests/testx509.sh | 1 +

--- a/tests/patches/0009-Disable-getcapability-TPM_CAP_ACT.patch
+++ b/tests/patches/0009-Disable-getcapability-TPM_CAP_ACT.patch
@@ -1,7 +1,7 @@
-From c8c3ea92b9797d743f993bade0196150e26b4c28 Mon Sep 17 00:00:00 2001
+From bcfe5f203d7a5c1e298ea5674268b3174fa67f31 Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Sun, 28 Feb 2021 16:38:10 -0500
-Subject: [PATCH 09/12] Disable getcapability TPM_CAP_ACT
+Subject: [PATCH 09/13] Disable getcapability TPM_CAP_ACT
 
 ---
  utils/regtests/testgetcap.sh | 6 +++---

--- a/tests/patches/0010-Adjust-test-cases-for-OpenSSL-3.patch
+++ b/tests/patches/0010-Adjust-test-cases-for-OpenSSL-3.patch
@@ -1,7 +1,7 @@
-From e50f9f4a05a6a255dd94808792ff33f3ccc9894d Mon Sep 17 00:00:00 2001
+From 2214b96d5110f955b89434d7add749fc3fb8a6e7 Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.ibm.com>
 Date: Tue, 3 May 2022 10:26:06 -0400
-Subject: [PATCH 10/12] Adjust test cases for OpenSSL 3
+Subject: [PATCH 10/13] Adjust test cases for OpenSSL 3
 
 1) Some openssl command lines need -traditional when converting a key
    from PEM to DER format.
@@ -21,7 +21,7 @@ TSS_RC_X509_ERROR - X509 parse error
  1 file changed, 56 insertions(+), 53 deletions(-)
 
 diff --git a/utils/regtests/testx509.sh b/utils/regtests/testx509.sh
-index 03650fe..54b0b56 100755
+index 03650fe..80fc946 100755
 --- a/utils/regtests/testx509.sh
 +++ b/utils/regtests/testx509.sh
 @@ -69,9 +69,9 @@ do

--- a/tests/patches/0011-Disable-ECC-encrypt-decrypt-tests.patch
+++ b/tests/patches/0011-Disable-ECC-encrypt-decrypt-tests.patch
@@ -1,12 +1,12 @@
-From b5787bd7b31da92a1315596b05ccc73e810ebb15 Mon Sep 17 00:00:00 2001
+From 3f317377839f13a6e9875ef63a7c5e824178f909 Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.ibm.com>
 Date: Wed, 10 May 2023 16:10:02 -0400
-Subject: [PATCH 11/12] Disable ECC encrypt/decrypt tests
+Subject: [PATCH 11/13] Disable ECC encrypt/decrypt tests
 
 ---
  utils/regtests/testecc.sh  | 2 +-
- utils/regtests/testhelp.sh | 4 ++--
- 2 files changed, 3 insertions(+), 3 deletions(-)
+ utils/regtests/testhelp.sh | 4 +++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/utils/regtests/testecc.sh b/utils/regtests/testecc.sh
 index f787597..1b78214 100755
@@ -22,16 +22,15 @@ index f787597..1b78214 100755
  
      echo "create an ECC ${CURVE} decryption key"
 diff --git a/utils/regtests/testhelp.sh b/utils/regtests/testhelp.sh
-index 520d422..40dff0f 100755
+index 520d422..cc8ad56 100755
 --- a/utils/regtests/testhelp.sh
 +++ b/utils/regtests/testhelp.sh
-@@ -6967,14 +6967,14 @@ echo ""
- echo "policycommandcode"
- echo ""
+@@ -6969,12 +6969,14 @@ echo ""
  
--for CC in 11f 120 121 122 124 125 126 127 128 129 12a 12b 12c 12d 12e 130 131 132 133 134 135 136 137 138 139 13a 13b 13c 13d 13e 13f 140 142 143 144 145 146 147 148 149 14a 14b 14c 14d 14e 14f 150 151 152 153 154 155 156 157 158 159 15b 15c 15d 15e 160 161 162 163 164 165 167 168 169 16a 16b 16c 16d 16e 16f 170 171 172 173 174 176 177 178 17a 17b 17c 17d 17e 17f 180 181 182 183 184 185 186 187 188 189 18a 18b 18c 18d 18e 18f 190 191 192 193 197 199 19A
-+for CC in 11f 120 121 122 124 125 126 127 128 129 12a 12b 12c 12d 12e 130 131 132 133 134 135 136 137 138 139 13a 13b 13c 13d 13e 13f 140 142 143 144 145 146 147 148 149 14a 14b 14c 14d 14e 14f 150 151 152 153 154 155 156 157 158 159 15b 15c 15d 15e 160 161 162 163 164 165 167 168 169 16a 16b 16d 16e 16f 170 171 172 173 174 176 177 178 17a 17b 17c 17d 17e 17f 180 181 182 183 184 185 186 187 188 189 18a 18b 18c 18d 18e 18f 191 192 193 197
+ for CC in 11f 120 121 122 124 125 126 127 128 129 12a 12b 12c 12d 12e 130 131 132 133 134 135 136 137 138 139 13a 13b 13c 13d 13e 13f 140 142 143 144 145 146 147 148 149 14a 14b 14c 14d 14e 14f 150 151 152 153 154 155 156 157 158 159 15b 15c 15d 15e 160 161 162 163 164 165 167 168 169 16a 16b 16c 16d 16e 16f 170 171 172 173 174 176 177 178 17a 17b 17c 17d 17e 17f 180 181 182 183 184 185 186 187 188 189 18a 18b 18c 18d 18e 18f 190 191 192 193 197 199 19A
  do
++    # skip all EC Encrypt/Decrypt commands
++    [[ ${CC} =~ ^(16c|190|199|19A)$ ]] && continue
  
      echo "startauthsession"
      ${PREFIX}startauthsession -se p > run.out

--- a/tests/patches/0012-Disable-Nuvoton-commands.patch
+++ b/tests/patches/0012-Disable-Nuvoton-commands.patch
@@ -1,7 +1,7 @@
-From d7ea9b0e0e4be46e367c9116617b33ce399a3601 Mon Sep 17 00:00:00 2001
+From 2902b8dffe585361362d3beee0771cd6bb571bc2 Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.ibm.com>
 Date: Wed, 10 May 2023 18:17:23 -0400
-Subject: [PATCH 12/12] Disable Nuvoton commands
+Subject: [PATCH 12/13] Disable Nuvoton commands
 
 ---
  utils/regtests/testntc.sh | 2 ++

--- a/tests/patches/0013-Disable-x509-test-cases-part2.patch
+++ b/tests/patches/0013-Disable-x509-test-cases-part2.patch
@@ -1,0 +1,26 @@
+From 2fdd0e84a3ac04cc09e9630b3b825b66ff288340 Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.ibm.com>
+Date: Mon, 15 May 2023 10:32:49 -0400
+Subject: [PATCH 13/13] Disable x509 test cases (part2)
+
+---
+ utils/regtests/testhelp.sh | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/utils/regtests/testhelp.sh b/utils/regtests/testhelp.sh
+index cc8ad56..33f8ad0 100755
+--- a/utils/regtests/testhelp.sh
++++ b/utils/regtests/testhelp.sh
+@@ -6972,6 +6972,9 @@ do
+     # skip all EC Encrypt/Decrypt commands
+     [[ ${CC} =~ ^(16c|190|199|19A)$ ]] && continue
+ 
++    # disable CC_CertifyX509 related tests
++    [[ ${CC} =~ ^(197|19A)$ ]] && continue
++
+     echo "startauthsession"
+     ${PREFIX}startauthsession -se p > run.out
+     checkSuccess $?
+-- 
+2.39.1
+

--- a/tests/test_tpm2_ibmtss2
+++ b/tests/test_tpm2_ibmtss2
@@ -102,6 +102,7 @@ if [ "$revision" -lt 155 ]; then
 	git am < "${PATCHESDIR}/0007-Disable-rev155-test-cases.patch"
 	git am < "${PATCHESDIR}/0008-Disable-x509-test-cases.patch"
 	git am < "${PATCHESDIR}/0009-Disable-getcapability-TPM_CAP_ACT.patch"
+	git am < "${PATCHESDIR}/0013-Disable-x509-test-cases-part2.patch"
 fi
 
 if openssl version | grep -q -E "^OpenSSL 3"; then


### PR DESCRIPTION
Older versions of libtpms need to have another patch applied that disables x509 certificate creation (0013-Disable-x509-test-cases-part2.patch).