### PR TITLE
swtpm_setup: Close file descriptors passed to swtpm process on parent…

### DIFF
--- a/src/utils/swtpm_utils.h
+++ b/src/utils/swtpm_utils.h
@@ -17,6 +17,12 @@
 #define min(X,Y) ((X) < (Y) ? (X) : (Y))
 #define ARRAY_LEN(a) (sizeof(a) / sizeof((a)[0]))
 
+#define SWTPM_CLOSE(FD)	\
+    if ((FD) >= 0) {	\
+        close((FD));	\
+        (FD) = -1;	\
+    }
+
 extern gchar *gl_LOGFILE;
 
 void append_to_file(const char *pathname, const char *str);


### PR DESCRIPTION
… side

Close the file descriptors passed to the swtpm process on the parent side for faster detection of errors in the swtpm process that can occur if swtpm was passed a profile that it cannot run with.