### PR TITLE
Enable setting the default RSA keysize using swtpm_setup.conf

### DIFF
--- a/man/man5/swtpm_setup.conf.pod
+++ b/man/man5/swtpm_setup.conf.pod
@@ -95,6 +95,13 @@ This keyword is to be followed by a comma-separated list
 of names of PCR banks. The list must not contain any spaces.
 Valid PCR bank names are sha1, sha256, sha384, and sha512.
 
+=item B<rsa_keysize> (since v0.10)
+
+This keyword allows to specify the default RSA keysize to be used if it is
+not provided with a command line option to swtpm_setup. Any value
+that can be passed to swtpm_setup is also valid here, such as 2048, or
+'max'. The supported key sizes depend on the version of libtpms.
+
 =back
 
 =head1 SEE ALSO

--- a/samples/swtpm_setup.conf.in
+++ b/samples/swtpm_setup.conf.in
@@ -4,3 +4,4 @@ create_certs_tool_config = @SYSCONFDIR@/swtpm-localca.conf
 create_certs_tool_options = @SYSCONFDIR@/swtpm-localca.options
 # Comma-separated list (no spaces) of PCR banks to activate by default
 active_pcr_banks = @DEFAULT_PCR_BANKS@
+rsa_keysize = 2048

--- a/src/swtpm_setup/swtpm_setup_utils.c
+++ b/src/swtpm_setup/swtpm_setup_utils.c
@@ -24,7 +24,7 @@
 #include "swtpm_setup_utils.h"
 
 /* Get a configuration value given its name */
-gchar *get_config_value(gchar **config_file_lines, const gchar *configname)
+gchar *get_config_value(gchar *const *config_file_lines, const gchar *configname)
 {
     g_autofree gchar *regex = g_strdup_printf("^%s[[:space:]]*=[[:space:]]*([^#\n]*).*",
                                               configname);

--- a/src/swtpm_setup/swtpm_setup_utils.h
+++ b/src/swtpm_setup/swtpm_setup_utils.h
@@ -12,7 +12,8 @@
 
 #include <glib.h>
 
-gchar *get_config_value(gchar **config_file_lines, const gchar *configname);
+gchar *get_config_value(gchar *const *config_file_lines,
+                        const gchar *configname);
 int create_config_files(gboolean overwrite, gboolean root_flag,
                         gboolean skip_if_exist);
 


### PR DESCRIPTION
This PR adds the ability to provide a default RSA keysize using swtpm_setup.conf. It is used unless the user provided it with command line option to swtpm_setup.