### PR TITLE
Make stdout unbuffered in swtpm_{setup,localca}

### DIFF
--- a/src/swtpm_localca/swtpm_localca.c
+++ b/src/swtpm_localca/swtpm_localca.c
@@ -611,6 +611,8 @@ int main(int argc, char *argv[])
     struct stat statbuf;
     int ret = 1;
 
+    setvbuf(stdout, 0, _IONBF, 0);
+
     if (init(&default_options_file, &default_config_file) < 0)
         goto error;
     optsfile = g_strdup(default_options_file);

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -1230,6 +1230,8 @@ int main(int argc, char *argv[])
     int ret = 1;
     g_autoptr(GError) error = NULL;
 
+    setvbuf(stdout, 0, _IONBF, 0);
+
     if (init(&config_file) < 0)
         goto error;
 


### PR DESCRIPTION
swtpm_setup and swtpm_localca may be run by a toolstack with log messages going to a pipe via stdout. Set stdout to be unbuffered to avoid log messages being lost if the process terminates unexpectedly.