### PR TITLE
headers: Exclude TPM ioctls definitions for the GNU/Hurd

### DIFF
--- a/include/swtpm/tpm_ioctl.h
+++ b/include/swtpm/tpm_ioctl.h
@@ -276,7 +276,7 @@ typedef struct ptm_lockstorage ptm_lockstorage;
 #define PTM_CAP_SEND_COMMAND_HEADER (1 << 15)
 #define PTM_CAP_LOCK_STORAGE       (1 << 16)
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__GNU__)
 enum {
     PTM_GET_CAPABILITY     = _IOR('P', 0, ptm_cap),
     PTM_INIT               = _IOWR('P', 1, ptm_init),


### PR DESCRIPTION
Follow changes in the QEMU codebase supporting GNU/Hurd.

Reference: https://lists.nongnu.org/archive/html/qemu-devel/2024-01/msg03702.html