### PR TITLE
SELinux: Add rules for sock_file on user_tmp_t and unlink

### DIFF
--- a/src/selinux/swtpm_svirt.te
+++ b/src/selinux/swtpm_svirt.te
@@ -29,5 +29,6 @@ allow svirt_tcg_t virt_var_run_t:sock_file { create setattr };
 allow svirt_tcg_t virt_var_run_t:file { create getattr open read unlink write };
 allow svirt_tcg_t virt_var_run_t:dir { write add_name remove_name };
 allow svirt_tcg_t swtpm_exec_t:file { entrypoint map };
+allow svirt_tcg_t user_tmp_t:sock_file { create setattr };
 # libvirt specific rules needed on F28
 allow svirt_tcg_t virtd_t:unix_stream_socket { read write getopt getattr accept };

--- a/src/selinux/swtpm_svirt.te
+++ b/src/selinux/swtpm_svirt.te
@@ -15,7 +15,7 @@ swtpm_domtrans(svirt_tcg_t)
 #============= svirt_t ==============
 allow svirt_t virtd_t:fifo_file { read write };
 allow svirt_t virtd_t:process sigchld;
-allow svirt_t user_tmp_t:sock_file { create setattr };
+allow svirt_t user_tmp_t:sock_file { create setattr unlink };
 allow svirt_t swtpm_exec_t:file { entrypoint map };
 # libvirt specific rules needed on F28
 allow svirt_t virtd_t:unix_stream_socket { read write getopt getattr accept };
@@ -25,10 +25,10 @@ allow svirt_t virt_var_run_t:file { create getattr open read unlink write };
 allow svirt_t virt_var_run_t:sock_file { create setattr };
 
 allow svirt_tcg_t virtd_t:fifo_file { write read };
-allow svirt_tcg_t virt_var_run_t:sock_file { create setattr };
+allow svirt_tcg_t virt_var_run_t:sock_file { create setattr unlink };
 allow svirt_tcg_t virt_var_run_t:file { create getattr open read unlink write };
 allow svirt_tcg_t virt_var_run_t:dir { write add_name remove_name };
 allow svirt_tcg_t swtpm_exec_t:file { entrypoint map };
-allow svirt_tcg_t user_tmp_t:sock_file { create setattr };
+allow svirt_tcg_t user_tmp_t:sock_file { create setattr unlink };
 # libvirt specific rules needed on F28
 allow svirt_tcg_t virtd_t:unix_stream_socket { read write getopt getattr accept };


### PR DESCRIPTION
The following command line did not function on an x86_64 host due to missing SELinux rules:

virt-install -v \
 --name fedora-38-aarch64 \
 --ram 4096 \
 --disk path=fedora-38.img,cache=none \
 --nographics \
 --os-variant fedora38 \
 --import \
 --virt-type=qemu \
 --arch aarch64 \
 --check all=off

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2228423

With a memoryBacking node added to the libvirt domain XML, the unlink
permission on user_tmp_t:sockfile becomes necessary to avoid an avc
denial.

```
<currentMemory unit='KiB'>2097152</currentMemory>
<memoryBacking>
  <hugepages>
    <page size='2048' unit='KiB'/>
  </hugepages>
</memoryBacking>
```

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2165142
