### PR TITLE
tests: Fix some issue with test for swtpm_setup --profile

### DIFF
--- a/tests/test_tpm2_swtpm_setup_profile
+++ b/tests/test_tpm2_swtpm_setup_profile
@@ -88,12 +88,14 @@ test_swtpm_setup_profile()
 		exit 1
 	fi
 
-	response=$(run_swtpm_ioctl "${SWTPM_INTERFACE}" --info 0x20)
-	if ! [[ "${response}" =~ ${exp_response} ]]; then
-		echo "Error: Response does not match expected response regular expression"
-		echo "Actual   : ${response}"
-		echo "Expected : ${exp_response}"
-		exit 1
+	if [ -n "${exp_response}" ]; then
+		response=$(run_swtpm_ioctl "${SWTPM_INTERFACE}" --info 0x20)
+		if ! [[ "${response}" =~ ${exp_response} ]]; then
+			echo "Error: Response does not match expected response regular expression"
+			echo "Actual   : ${response}"
+			echo "Expected : ${exp_response}"
+			exit 1
+		fi
 	fi
 
 	if [ -n "${disabled_algos}" ]; then
@@ -138,7 +140,7 @@ if ! kill_quiet -0 "${SWTPM_PID}"; then
 	exit 1
 fi
 
-profiles=$(run_swtpm_ioctl "${SWTPM_INTERFACE}" --info 0x20 |
+profiles=$(run_swtpm_ioctl "${SWTPM_INTERFACE}" --info 0x40 |
 	   sed 's/{"Name/\n{"Name/g' |
 	   sed -n 's/^{"Name":"\([^"]\+\)".*/\1/p')
 
@@ -228,7 +230,7 @@ done
 
 # Without given StateFormatLevel it should go up to StateFormatLevel '4' (due to AES-192 being selected)
 profile="{\"Name\":\"custom\",\"Commands\":\"${cmds}\"}"
-exp_response=".*,\"StateFormatLevel\":4,.*"
+exp_response=".*,\"StateFormatLevel\":[[:digit:]]+,.*"
 test_swtpm_setup_profile \
 	"${workdir}" "${profile}" "${exp_response}" "" "" "" "${exp_fail}"
 
@@ -249,7 +251,7 @@ done
 
 # Without given StateFormatLevel it should go up to StateFormatLevel '4' (due to AES-192 being selected)
 profile="{\"Name\":\"custom\",\"Commands\":\"${cmds}\"}"
-exp_response=".*,\"StateFormatLevel\":4,.*"
+exp_response=".*,\"StateFormatLevel\":[[:digit:]]+,.*"
 test_swtpm_setup_profile \
 	"${workdir}" "${profile}" "${exp_response}" "" "" "" "${exp_fail}"
 


### PR DESCRIPTION
Fix the following issues:
- use a regular expression instead of hard coded '4' to match StateFormatLevel number that will change in the future
- get all available profiles from running tpm rather than only the active profile -> use --info 0x40
- only compare with regular experssion if it is non-empty because this otherwise fails on Cygwin