### PR TITLE
style: found and fixed some typos in the man pages

### DIFF
--- a/man/man8/swtpm.pod
+++ b/man/man8/swtpm.pod
@@ -14,7 +14,7 @@ B<swtpm cuse [OPTIONS]>
 
 B<swtpm> implements a TPM software emulator built on libtpms.
 It provides access to TPM functionality over a TCP/IP socket interface
-or it can listend for commands on a character device, or create a CUSE
+or it can listen for commands on a character device, or create a CUSE
 (character device in userspace) interface for receiving of TPM commands.
 
 Unless corresponding command line parameters are used, the
@@ -306,7 +306,7 @@ this can be changed with this option.
 The I<disable-auto-shutdown> flag prevents swtpm from automatically sending a
 TPM2_Shutdown() before the reset of a TPM 2 or before the swtpm process
 is terminated. When this flag is not provide swtpm will send this command to
-avoid increasing the dictionary attack (DA) lockout counter and ulimately
+avoid increasing the dictionary attack (DA) lockout counter and ultimately
 a DA lockout by the TPM 2 due to omission of sending a required TPM2_Shutdown()
 before TPM 2 reset or swtpm process termination.
 
@@ -394,7 +394,7 @@ parameter.
 
 The TPM 2 commands may be prefixed by a header that carries a 4-byte
 command, 1 byte for locality, and 4-byte TPM 2 command length indicator.
-The TPM 2 will respond by preprending a 4-byte response indicator and a
+The TPM 2 will respond by prepending a 4-byte response indicator and a
 4-byte trailer. All data is sent in big endian format.
 
 =item B<flags-opt-startup> (since v0.3)
@@ -482,7 +482,7 @@ algorithms in the OpenSSL crypto library that the TPM 2 would normally
 provide (RSA-PSS, Camellia, TDES, ...) and therefore they cannot be made
 available by the TPM 2. Because of this it may be required that a profile be used
 to avoid the TPM 2 entering failure mode upon self-testing. The effect of the
-disablement of algoritms may be that certain programs and test suites requiring
+disablement of algorithms may be that certain programs and test suites requiring
 them may not work correctly anymore. Therefore, profiles other than the default
 profile have to be applied very carefully to avoid unnecessary application
 failures where the only solution would be to not run them on a host that has
@@ -513,7 +513,7 @@ this:
           "StateFormatLevel": 4,
           "Commands": "0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,0x17a-0x193,0x197,0x199-0x19a",
           "Algorithms": "rsa,rsa-min-size=1024,tdes,tdes-min-size=128,sha1,hmac,aes,aes-min-size=128,mgf1,keyedhash,xor,sha256,sha384,sha512,null,rsassa,rsaes,rsapss,oaep,ecdsa,ecdh,ecdaa,sm2,ecschnorr,ecmqv,kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,ecc-nist,ecc-bn,symcipher,camellia,camellia-min-size=128,cmac,ctr,ofb,cbc,cfb,ecb",
-          "Description": "This profile enables all currenly supported commands and algorithms. It is applied when the user chooses no profile."
+          "Description": "This profile enables all currently supported commands and algorithms. It is applied when the user chooses no profile."
         },
         {
           "Name": "null",
@@ -543,7 +543,7 @@ I<swtpm_ioctl> tool:
         "StateFormatLevel": 4,
         "Commands": "0x11f-0x122,0x124-0x12e,0x130-0x140,0x142-0x159,0x15b-0x15e,0x160-0x165,0x167-0x174,0x176-0x178,0x17a-0x193,0x197,0x199-0x19a",
         "Algorithms": "rsa,rsa-min-size=1024,tdes,tdes-min-size=128,sha1,hmac,aes,aes-min-size=128,mgf1,keyedhash,xor,sha256,sha384,sha512,null,rsassa,rsaes,rsapss,oaep,ecdsa,ecdh,ecdaa,sm2,ecschnorr,ecmqv,kdf1-sp800-56a,kdf2,kdf1-sp800-108,ecc,ecc-min-size=192,ecc-nist,ecc-bn,symcipher,camellia,camellia-min-size=128,cmac,ctr,ofb,cbc,cfb,ecb",
-        "Description": "This profile enables all currenly supported commands and algorithms. It is applied when the user chooses no profile."
+        "Description": "This profile enables all currently supported commands and algorithms. It is applied when the user chooses no profile."
       }
     }
 

--- a/man/man8/swtpm_cert.pod
+++ b/man/man8/swtpm_cert.pod
@@ -163,7 +163,7 @@ The output may contain the following:
 
 The version field is available since 0.7.
 
-The maining of the feature verbs is as follows:
+The meaning of the feature verbs is as follows:
 
 =over 4
 

--- a/man/man8/swtpm_ioctl.pod
+++ b/man/man8/swtpm_ioctl.pod
@@ -65,7 +65,7 @@ Get the tpmEstablished bit.
 =item B<-r locality>
 
 Reset the tpmEstablished bit using the given locality. Only localities 3 and 4 work.
-This operation will not permanently change the localty that was previously set
+This operation will not permanently change the locality that was previously set
 using the I<-l> option.
 
 =item B<-l locality>

--- a/man/man8/swtpm_localca.pod
+++ b/man/man8/swtpm_localca.pod
@@ -29,7 +29,7 @@ SWTPM_ROOTCA_PASSWORD can be set for the password of the root CA's
 private key.
 
 Note: Due to limitations of 'certtool', the possible passwords used for
-securing the root CA's private key and the intermedia CA's private
+securing the root CA's private key and the intermediate CA's private
 key have to be passed over the command line and therefore will be visible
 to others on the system. If you are concerned about this, you should create
 the CAs elsewhere and copy them onto the target system.
@@ -57,7 +57,7 @@ This parameter indicates the modulus of the public key of the endorsement key
 The --key option is an alias for --ek and should be used if key parameters
 for another key than an endorsement key are passed.
 
-In case ECC (elliptic curve crypography) keys are used, the parameter must
+In case ECC (elliptic curve cryptography) keys are used, the parameter must
 have the format --ek x=<hex digits>,y=<hex digits>,id=<curve id>. The
 id=<curve id> part is optional and only necessary for ECC curves other
 than secp256r1.

--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -55,7 +55,7 @@ Create an endorsement key (EK).
 Create an EK that can sign. This option requires --tpm2.
 
 This option will create a non-standard EK. When re-creating the EK, TPM 2
-tools have to use the EK Template that is witten at an NV index corresponding
+tools have to use the EK Template that is written at an NV index corresponding
 to the created EK (e.g., NV index 0x01c00004 for RS 2048 EK). Otherwise the
 tool-created EK will not correspond to the actual key being used or the
 modulus shown in the EK certificate.


### PR DESCRIPTION
I noticed some spelling mistakes while reading the man pages and decided to run a spell checker on the rest