### PR TITLE
selinux: Redevelop SELinux policy for Fedora 40 (ditch old rules)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ Makefile
 /src/selinux/*.pp.bz2
 /src/selinux/swtpm.pp
 /src/selinux/swtpm.fc
+/src/selinux/swtpm_libvirt.fc
+/src/selinux/swtpm_libvirt.if
+/src/selinux/swtpm_libvirt.pp
 /src/selinux/swtpm_svirt.fc
 /src/selinux/swtpm_svirt.if
 /src/selinux/swtpm_svirt.pp

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 CHANGES - changes for swtpm
 
+version 0.9.0:
+  - selinux:
+    - New SELinux policy that requires Fedora 40 or later
+
 version 0.8.0:
   - swtpm:
     - Implement release-lock-outgoing parameter for --migration option

--- a/src/selinux/Makefile.am
+++ b/src/selinux/Makefile.am
@@ -8,6 +8,7 @@ policiesconfdir = $(datadir)/selinux/packages
 
 POLICIES = \
 	swtpm.pp \
+	swtpm_libvirt.pp \
 	swtpm_svirt.pp
 
 if WITH_CUSE
@@ -30,6 +31,10 @@ swtpm_svirt.pp_FILES = \
 	$(addprefix $(top_srcdir)/src/selinux/,\
 	  swtpm_svirt.te swtpm.if swtpm.te) \
 	$(top_builddir)/src/selinux/swtpm.fc
+
+swtpm_libvirt.pp_FILES = \
+	$(addprefix $(top_srcdir)/src/selinux/,\
+	  swtpm_libvirt.te)
 
 if WITH_CUSE
 swtpmcuse.pp_FILES = \
@@ -80,6 +85,7 @@ EXTRA_DIST = \
 	swtpm.if \
 	swtpm.te \
 	swtpm_svirt.te \
+	swtpm_libvirt.te \
 	swtpmcuse.fc.in \
 	swtpmcuse.if \
 	swtpmcuse.te

--- a/src/selinux/swtpm.te
+++ b/src/selinux/swtpm.te
@@ -2,8 +2,16 @@ policy_module(swtpm, 1.0.0)
 
 ########################################
 #
-# Declarations
+# Requires Fedora 40
 #
+
+require {
+	type qemu_var_run_t;
+	type var_log_t;
+	type virt_var_lib_t;
+	type virtqemud_t;
+	type virtqemud_tmp_t;
+}
 
 attribute_role swtpm_roles;
 roleattribute system_r swtpm_roles;
@@ -17,10 +25,15 @@ role swtpm_roles types swtpm_t;
 #
 # swtpm local policy
 #
-allow swtpm_t self:capability { setgid setuid dac_override dac_read_search };
+allow swtpm_t qemu_var_run_t:file { create getattr open read unlink write };
+allow swtpm_t qemu_var_run_t:dir { add_name remove_name write };
+allow swtpm_t qemu_var_run_t:sock_file { create setattr unlink };
+allow swtpm_t var_log_t:file open;
+allow swtpm_t virt_var_lib_t:dir { add_name remove_name write };
+allow swtpm_t virt_var_lib_t:file { create rename setattr unlink write };
+allow swtpm_t virtqemud_t:unix_stream_socket { read write getattr };
+allow swtpm_t virtqemud_tmp_t:file { open write };
 
-allow swtpm_t self:fifo_file manage_fifo_file_perms;
-allow swtpm_t self:unix_stream_socket create_stream_socket_perms;
 
 domain_use_interactive_fds(swtpm_t)
 

--- a/src/selinux/swtpm_libvirt.te
+++ b/src/selinux/swtpm_libvirt.te
@@ -1,0 +1,57 @@
+policy_module(swtpm_libvirt, 1.0.0)
+
+########################################
+#
+# Rules for enabling interactions due to swtpm usage by libvirt
+# Requires Fedora 40
+#
+
+require {
+	type admin_home_t;
+	type device_t;
+	type fs_t;
+	type hugetlbfs_t;
+	type qemu_var_run_t;
+	type svirt_t;
+	type svirt_image_t;
+	type svirt_tcg_t;
+	type svirt_tcg_devpts_t;
+	type swtpm_t;
+	type urandom_device_t;
+	type var_lib_t;
+	type var_log_t;
+	type virt_log_t;
+	type virt_var_lib_t;
+	type virtqemud_t;
+}
+
+allow virtqemud_t admin_home_t:file { relabelfrom relabelto setattr write };
+allow virtqemud_t device_t:filesystem unmount;
+allow virtqemud_t fs_t:filesystem getattr;
+allow virtqemud_t hugetlbfs_t:dir relabelfrom;
+allow virtqemud_t qemu_var_run_t:file { relabelfrom relabelto };
+allow virtqemud_t qemu_var_run_t:sock_file relabelfrom;
+allow virtqemud_t self:capability { sys_nice sys_module };
+allow virtqemud_t self:fifo_file relabelfrom;
+allow virtqemud_t svirt_t:process { noatsecure rlimitinh siginh };
+allow virtqemud_t svirt_image_t:chr_file setattr;
+allow virtqemud_t svirt_tcg_t:dir search;
+allow virtqemud_t svirt_tcg_t:file { open read };
+allow virtqemud_t svirt_tcg_t:process { noatsecure rlimitinh setsched siginh signal signull transition };
+allow virtqemud_t svirt_tcg_t:unix_stream_socket { bind connectto create listen };
+allow virtqemud_t svirt_tcg_devpts_t:chr_file { ioctl open read write };
+allow virtqemud_t swtpm_t:process { noatsecure rlimitinh siginh signull };
+allow virtqemud_t urandom_device_t:chr_file setattr;
+
+# Some rules are due to swtpm-localca ( https://bugzilla.redhat.com/show_bug.cgi?id=2278905#c34 )
+allow virtqemud_t var_lib_t:dir add_name;
+allow virtqemud_t var_lib_t:file { create setattr write };
+
+allow virtqemud_t var_log_t:dir { add_name remove_name };
+allow virtqemud_t var_log_t:file { create relabelfrom relabelto setattr unlink write };
+
+allow virtqemud_t virt_log_t:dir remove_name;
+allow virtqemud_t virt_log_t:file unlink;
+
+allow virtqemud_t virt_var_lib_t:dir { relabelfrom relabelto };
+allow virtqemud_t virt_var_lib_t:file { relabelfrom relabelto };

--- a/src/selinux/swtpm_svirt.te
+++ b/src/selinux/swtpm_svirt.te
@@ -1,34 +1,34 @@
 policy_module(swtpm_svirt,1.0)
 
+########################################
+#
+# Requires Fedora 40
+#
+
 require {
+	type svirt_image_t;
 	type svirt_t;
 	type svirt_tcg_t;
 	type swtpm_exec_t;
-	type virtd_t;
 	type user_tmp_t;
-	type virt_var_run_t;
+	type virtd_t;
+	type virtqemud_t;
 }
 
 swtpm_domtrans(svirt_t)
 swtpm_domtrans(svirt_tcg_t)
 
 #============= svirt_t ==============
-allow svirt_t virtd_t:fifo_file { read write };
-allow svirt_t virtd_t:process sigchld;
-allow svirt_t user_tmp_t:sock_file { create setattr unlink };
-allow svirt_t swtpm_exec_t:file { entrypoint map };
-# libvirt specific rules needed on F28
-allow svirt_t virtd_t:unix_stream_socket { read write getopt getattr accept };
-# virt_var_run_t rules needed on F30
-allow svirt_t virt_var_run_t:dir { add_name remove_name write };
-allow svirt_t virt_var_run_t:file { create getattr open read unlink write };
-allow svirt_t virt_var_run_t:sock_file { create setattr };
+allow svirt_t swtpm_exec_t:file entrypoint;
 
-allow svirt_tcg_t virtd_t:fifo_file { write read };
-allow svirt_tcg_t virt_var_run_t:sock_file { create setattr unlink };
-allow svirt_tcg_t virt_var_run_t:file { create getattr open read unlink write };
-allow svirt_tcg_t virt_var_run_t:dir { write add_name remove_name };
-allow svirt_tcg_t swtpm_exec_t:file { entrypoint map };
-allow svirt_tcg_t user_tmp_t:sock_file { create setattr unlink };
-# libvirt specific rules needed on F28
-allow svirt_tcg_t virtd_t:unix_stream_socket { read write getopt getattr accept };
+# Due to session mode and usage of dir /run/user/*/libvirt/qemu/run/swtpm
+allow svirt_t user_tmp_t:sock_file { create setattr unlink };
+
+allow svirt_t virtd_t:dir search;
+allow svirt_t virtd_t:fifo_file write;
+allow svirt_t virtqemud_t:fifo_file write;
+
+allow svirt_tcg_t swtpm_exec_t:file entrypoint;
+allow svirt_tcg_t svirt_image_t:file { map read write };  # also: domain_can_mmap_files
+allow svirt_tcg_t virtqemud_t:fifo_file write;
+allow svirt_tcg_t virtqemud_t:file { getattr open read };

