### PR TITLE
swtpm: Use fchmod to set mode bits provided by user

### DIFF
--- a/src/swtpm/tpmstate.c
+++ b/src/swtpm/tpmstate.c
@@ -50,6 +50,8 @@
 
 static char *g_backend_uri;
 static mode_t g_tpmstate_mode = 0640;
+/* false if provided user via command line mode=..., true if using default */
+static bool g_tpmstate_mode_is_default = true;
 static TPMLIB_TPMVersion g_tpmstate_version = TPMLIB_TPM_VERSION_1_2;
 
 void tpmstate_global_free(void)
@@ -86,15 +88,17 @@ const char *tpmstate_get_backend_uri(void)
     return NULL;
 }
 
-int tpmstate_set_mode(mode_t mode)
+int tpmstate_set_mode(mode_t mode, bool mode_is_default)
 {
     g_tpmstate_mode = mode;
+    g_tpmstate_mode_is_default = mode_is_default;
 
     return 0;
 }
 
-mode_t tpmstate_get_mode(void)
+mode_t tpmstate_get_mode(bool *mode_is_default)
 {
+    *mode_is_default = g_tpmstate_mode_is_default;
     return g_tpmstate_mode;
 }
 

--- a/src/swtpm/tpmstate.h
+++ b/src/swtpm/tpmstate.h
@@ -38,14 +38,15 @@
 #ifndef _SWTPM_TPMSTATE_H_
 #define _SWTPM_TPMSTATE_H_
 
+#include <stdbool.h>
 #include <sys/types.h>
 #include <libtpms/tpm_library.h>
 
 int tpmstate_set_backend_uri(char *backend_uri);
 const char *tpmstate_get_backend_uri(void);
 
-int tpmstate_set_mode(mode_t mode);
-mode_t tpmstate_get_mode(void);
+int tpmstate_set_mode(mode_t mode, bool mode_is_default);
+mode_t tpmstate_get_mode(bool *mode_is_default);
 void tpmstate_global_free(void);
 
 void tpmstate_set_version(TPMLIB_TPMVersion version);


### PR DESCRIPTION
The mode bits that the user provided were only applied with open() and were
subject to masking with the value of current umask. When umask was set to
0027 the test case test_commandline was failing because the mode bits on
the create TPM state file were not the expected ones (masked by umask).
Therefore, set the mode bits using fchmod if the user provided them,
otherwise do not set them. This way the mode bits will be set to the values
the user requested.

Currently the directory storage backend was setting the mode bits to the
default value (0640) *after* opening the TPM state file. Now, if the user
did not provide any mode bits then the mode bits will be set so that the
file can be written to as owner. This ensures that at least mode bits 0600
are set by default. However, if the user provided mode bit flags then these
will be used without modification.