### PR TITLE
swtpm: Replace mkstemp with g_mkstemp_full (Coverity)

### DIFF
--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -20,6 +20,7 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 #include <glib.h>
 
@@ -90,7 +91,7 @@ static int swtpm_start(struct swtpm *self)
     int ret = 1;
     char pidfile[] = "/tmp/.swtpm_setup.pidfile.XXXXXX";
 
-    pidfile_fd = mkstemp(pidfile);
+    pidfile_fd = g_mkstemp_full(pidfile, O_EXCL|O_CREAT, 0600);
     if (pidfile_fd < 0) {
         logerr(self->logfile, "Could not create pidfile: %s\n", strerror(errno));
         goto error_no_pidfile;


### PR DESCRIPTION
Replace mkstemp with g_mkstemp_full and pass parameters that lead to the same mode bits and file opening flags and mkstemp had. This addresses a Coverity complaint regarding missing application of umask before mkstemp.