### PR TITLE
Update apparmor profile with additional permissions

### DIFF
--- a/debian/usr.bin.swtpm
+++ b/debian/usr.bin.swtpm
@@ -17,6 +17,7 @@ profile swtpm /usr/bin/swtpm {
   capability fsetid,
   capability setgid,
   capability setuid,
+  capability sys_admin,
 
   network inet stream,
   network inet6 stream,

--- a/debian/usr.bin.swtpm
+++ b/debian/usr.bin.swtpm
@@ -29,6 +29,7 @@ profile swtpm /usr/bin/swtpm {
   /run/libvirt/qemu/swtpm/*.pid rwk,
   /run/libvirt/qemu/swtpm/*.sock rwk,
   /tmp/** rwk,
+  /var/lib/libvirt/swtpm/** wk,
 
   owner /dev/vtpmx rw,
   owner /etc/nsswitch.conf r,


### PR DESCRIPTION
Add the sys_admin capability to the profile to allow access to kernel drivers like vtpm_proxy and add write permissions for non-owner files in /var/lib/libvirt/swtpm/ to fix lock file denials