--- a/swtpm.spec
+++ b/swtpm.spec
@@ -117,13 +117,14 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/%{name}/*.{a,la,so}
 
 %post selinux
 for pp in /usr/share/selinux/packages/swtpm.pp \
+          /usr/share/selinux/packages/swtpm_libvirt.pp \
           /usr/share/selinux/packages/swtpm_svirt.pp; do
   %selinux_modules_install -s %{selinuxtype} ${pp}
 done
 
 %postun selinux
 if [ $1 -eq  0 ]; then
-  for p in swtpm swtpm_svirt; do
+  for p in swtpm swtpm_libvirt swtpm_svirt; do
     %selinux_modules_uninstall -s %{selinuxtype} $p
   done
 fi
@@ -142,6 +143,7 @@ fi
 
 %files selinux
 %{_datadir}/selinux/packages/swtpm.pp
+%{_datadir}/selinux/packages/swtpm_libvirt.pp
 %{_datadir}/selinux/packages/swtpm_svirt.pp
 
 %files libs

--- a/swtpm.spec.in
+++ b/swtpm.spec.in
@@ -117,13 +117,14 @@ rm -f $RPM_BUILD_ROOT%{_libdir}/%{name}/*.{a,la,so}
 
 %post selinux
 for pp in /usr/share/selinux/packages/swtpm.pp \
+          /usr/share/selinux/packages/swtpm_libvirt.pp \
           /usr/share/selinux/packages/swtpm_svirt.pp; do
   %selinux_modules_install -s %{selinuxtype} ${pp}
 done
 
 %postun selinux
 if [ $1 -eq  0 ]; then
-  for p in swtpm swtpm_svirt; do
+  for p in swtpm swtpm_libvirt swtpm_svirt; do
     %selinux_modules_uninstall -s %{selinuxtype} $p
   done
 fi
@@ -142,6 +143,7 @@ fi
 
 %files selinux
 %{_datadir}/selinux/packages/swtpm.pp
+%{_datadir}/selinux/packages/swtpm_libvirt.pp
 %{_datadir}/selinux/packages/swtpm_svirt.pp
 
 %files libs


### PR DESCRIPTION
Due to a significant change in the targeted SELinux policy re-develop the SELinux policy for swtpm. New rules in swtpm_libvirt.te are needed when libvirt causes new interactions between types.