### PR TITLE
Install tests

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -224,13 +224,15 @@ EXTRA_DIST = \
 	_test_tpm2_volatilestate \
 	_test_tpm2_wrongorder \
 	_test_volatilestate \
-	_test_wrongorder
+	_test_wrongorder \
+	installed-runner.sh
 
 testdir = $(libexecdir)/installed-tests/$(PACKAGE)
 
 install-data-hook:
 	mkdir -p $(DESTDIR)$(testdir)
 	cd $(srcdir) && for file in $(EXTRA_DIST); do install -D "$$file" "$(DESTDIR)$(testdir)/$$file" ; done
+	echo "$(TESTS)" > $(DESTDIR)$(testdir)/tests
 
 uninstall-hook:
 	cd $(DESTDIR)$(testdir) && rm -f $(EXTRA_DIST) tests
@@ -254,6 +256,6 @@ syntax-check:
 # SC2009: Consider using pgrep instead of grepping ps output.
 # SC2317: (info): Command appears to be unreachable. Check usage (or ignore if invoked indirectly).
 	shellcheck -e SC2009,SC2317 \
-		$(TESTS) $(TEST_UTILS) $(filter _test_%,$(EXTRA_DIST)) softhsm_setup
+		$(TESTS) $(TEST_UTILS) $(filter _test_%,$(EXTRA_DIST)) softhsm_setup installed-runner.sh
 
 check: check-am check-display

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -226,6 +226,15 @@ EXTRA_DIST = \
 	_test_volatilestate \
 	_test_wrongorder
 
+testdir = $(libexecdir)/installed-tests/$(PACKAGE)
+
+install-data-hook:
+	mkdir -p $(DESTDIR)$(testdir)
+	cd $(srcdir) && for file in $(EXTRA_DIST); do install -D "$$file" "$(DESTDIR)$(testdir)/$$file" ; done
+
+uninstall-hook:
+	cd $(DESTDIR)$(testdir) && rm -f $(EXTRA_DIST) tests
+
 check-display:
 	@if test -n "$$SWTPM_EXE"; then \
 		echo "*** Using SWTPM_EXE=$$SWTPM_EXE"; \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -233,6 +233,7 @@ install-data-hook:
 	mkdir -p $(DESTDIR)$(testdir)
 	cd $(srcdir) && for file in $(EXTRA_DIST); do install -D "$$file" "$(DESTDIR)$(testdir)/$$file" ; done
 	echo "$(TESTS)" > $(DESTDIR)$(testdir)/tests
+	sed -i '/SWTPM_TEST_UNINSTALLED=1/d' $(DESTDIR)$(testdir)/common
 
 uninstall-hook:
 	cd $(DESTDIR)$(testdir) && rm -f $(EXTRA_DIST) tests

