### PR TITLE
Revert "utils: Implement find_program() to try BINDIR path before PATH"

### DIFF
--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -39,9 +39,8 @@ Prefix with dir:// to use directory backend, or file:// to use linear file.
 
 =item B<--tpm <path to executable>>
 
-Path to the TPM executable; this is an optional argument and by default the
-swtpm executable found in the installation directory (BINDIR) will be used
-before swtpm is tried to be found in the PATH.
+Path to the TPM executable; this is an optional argument and
+by default the swtpm executable found in the PATH will be used.
 
 =item B<--tpm2>
 

--- a/src/swtpm_localca/swtpm_localca.c
+++ b/src/swtpm_localca/swtpm_localca.c
@@ -401,7 +401,7 @@ static int create_cert(unsigned long flags, const gchar *typ, const gchar *direc
     int ret = 1;
     size_t i, j;
 
-    swtpm_cert_path = find_program("swtpm_cert");
+    swtpm_cert_path = g_find_program_in_path("swtpm_cert");
     if (swtpm_cert_path == NULL) {
         logerr(gl_LOGFILE, "Could not find swtpm_cert in PATH.\n");
         return 1;

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -1277,7 +1277,7 @@ int main(int argc, char *argv[])
     if (init(&config_file) < 0)
         goto error;
 
-    swtpm_prg = find_program("swtpm");
+    swtpm_prg = g_find_program_in_path("swtpm");
     if (swtpm_prg) {
         tmp = g_strconcat(swtpm_prg, " socket", NULL);
         g_free(swtpm_prg);

--- a/src/utils/swtpm_utils.c
+++ b/src/utils/swtpm_utils.c
@@ -22,7 +22,6 @@
 
 #include <glib.h>
 
-#include "swtpm_conf.h"
 #include "swtpm_utils.h"
 
 void append_to_file(const char *pathname, const char *str)
@@ -440,23 +439,4 @@ int check_directory_access(const gchar *directory, int mode, const struct passwd
         return 1;
     }
     return 0;
-}
-
-/* A program that is only described by the name of the executable is searched
- * for in the BINDIR path and only then in $PATH
- */
-gchar *find_program(const gchar *program)
-{
-    g_autofree gchar *dirname = g_path_get_dirname(program);
-    gchar *path;
-
-    if (g_strcmp0(".", dirname) == 0) {
-        path = g_strdup_printf(BINDIR "/%s", program);
-        if (g_file_test(path, G_FILE_TEST_IS_EXECUTABLE))
-            return path;
-
-        g_free(path);
-    }
-
-    return g_find_program_in_path(program);
 }

--- a/src/utils/swtpm_utils.h
+++ b/src/utils/swtpm_utils.h
@@ -55,6 +55,4 @@ gchar *str_replace(const char *in, const char *torep, const char *rep);
 
 int check_directory_access(const gchar *directory, int mode, const struct passwd *curr_user);
 
-gchar *find_program(const gchar *program);
-
 #endif /* SWTPM_UTILS_H */


### PR DESCRIPTION
Test cases using swtpm_localca were failing because swtpm_localca now picked up the swtpm_cert installed in /usr/bin/swtpm_cert rather than the one in the PATH. This revert fixes the issue and users will have to adjust their PATH for out-of-PATH installations.

Resolves: https://github.com/stefanberger/swtpm/issues/829