### PR TITLE
tests: Set OPENSSL_ENABLE_SHA1_SIGNATURES=1 for IBMTSS2 test

### DIFF
--- a/tests/test_tpm2_ibmtss2
+++ b/tests/test_tpm2_ibmtss2
@@ -104,7 +104,7 @@ if ! ./startup; then
 	exit 1
 fi
 
-./reg.sh -a 2>&1 | tee "${REGLOG}"
+OPENSSL_ENABLE_SHA1_SIGNATURES=1 ./reg.sh -a 2>&1 | tee "${REGLOG}"
 
 ret=0
 


### PR DESCRIPTION
The IBMTSS2 tests uite creates signatures over SHA1 that may now fail on RHEL 9.x and CentOS 9. To have these tests succeed set OPENSSL_ENABLE_SHA1_SIGNATURES=1 so the tests do not need to be modified and also check that the TPM 2 can handle SHA1 signatures as before. 'swtpm socket --tpm2' should set this environment variable automatically if needed.