--- a/tests/_test_swtpm_bios
+++ b/tests/_test_swtpm_bios
@@ -6,7 +6,6 @@
 ROOT=${abs_top_builddir:-$(pwd)/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
-SWTPM_BIOS=$ROOT/src/swtpm_bios/swtpm_bios
 VTPM_NAME="vtpm-test-swtpm-bios"
 SWTPM_DEV_NAME="/dev/${VTPM_NAME}"
 TPM_PATH="$(mktemp -d)" || exit 1

--- a/tests/_test_tpm2_file_permissions
+++ b/tests/_test_tpm2_file_permissions
@@ -15,7 +15,6 @@ PIDFILE=${TPM_PATH}/swtpm.pid
 LOGFILE=${TPM_PATH}/swtpm.log
 PWDFILE=${TPM_PATH}/pwdfile.txt
 SWTPM_INTERFACE=${SWTPM_INTERFACE:-cuse}
-SWTPM_SETUP_CONF=${TPM_PATH}/swtpm_setup.conf
 
 function cleanup()
 {
@@ -29,6 +28,7 @@ trap "cleanup" EXIT
 
 [ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+SWTPM_SETUP_CONF=${TPM_PATH}/swtpm_setup.conf
 
 cat <<_EOF_ > "${SWTPM_SETUP_CONF}"
 create_certs_tool=unused

--- a/tests/common
+++ b/tests/common
@@ -8,13 +8,18 @@ if [ -z "${INSTALLED}" ]; then
     SWTPM_BIOS=${SWTPM_BIOS:-${ROOT}/src/swtpm_bios/swtpm_bios}
     SWTPM_SETUP=${SWTPM_SETUP:-${ROOT}/src/swtpm_setup/swtpm_setup}
     SWTPM_CERT=${SWTPM_CERT:-${ROOT}/src/swtpm_cert/swtpm_cert}
+    SWTPM_SETUP_CONF="${ROOT}/samples/swtpm_setup.conf"
 else
     SWTPM_EXE=${SWTPM_EXE:-$(type -P swtpm)}
     SWTPM_IOCTL=${SWTPM_IOCTL:-$(type -P swtpm_ioctl)}
     SWTPM_BIOS=${SWTPM_BIOS:-$(type -P swtpm_bios)}
     SWTPM_SETUP=${SWTPM_SETUP:-$(type -P swtpm_setup)}
     SWTPM_CERT=${SWTPM_CERT:-$(type -P swtpm_cert)}
+    SWTPM_SETUP_CONF="$(dirname "$0")/swtpm_setup.conf"
 fi
+
+# SC2034 unused
+export SWTPM_SETUP_CONF
 
 ECHO=$(type -P echo)
 

--- a/tests/common
+++ b/tests/common
@@ -8,6 +8,7 @@ if [ -z "${INSTALLED}" ]; then
     SWTPM_BIOS=${SWTPM_BIOS:-${ROOT}/src/swtpm_bios/swtpm_bios}
     SWTPM_SETUP=${SWTPM_SETUP:-${ROOT}/src/swtpm_setup/swtpm_setup}
     SWTPM_CERT=${SWTPM_CERT:-${ROOT}/src/swtpm_cert/swtpm_cert}
+    SWTPM_LOCALCA=${SWTPM_LOCALCA:-${ROOT}/src/swtpm_localca/swtpm_localca}
     SWTPM_SETUP_CONF="${ROOT}/samples/swtpm_setup.conf"
 else
     SWTPM_EXE=${SWTPM_EXE:-$(type -P swtpm)}
@@ -15,6 +16,7 @@ else
     SWTPM_BIOS=${SWTPM_BIOS:-$(type -P swtpm_bios)}
     SWTPM_SETUP=${SWTPM_SETUP:-$(type -P swtpm_setup)}
     SWTPM_CERT=${SWTPM_CERT:-$(type -P swtpm_cert)}
+    SWTPM_LOCALCA=${SWTPM_LOCALCA:-$(type -P swtpm_localca)}
     SWTPM_SETUP_CONF="$(dirname "$0")/swtpm_setup.conf"
 fi
 

--- a/tests/common
+++ b/tests/common
@@ -1,12 +1,21 @@
 
 # shellcheck shell=bash
 
-SWTPM=swtpm
-SWTPM_EXE=${SWTPM_EXE:-${ROOT}/src/swtpm/${SWTPM}}
-SWTPM_IOCTL=${SWTPM_IOCTL:-${ROOT}/src/swtpm_ioctl/swtpm_ioctl}
-SWTPM_BIOS=${SWTPM_BIOS:-${ROOT}/src/swtpm_bios/swtpm_bios}
-SWTPM_SETUP=${SWTPM_SETUP:-${ROOT}/src/swtpm_setup/swtpm_setup}
-SWTPM_CERT=${SWTPM_CERT:-${ROOT}/src/swtpm_cert/swtpm_cert}
+if [ -z "${INSTALLED}" ]; then
+    SWTPM=swtpm
+    SWTPM_EXE=${SWTPM_EXE:-${ROOT}/src/swtpm/${SWTPM}}
+    SWTPM_IOCTL=${SWTPM_IOCTL:-${ROOT}/src/swtpm_ioctl/swtpm_ioctl}
+    SWTPM_BIOS=${SWTPM_BIOS:-${ROOT}/src/swtpm_bios/swtpm_bios}
+    SWTPM_SETUP=${SWTPM_SETUP:-${ROOT}/src/swtpm_setup/swtpm_setup}
+    SWTPM_CERT=${SWTPM_CERT:-${ROOT}/src/swtpm_cert/swtpm_cert}
+else
+    SWTPM_EXE=${SWTPM_EXE:-$(type -P swtpm)}
+    SWTPM_IOCTL=${SWTPM_IOCTL:-$(type -P swtpm_ioctl)}
+    SWTPM_BIOS=${SWTPM_BIOS:-$(type -P swtpm_bios)}
+    SWTPM_SETUP=${SWTPM_SETUP:-$(type -P swtpm_setup)}
+    SWTPM_CERT=${SWTPM_CERT:-$(type -P swtpm_cert)}
+fi
+
 ECHO=$(type -P echo)
 
 case "$(uname -s)" in

--- a/tests/common
+++ b/tests/common
@@ -1,7 +1,9 @@
 
 # shellcheck shell=bash
 
-if [ -z "${INSTALLED}" ]; then
+SWTPM_TEST_UNINSTALLED=1
+
+if [ -n "${SWTPM_TEST_UNINSTALLED}" ]; then
     SWTPM=swtpm
     SWTPM_EXE=${SWTPM_EXE:-${ROOT}/src/swtpm/${SWTPM}}
     SWTPM_IOCTL=${SWTPM_IOCTL:-${ROOT}/src/swtpm_ioctl/swtpm_ioctl}

--- a/tests/installed-runner.sh
+++ b/tests/installed-runner.sh
@@ -23,8 +23,6 @@ pass_count=0
 skip_count=0
 fail_count=0
 
-export INSTALLED=1
-
 # Iterate through each test in the TESTS variable
 for t in $TESTS; do
   if [ "$verbose" -eq 1 ]; then

--- a/tests/installed-runner.sh
+++ b/tests/installed-runner.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env sh
+
+verbose=0
+
+# Check for the -v option to enable verbose output
+while getopts "v" opt; do
+  case $opt in
+    v) verbose=1 ;;
+    *) echo "Usage: $0 [-v]" >&2; exit 1 ;;
+  esac
+done
+
+TESTS_FILE="$(dirname "$0")/tests"
+if [ -f "$TESTS_FILE" ]; then
+    TESTS=$(cat "$TESTS_FILE")
+else
+    echo "Error: 'tests' file does not exist."
+    exit 1
+fi
+
+test_count=0
+pass_count=0
+skip_count=0
+fail_count=0
+
+export INSTALLED=1
+
+# Iterate through each test in the TESTS variable
+for t in $TESTS; do
+  if [ "$verbose" -eq 1 ]; then
+    "$(dirname "$0")/$t"
+    ret=$?
+  else
+    output=$("$(dirname "$0")/$t" 2>&1)
+    ret=$?
+  fi
+
+  test_count=$((test_count + 1))
+  case $ret in
+    0)
+      echo "PASS: $t"
+      pass_count=$((pass_count + 1))
+      ;;
+    77)
+      echo "SKIP: $t"
+      skip_count=$((skip_count + 1))
+      ;;
+    *)
+      echo "FAIL: $t (exit $ret)"
+      fail_count=$((fail_count + 1))
+      echo "$output"
+      ;;
+  esac
+done
+
+echo "Summary:"
+echo "# TOTAL: $test_count"
+echo "# PASS: $pass_count"
+echo "# SKIP: $skip_count"
+echo "# FAIL: $fail_count"
+
+# Exit with 1 if any test failed
+if [ "$fail_count" -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi

--- a/tests/test_parameters
+++ b/tests/test_parameters
@@ -4,7 +4,6 @@
 
 ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:=$(dirname "$0")}
