### PR TITLE
swtpm_setup: Exit with '0' upon --version rather than '1'.

### DIFF
--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -1387,7 +1387,7 @@ int main(int argc, char *argv[])
         case '1': /* --version */
             versioninfo();
             ret = 0;
-            goto error;
+            goto out;
         case 'y': /* --print-capabilities */
             printcapabilities = TRUE;
             break;


### PR DESCRIPTION
The --version option was using the wrong goto label error rather than out to now also exit with exitcode 0.