### PR TITLE
tests: Add test cases for using swtpm --print-states while swtpm is r…

### DIFF
--- a/tests/_test_print_states
+++ b/tests/_test_print_states
@@ -15,6 +15,9 @@ trap "cleanup" SIGTERM EXIT
 
 function cleanup()
 {
+	if [ -n "${SWTPM_PID}" ]; then
+		kill_quiet -9 "${SWTPM_PID}"
+	fi
 	rm -rf "${workdir}"
 }
 
@@ -61,6 +64,55 @@ if ! [[ ${msg} =~ ${exp} ]]; then
 fi
 
 echo "Test 2: OK"
-cleanup
 
+if [ "${SWTPM_IFACE}" = socket ]; then
+	# Test 3: Running swtpm that holds lock on .lock; swtpm --print-states not locked out
+	rm -f "${workdir}/"*
+	run_swtpm "${SWTPM_INTERFACE}" --tpmstate "dir=${workdir}"
+
+	if ! kill_quiet -0 "${SWTPM_PID}"; then
+		echo "Error: ${SWTPM_INTERFACE} TPM did not start."
+		exit 1
+	fi
+
+	if ! msg="$(${SWTPM_EXE} "${SWTPM_IFACE}" --print-states --tpmstate "dir=${workdir}" 2>&1)"; then
+		echo "Error: Could not pass --print-states"
+		echo "${msg}"
+		exit 1
+	fi
+
+	exp='\{ "type": "swtpm", "states": \[\] \}'
+	if ! [[ ${msg} =~ ${exp} ]]; then
+		echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-states:"
+		echo "Actual   : ${msg}"
+		echo "Expected : ${exp}"
+		exit 1
+	fi
+
+	# Init the TPM
+	if ! run_swtpm_ioctl "${SWTPM_INTERFACE}" -i; then
+		echo "Error: ${SWTPM_INTERFACE} TPM initialization failed."
+		exit 1
+	fi
+
+	if ! msg="$(${SWTPM_EXE} "${SWTPM_IFACE}" --print-states --tpmstate "dir=${workdir}" 2>&1)"; then
+		echo "Error: Could not pass --print-states"
+		echo "${msg}"
+		exit 1
+	fi
+
+	exp='\{ "type": "swtpm", "states": \[ \{"name": "permall", "size": 1185\} \] \}'
+	if ! [[ ${msg} =~ ${exp} ]]; then
+		echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-states:"
+		echo "Actual   : ${msg}"
+		echo "Expected : ${exp}"
+		exit 1
+	fi
+
+	echo "Test 3: OK"
+else
+	echo "Test 3: Skipped"
+fi
+
+cleanup
 exit 0

--- a/tests/_test_tpm2_print_states
+++ b/tests/_test_tpm2_print_states
@@ -15,6 +15,9 @@ trap "cleanup" SIGTERM EXIT
 
 function cleanup()
 {
+	if [ -n "${SWTPM_PID}" ]; then
+		kill_quiet -9 "${SWTPM_PID}"
+	fi
 	rm -rf "${workdir}"
 }
 
@@ -61,6 +64,55 @@ if ! [[ ${msg} =~ ${exp} ]]; then
 fi
 
 echo "Test 2: OK"
+
+if [ "${SWTPM_IFACE}" = socket ]; then
+	# Test 3: Running swtpm that holds lock on .lock; swtpm --print-states not locked out
+	rm -f "${workdir}/"*
+	run_swtpm "${SWTPM_INTERFACE}" --tpmstate "dir=${workdir}" --tpm2
+
+	if ! kill_quiet -0 "${SWTPM_PID}"; then
+		echo "Error: ${SWTPM_INTERFACE} TPM did not start."
+		exit 1
+	fi
+
+	if ! msg="$(${SWTPM_EXE} "${SWTPM_IFACE}" --print-states --tpmstate "dir=${workdir}" --tpm2 2>&1)"; then
+		echo "Error: Could not pass --print-states"
+		echo "${msg}"
+		exit 1
+	fi
+
+	exp='\{ "type": "swtpm", "states": \[\] \}'
+	if ! [[ ${msg} =~ ${exp} ]]; then
+		echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-states:"
+		echo "Actual   : ${msg}"
+		echo "Expected : ${exp}"
+		exit 1
+	fi
+
+	# Init the TPM
+	if ! run_swtpm_ioctl "${SWTPM_INTERFACE}" -i; then
+		echo "Error: ${SWTPM_INTERFACE} TPM initialization failed."
+		exit 1
+	fi
+
+	if ! msg="$(${SWTPM_EXE} "${SWTPM_IFACE}" --print-states --tpmstate "dir=${workdir}" --tpm2 2>&1)"; then
+		echo "Error: Could not pass --print-states"
+		echo "${msg}"
+		exit 1
+	fi
+
+	exp='\{ "type": "swtpm", "states": \[ \{"name": "permall", "size": 1315\} \] \}'
+	if ! [[ ${msg} =~ ${exp} ]]; then
+		echo "Unexpected response from ${SWTPM_IFACE} TPM to --print-states:"
+		echo "Actual   : ${msg}"
+		echo "Expected : ${exp}"
+		exit 1
+	fi
+
+	echo "Test 3: OK"
+else
+	echo "Test 3: Skipped"
+fi
 cleanup
 
 exit 0

--- a/tests/test_print_states
+++ b/tests/test_print_states
@@ -13,6 +13,10 @@ ret=$?
 [ $ret -ne 0 ] && [ $ret -ne 77 ] && exit $ret
 
 export SWTPM_IFACE=socket
+export SWTPM_INTERFACE=socket+socket
+export SWTPM_SERVER_NAME=localhost
+export SWTPM_SERVER_PORT=65476
+export SWTPM_CTRL_PORT=65477
 bash _test_print_states
 ret=$?
 [ $ret -ne 0 ] && [ $ret -ne 77 ] && exit $ret

--- a/tests/test_tpm2_print_states
+++ b/tests/test_tpm2_print_states
@@ -13,6 +13,10 @@ ret=$?
 [ $ret -ne 0 ] && [ $ret -ne 77 ] && exit $ret
 
 export SWTPM_IFACE=socket
+export SWTPM_INTERFACE=socket+socket
+export SWTPM_SERVER_NAME=localhost
+export SWTPM_SERVER_PORT=65470
+export SWTPM_CTRL_PORT=65471
 bash _test_tpm2_print_states
 ret=$?
 [ $ret -ne 0 ] && [ $ret -ne 77 ] && exit $ret


### PR DESCRIPTION
…unning

swtpm <0.8 tried to lock the .lock file when executing --print-states, which then failed when another swtpm was holding the lock. This adds a test case for this scenario.