-SRCDIR=${abs_top_srcdir:-$(dirname "$0")/..}
 
 PATH=$ROOT/src/swtpm:$PATH
 
@@ -68,7 +67,6 @@ skip_test_no_tpm12 "${SWTPM_EXE}"
 SWTPM=swtpm
 SWTPM_EXE=${SWTPM_EXE:-$ROOT/src/swtpm/$SWTPM}
 TPMDIR="$(mktemp -d)" || exit 1
-SWTPM_SETUP_CONF=$SRCDIR/samples/swtpm_setup.conf
 # filesystem privileges require to run swtpm_setup as root during test
 TPMAUTHORING="$ROOT/src/swtpm_setup/swtpm_setup --config ${SWTPM_SETUP_CONF}"
 PATH=${ROOT}/src/swtpm_bios:${TESTDIR}:$PATH

--- a/tests/test_parameters
+++ b/tests/test_parameters
@@ -64,11 +64,9 @@ FILESIZES=(
 source "${TESTDIR}/common"
 skip_test_no_tpm12 "${SWTPM_EXE}"
 
-SWTPM=swtpm
-SWTPM_EXE=${SWTPM_EXE:-$ROOT/src/swtpm/$SWTPM}
 TPMDIR="$(mktemp -d)" || exit 1
 # filesystem privileges require to run swtpm_setup as root during test
-TPMAUTHORING="$ROOT/src/swtpm_setup/swtpm_setup --config ${SWTPM_SETUP_CONF}"
+TPMAUTHORING="$SWTPM_SETUP --config ${SWTPM_SETUP_CONF}"
 PATH=${ROOT}/src/swtpm_bios:${TESTDIR}:$PATH
 
 trap "cleanup" SIGTERM EXIT

--- a/tests/test_swtpm_cert
+++ b/tests/test_swtpm_cert
@@ -5,7 +5,7 @@
 ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:=$(dirname "$0")}
 
-SWTPM_CERT=${SWTPM_CERT:-${ROOT}/src/swtpm_cert/swtpm_cert}
+source "${TESTDIR}/common"
 
 trap "cleanup" SIGTERM EXIT
 

--- a/tests/test_swtpm_setup_create_cert
+++ b/tests/test_swtpm_setup_create_cert
@@ -8,8 +8,6 @@ TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 source "${TESTDIR}/common"
 skip_test_no_tpm12 "${SWTPM_EXE}"
 
-SWTPM_LOCALCA=${ROOT}/src/swtpm_localca/swtpm_localca
-
 workdir="$(mktemp -d)" || exit 1
 
 SIGNINGKEY=${workdir}/signingkey.pem

--- a/tests/test_swtpm_setup_file_backend
+++ b/tests/test_swtpm_setup_file_backend
@@ -4,12 +4,9 @@
 
 ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
-SRCDIR=${abs_top_srcdir:-$(dirname "$0")/..}
 
 source "${TESTDIR}/common"
 skip_test_no_tpm12 "${SWTPM_EXE}"
-
-SWTPM_SETUP_CONF=$SRCDIR/samples/swtpm_setup.conf
 
 state_save_dir="$(mktemp -d)" || exit 1
 state_save=${state_save_dir}/swtpm-test.state.save

--- a/tests/test_swtpm_setup_overwrite
+++ b/tests/test_swtpm_setup_overwrite
@@ -4,13 +4,10 @@
 
 ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
-SRCDIR=${abs_top_srcdir:-$(dirname "$0")/..}
 
 source "${TESTDIR}/common"
 skip_test_no_tpm12 "${SWTPM_EXE}"
 STATEBASENAME="tpm-00.permall"
-
-SWTPM_SETUP_CONF=$SRCDIR/samples/swtpm_setup.conf
 
 trap "cleanup" SIGTERM EXIT
 

--- a/tests/test_tpm2_parameters
+++ b/tests/test_tpm2_parameters
@@ -11,8 +11,6 @@ skip_test_no_tpm20 "${SWTPM_EXE}"
 
 PATH=$ROOT/src/swtpm:$PATH
 
-source "${abs_top_builddir:-$(dirname "$0")/..}/tests/test_config"
-
 PARAMETERS=(
 	""
 	"--createek"
@@ -62,10 +60,8 @@ exec 101<"${TESTDIR}/data/pwdfile.txt"
 
 # produced file size is always the same with TPM2
 
-SWTPM=swtpm
-SWTPM_EXE=$ROOT/src/swtpm/$SWTPM
 TPMDIR="$(mktemp -d)" || exit 1
-TPMAUTHORING="$ROOT/src/swtpm_setup/swtpm_setup --tpm2 --config ${SWTPM_SETUP_CONF}"
+TPMAUTHORING="$SWTPM_SETUP --tpm2 --config ${SWTPM_SETUP_CONF}"
 PATH=${ROOT}/src/swtpm_bios:$PATH
 
 

--- a/tests/test_tpm2_parameters
+++ b/tests/test_tpm2_parameters
@@ -9,8 +9,6 @@ ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 source "${TESTDIR}/common"
 skip_test_no_tpm20 "${SWTPM_EXE}"
 
-SRCDIR=${abs_top_srcdir:-$(dirname "$0")/..}
-
 PATH=$ROOT/src/swtpm:$PATH
 
 source "${abs_top_builddir:-$(dirname "$0")/..}/tests/test_config"
@@ -67,7 +65,6 @@ exec 101<"${TESTDIR}/data/pwdfile.txt"
 SWTPM=swtpm
 SWTPM_EXE=$ROOT/src/swtpm/$SWTPM
 TPMDIR="$(mktemp -d)" || exit 1
-SWTPM_SETUP_CONF=$SRCDIR/samples/swtpm_setup.conf
 TPMAUTHORING="$ROOT/src/swtpm_setup/swtpm_setup --tpm2 --config ${SWTPM_SETUP_CONF}"
 PATH=${ROOT}/src/swtpm_bios:$PATH
 

--- a/tests/test_tpm2_swtpm_cert
+++ b/tests/test_tpm2_swtpm_cert
@@ -5,7 +5,7 @@
 ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
-SWTPM_CERT=${SWTPM_CERT:-${ROOT}/src/swtpm_cert/swtpm_cert}
+source "${TESTDIR}/common"
 
 cert="$(mktemp)" || exit 1
 

--- a/tests/test_tpm2_swtpm_cert_ecc
+++ b/tests/test_tpm2_swtpm_cert_ecc
@@ -5,7 +5,7 @@
 ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
-SWTPM_CERT=${SWTPM_CERT:-${ROOT}/src/swtpm_cert/swtpm_cert}
+source "${TESTDIR}/common"
 
 cert="$(mktemp)" || exit 1
 

--- a/tests/test_tpm2_swtpm_localca
+++ b/tests/test_tpm2_swtpm_localca
@@ -3,10 +3,9 @@
 # For the license, see the LICENSE file in the root directory.
 #set -x
 
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TOPBUILD=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
-
-SWTPM_LOCALCA=${TOPBUILD}/src/swtpm_localca/swtpm_localca
 
 workdir="$(mktemp -d "/tmp/path with spaces.XXXXXX")" || exit 1
 

--- a/tests/test_tpm2_swtpm_localca_pkcs11.test
+++ b/tests/test_tpm2_swtpm_localca_pkcs11.test
@@ -3,10 +3,8 @@
 # For the license, see the LICENSE file in the root directory.
 #set -x
 
-TOPBUILD=${abs_top_builddir:-$(dirname "$0")/..}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
-
-SWTPM_LOCALCA=${TOPBUILD}/src/swtpm_localca/swtpm_localca
 
 workdir="$(mktemp -d)" || exit 1
 
@@ -26,7 +24,7 @@ done
 ISSUERCERT="${workdir}/issuercert.pem"
 CERTSERIAL="${workdir}/certserial"
 
-PATH="${TOPBUILD}/src/swtpm_cert:$PATH"
+PATH="${ROOT}/src/swtpm_cert:$PATH"
 
 source "${TESTDIR}/common"
 

--- a/tests/test_tpm2_swtpm_setup_create_cert
+++ b/tests/test_tpm2_swtpm_setup_create_cert
@@ -9,8 +9,6 @@ TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 source "${TESTDIR}/common"
 skip_test_no_tpm20 "${SWTPM_EXE}"
 
-SWTPM_LOCALCA=${TOPBUILD}/src/swtpm_localca/swtpm_localca
-
 workdir="$(mktemp -d "/tmp/path with spaces.XXXXXX")" || exit 1
 
 SIGNINGKEY=${workdir}/signingkey.pem

--- a/tests/test_tpm2_swtpm_setup_overwrite
+++ b/tests/test_tpm2_swtpm_setup_overwrite
@@ -4,13 +4,10 @@
 
 ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
-SRCDIR=${abs_top_srcdir:-$(dirname "$0")/..}
 
 source "${TESTDIR}/common"
 skip_test_no_tpm20 "${SWTPM_EXE}"
 STATEBASENAME="tpm2-00.permall"
-
-SWTPM_SETUP_CONF=$SRCDIR/samples/swtpm_setup.conf
 
 trap "cleanup" SIGTERM EXIT
 


### PR DESCRIPTION
Allow tests/ to be installed and run from the system.

The installation path is loosely based on https://wiki.gnome.org/Initiatives/GnomeGoals/InstalledTests guidelines. We don't provide the .test files though, at this point. Instead, I wrote a simply installed-runner.sh script which mimics autotools basic runner. (ideally, the tests could use TAP instead etc)

Missing:
- [ ] running with SWTPM_TEST_EXPENSIVE=1
- [ ] SWTPM_TEST_STORE_VOLATILE=1 
- [ ] SWTPM_TEST_IBMTSS2=1
- [ ] and sudo

I think the current patch set should be ok for review/merge though.