### PR TITLE
Allow more tests to run installed

### DIFF
--- a/tests/_test_encrypted_state
+++ b/tests/_test_encrypted_state
@@ -34,8 +34,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_encrypted_state
+++ b/tests/_test_encrypted_state
@@ -43,7 +43,7 @@ TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--key "file=$keyfile,mode=aes-cbc,format=hex,remove" \
 	--log "file=$logfile"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."
@@ -143,7 +143,7 @@ TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--key "file=$binkeyfile,mode=aes-cbc,format=binary,remove" \
 	--log "file=$logfile"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error (2): ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_getcap
+++ b/tests/_test_getcap
@@ -26,8 +26,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_hashing
+++ b/tests/_test_hashing
@@ -33,7 +33,7 @@ rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_hashing
+++ b/tests/_test_hashing
@@ -26,8 +26,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_hashing2
+++ b/tests/_test_hashing2
@@ -33,7 +33,7 @@ rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_hashing2
+++ b/tests/_test_hashing2
@@ -26,8 +26,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_init
+++ b/tests/_test_init
@@ -27,8 +27,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_init
+++ b/tests/_test_init
@@ -40,7 +40,7 @@ run_swtpm "${SWTPM_INTERFACE}" \
 	--tpmstate "dir=$TPM_PATH" \
 	--pid "file=$PID_FILE"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_locality
+++ b/tests/_test_locality
@@ -33,7 +33,7 @@ rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_locality
+++ b/tests/_test_locality
@@ -26,8 +26,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_migration_key
+++ b/tests/_test_migration_key
@@ -45,8 +45,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 
 # make a backup of the volatile state
 TPM_PATH=$tpmstatedir

--- a/tests/_test_migration_key
+++ b/tests/_test_migration_key
@@ -55,7 +55,7 @@ cp "${TESTDIR}"/data/tpmstate1/* "$TPM_PATH"
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--migration-key "pwdfile=$migpwdfile,remove=false,kdf=sha512"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."
@@ -149,7 +149,7 @@ echo "Test 1: Ok"
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--migration-key "pwdfile=$migpwdfile,remove=false,kdf=sha512"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."
@@ -194,7 +194,7 @@ echo "Test 2: Ok"
 # This time we make this fail since we don't provide the migration key
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."
@@ -231,7 +231,7 @@ echo "Test 3: Ok"
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--migration-key "pwdfile=$migpwdfile,remove=true,kdf=sha512"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -8,8 +8,8 @@ TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
 PATH=$ROOT/src/swtpm:$PATH
 
-[ "${SWTPM_IFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_IFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 if ! msg="$(${SWTPM_EXE} "${SWTPM_IFACE}" --print-capabilities 2>&1)"; then
 	echo "Error: Could not pass --print-capabilities"

--- a/tests/_test_print_states
+++ b/tests/_test_print_states
@@ -8,8 +8,8 @@ TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
 PATH=$ROOT/src/swtpm:$PATH
 
-[ "${SWTPM_IFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_IFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 trap "cleanup" SIGTERM EXIT
 

--- a/tests/_test_resume_volatile
+++ b/tests/_test_resume_volatile
@@ -41,7 +41,7 @@ cp "${TESTDIR}"/data/tpmstate1/* "${TPM_PATH}"
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."
@@ -92,7 +92,7 @@ cp "${TESTDIR}"/data/tpmstate2/* "${TPM_PATH}"
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--key "pwdfile=${TESTDIR}/data/tpmstate2/pwdfile.txt,kdf=sha512"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."
@@ -145,7 +145,7 @@ cp "${TESTDIR}"/data/tpmstate2b/* "${TPM_PATH}"
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--key "pwdfile=${TESTDIR}/data/tpmstate2b/pwdfile.txt,mode=aes-256-cbc"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_resume_volatile
+++ b/tests/_test_resume_volatile
@@ -30,8 +30,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 
 TPM_PATH=$tpmstatedir
 VOLATILE_STATE_FILE="$TPM_PATH/tpm-00.volatilestate"

--- a/tests/_test_save_load_encrypted_state
+++ b/tests/_test_save_load_encrypted_state
@@ -34,8 +34,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_save_load_encrypted_state
+++ b/tests/_test_save_load_encrypted_state
@@ -45,7 +45,7 @@ TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--log "file=$logfile"
 exec 101>&-
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."
@@ -290,7 +290,7 @@ TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--log "file=$logfile"
 exec 101>&-
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."
@@ -364,7 +364,7 @@ TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--key "pwdfile=$keyfile,mode=aes-256-cbc" \
 	--log "file=$logfile"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_save_load_state
+++ b/tests/_test_save_load_state
@@ -47,7 +47,7 @@ TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	${BACKEND_PARAM:+${BACKEND_PARAM}} \
 	--log "file=$logfile"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_save_load_state
+++ b/tests/_test_save_load_state
@@ -38,8 +38,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_setbuffersize
+++ b/tests/_test_setbuffersize
@@ -27,8 +27,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_swtpm_bios
+++ b/tests/_test_swtpm_bios
@@ -27,8 +27,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_swtpm_bios
+++ b/tests/_test_swtpm_bios
@@ -34,7 +34,7 @@ rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 
 run_swtpm "${SWTPM_INTERFACE}" --tpmstate "dir=$TPM_PATH" --pid "file=$PID_FILE"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_tpm2_avoid_da_lockout
+++ b/tests/_test_tpm2_avoid_da_lockout
@@ -24,9 +24,9 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
 source "${TESTDIR}/test_common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--tpm2 \

--- a/tests/_test_tpm2_derived_keys
+++ b/tests/_test_tpm2_derived_keys
@@ -30,8 +30,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 TPM_PATH=$tpmstatedir
 

--- a/tests/_test_tpm2_encrypted_state
+++ b/tests/_test_tpm2_encrypted_state
@@ -44,7 +44,7 @@ TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--log "file=$logfile" \
 	--tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."
@@ -145,7 +145,7 @@ TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--log "file=$logfile" \
 	--tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error (2): ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_tpm2_encrypted_state
+++ b/tests/_test_tpm2_encrypted_state
@@ -34,8 +34,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_tpm2_file_permissions
+++ b/tests/_test_tpm2_file_permissions
@@ -26,8 +26,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 SWTPM_SETUP_CONF=${TPM_PATH}/swtpm_setup.conf
 
 cat <<_EOF_ > "${SWTPM_SETUP_CONF}"

--- a/tests/_test_tpm2_getcap
+++ b/tests/_test_tpm2_getcap
@@ -33,7 +33,7 @@ rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" --tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_tpm2_getcap
+++ b/tests/_test_tpm2_getcap
@@ -26,8 +26,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_tpm2_hashing
+++ b/tests/_test_tpm2_hashing
@@ -27,8 +27,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_tpm2_hashing
+++ b/tests/_test_tpm2_hashing
@@ -34,7 +34,7 @@ rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" --tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_tpm2_hashing2
+++ b/tests/_test_tpm2_hashing2
@@ -33,7 +33,7 @@ rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" --tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_tpm2_hashing2
+++ b/tests/_test_tpm2_hashing2
@@ -26,8 +26,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_tpm2_hashing3
+++ b/tests/_test_tpm2_hashing3
@@ -33,7 +33,7 @@ rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" --tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_tpm2_hashing3
+++ b/tests/_test_tpm2_hashing3
@@ -26,8 +26,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_tpm2_init
+++ b/tests/_test_tpm2_init
@@ -37,7 +37,7 @@ fi
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" --tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_tpm2_init
+++ b/tests/_test_tpm2_init
@@ -26,8 +26,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_tpm2_locality
+++ b/tests/_test_tpm2_locality
@@ -33,7 +33,7 @@ rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" --tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_tpm2_locality
+++ b/tests/_test_tpm2_locality
@@ -26,8 +26,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_tpm2_migration_key
+++ b/tests/_test_tpm2_migration_key
@@ -126,7 +126,7 @@ TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--tpm2 \
 	--migration-key "pwdfile=$migpwdfile,remove=false,kdf=sha512"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."
@@ -177,7 +177,7 @@ TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--log "file=${logfile}" \
 	--tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."
@@ -222,7 +222,7 @@ TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--tpm2 \
 	--migration-key "pwdfile=$migpwdfile,remove=true,kdf=sha512"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: TPM did not start."

--- a/tests/_test_tpm2_migration_key
+++ b/tests/_test_tpm2_migration_key
@@ -46,8 +46,8 @@ logfile="$(mktemp)" || exit 1
 SWTPM_CMD_UNIX_PATH=${tpmstatedir}/unix-cmd.sock
 SWTPM_CTRL_UNIX_PATH=${tpmstatedir}/unix-ctrl.sock
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 # make a backup of the volatile state
 TPM_PATH=$tpmstatedir

--- a/tests/_test_tpm2_print_capabilities
+++ b/tests/_test_tpm2_print_capabilities
@@ -8,8 +8,8 @@ TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
 PATH=$ROOT/src/swtpm:$PATH
 
-[ "${SWTPM_IFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_IFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 if ! msg="$(${SWTPM_EXE} "${SWTPM_IFACE}" --tpm2 --print-capabilities 2>&1)"; then
 	echo "Error: Could not pass --print-capabilities"

--- a/tests/_test_tpm2_print_states
+++ b/tests/_test_tpm2_print_states
@@ -8,8 +8,8 @@ TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
 PATH=$ROOT/src/swtpm:$PATH
 
-[ "${SWTPM_IFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_IFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 trap "cleanup" SIGTERM EXIT
 

--- a/tests/_test_tpm2_probe
+++ b/tests/_test_tpm2_probe
@@ -33,7 +33,7 @@ rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" --tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_tpm2_probe
+++ b/tests/_test_tpm2_probe
@@ -26,8 +26,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_tpm2_resume_volatile
+++ b/tests/_test_tpm2_resume_volatile
@@ -41,7 +41,7 @@ cp "${TESTDIR}"/data/tpm2state1/* "${TPM_PATH}"
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" --tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: CUSE TPM did not start."
@@ -92,7 +92,7 @@ TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--tpm2 \
 	--key "pwdfile=${TESTDIR}/data/tpm2state2/pwdfile.txt,kdf=sha512"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: CUSE TPM did not start."
@@ -146,7 +146,7 @@ TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--tpm2 \
 	--key "pwdfile=${TESTDIR}/data/tpm2state2b/pwdfile.txt,mode=aes-256-cbc"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: CUSE TPM did not start."

--- a/tests/_test_tpm2_resume_volatile
+++ b/tests/_test_tpm2_resume_volatile
@@ -30,8 +30,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 TPM_PATH=$tpmstatedir
 VOLATILE_STATE_FILE="$TPM_PATH/tpm2-00.volatilestate"

--- a/tests/_test_tpm2_save_load_encrypted_state
+++ b/tests/_test_tpm2_save_load_encrypted_state
@@ -44,7 +44,7 @@ TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--log "file=$logfile" \
 	--tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."
@@ -256,7 +256,7 @@ TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--log "file=$logfile" \
 	--tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."
@@ -333,7 +333,7 @@ TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--log "file=$logfile" \
 	--tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_tpm2_save_load_encrypted_state
+++ b/tests/_test_tpm2_save_load_encrypted_state
@@ -34,8 +34,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_tpm2_save_load_state
+++ b/tests/_test_tpm2_save_load_state
@@ -40,7 +40,7 @@ TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--log "file=$logfile,level=20" \
 	--tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_tpm2_save_load_state
+++ b/tests/_test_tpm2_save_load_state
@@ -31,8 +31,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_tpm2_save_load_state_da_timeout
+++ b/tests/_test_tpm2_save_load_state_da_timeout
@@ -41,7 +41,7 @@ TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--log "file=$logfile,level=20" \
 	--tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_tpm2_save_load_state_da_timeout
+++ b/tests/_test_tpm2_save_load_state_da_timeout
@@ -32,8 +32,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_tpm2_save_load_state_locking
+++ b/tests/_test_tpm2_save_load_state_locking
@@ -28,8 +28,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" \
 	--migration release-lock-outgoing \

--- a/tests/_test_tpm2_savestate
+++ b/tests/_test_tpm2_savestate
@@ -33,7 +33,7 @@ rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" --tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_tpm2_savestate
+++ b/tests/_test_tpm2_savestate
@@ -26,8 +26,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_tpm2_setbuffersize
+++ b/tests/_test_tpm2_setbuffersize
@@ -27,8 +27,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_tpm2_swtpm_bios
+++ b/tests/_test_tpm2_swtpm_bios
@@ -11,7 +11,7 @@ SWTPM_DEV_NAME="/dev/${VTPM_NAME}"
 TPM_PATH="$(mktemp -d)" || exit 1
 STATE_FILE=$TPM_PATH/tpm2-00.permall
 VOLATILE_STATE_FILE=$TPM_PATH/tpm-00.volatilestate
-PID_FILE=$TPM_PATH/SWTPM.pid
+PID_FILE=$TPM_PATH/swtpm.pid
 SWTPM_INTERFACE=${SWTPM_INTERFACE:-cuse}
 SWTPM_CMD_UNIX_PATH=${TPM_PATH}/unix-cmd.sock
 SWTPM_CTRL_UNIX_PATH=${TPM_PATH}/unix-ctrl.sock
@@ -34,7 +34,7 @@ rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 
 run_swtpm "${SWTPM_INTERFACE}" --tpm2 --tpmstate "dir=$TPM_PATH" --pid "file=$PID_FILE"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_tpm2_swtpm_bios
+++ b/tests/_test_tpm2_swtpm_bios
@@ -27,8 +27,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_tpm2_volatilestate
+++ b/tests/_test_tpm2_volatilestate
@@ -33,7 +33,7 @@ rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" --tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."
@@ -107,7 +107,7 @@ fi
 # Start the TPM again
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" --tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_tpm2_volatilestate
+++ b/tests/_test_tpm2_volatilestate
@@ -26,8 +26,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_tpm2_wrongorder
+++ b/tests/_test_tpm2_wrongorder
@@ -33,7 +33,7 @@ rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" --tpm2
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_tpm2_wrongorder
+++ b/tests/_test_tpm2_wrongorder
@@ -26,8 +26,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_tpm_probe
+++ b/tests/_test_tpm_probe
@@ -33,7 +33,7 @@ rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_tpm_probe
+++ b/tests/_test_tpm_probe
@@ -26,8 +26,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_volatilestate
+++ b/tests/_test_volatilestate
@@ -33,7 +33,7 @@ rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."
@@ -106,7 +106,7 @@ fi
 # Start the TPM again
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_volatilestate
+++ b/tests/_test_volatilestate
@@ -26,8 +26,8 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
+[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/_test_wrongorder
+++ b/tests/_test_wrongorder
@@ -35,7 +35,7 @@ rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" --log "file=$LOG_FILE,level=20"
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "${SWTPM_PID}"; then
 	echo "Error: ${SWTPM_INTERFACE} TPM did not start."

--- a/tests/_test_wrongorder
+++ b/tests/_test_wrongorder
@@ -27,9 +27,9 @@ function cleanup()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 source "${TESTDIR}/common"
 source "${TESTDIR}/test_common"
+[ "${SWTPM_INTERFACE}" == cuse ] && source "${TESTDIR}/test_cuse"
 
 rm -f "$STATE_FILE" "$VOLATILE_STATE_FILE" 2>/dev/null
 

--- a/tests/common
+++ b/tests/common
@@ -4,8 +4,7 @@
 SWTPM_TEST_UNINSTALLED=1
 
 if [ -n "${SWTPM_TEST_UNINSTALLED}" ]; then
-    SWTPM=swtpm
-    SWTPM_EXE=${SWTPM_EXE:-${ROOT}/src/swtpm/${SWTPM}}
+    SWTPM_EXE=${SWTPM_EXE:-${ROOT}/src/swtpm/swtpm}
     SWTPM_IOCTL=${SWTPM_IOCTL:-${ROOT}/src/swtpm_ioctl/swtpm_ioctl}
     SWTPM_BIOS=${SWTPM_BIOS:-${ROOT}/src/swtpm_bios/swtpm_bios}
     SWTPM_SETUP=${SWTPM_SETUP:-${ROOT}/src/swtpm_setup/swtpm_setup}

--- a/tests/test_commandline
+++ b/tests/test_commandline
@@ -13,13 +13,12 @@ fi
 ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:=$(dirname "$0")}
 
-# need SWTPM to be set
 source "${TESTDIR}/common"
 skip_test_no_tpm12 "${SWTPM_EXE}"
 
 TPMDIR="$(mktemp -d)" || exit 1
-PID_FILE=$TPMDIR/${SWTPM}.pid
-LOG_FILE=$TPMDIR/${SWTPM}.log
+PID_FILE=$TPMDIR/swtpm.pid
+LOG_FILE=$TPMDIR/swtpm.log
 
 source "${TESTDIR}/test_common"
 
@@ -177,7 +176,7 @@ cleanup
 
 # Test 4: --tpmstate backend-uri=dir:// parameter test
 TPMDIR="$(mktemp -d)" || exit 1
-PID_FILE=$TPMDIR/${SWTPM}.pid
+PID_FILE=$TPMDIR/swtpm.pid
 FILEMODE=641
 
 $SWTPM_EXE socket \

--- a/tests/test_ctrlchannel2
+++ b/tests/test_ctrlchannel2
@@ -5,11 +5,8 @@
 ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
-SWTPM=swtpm
-SWTPM_EXE=${SWTPM_EXE:-$ROOT/src/swtpm/$SWTPM}
-SWTPM_IOCTL=${SWTPM_IOCTL:-$ROOT/src/swtpm_ioctl/swtpm_ioctl}
 TPMDIR="$(mktemp -d)" || exit 1
-PID_FILE=$TPMDIR/${SWTPM}.pid
+PID_FILE=$TPMDIR/swtpm.pid
 SOCK_PATH=$TPMDIR/sock
 VOLATILESTATE=$TPMDIR/volatile
 

--- a/tests/test_cuse
+++ b/tests/test_cuse
@@ -13,8 +13,12 @@ if [ "$(id -u)" -ne 0 ]; then
 	exit 77
 fi
 
-if ! grep -q -E '#[[:blank:]]*define[[:blank:]]+WITH_CUSE[[:blank:]]+1[[:blank:]]*$' \
-		"${PWD}/../config.h"; then
+if [ -z "${SWTPM_EXE}" ]; then
+	echo "Error: SWTPM_EXE must be set"
+	exit 1
+fi
+
+if ! ${SWTPM_EXE} --help | grep -q cuse; then
 	echo "Skipping test: swtpm was not compiled with CUSE interface"
 	exit 77
 fi

--- a/tests/test_samples_create_tpmca
+++ b/tests/test_samples_create_tpmca
@@ -27,7 +27,6 @@ source "${abs_top_builddir:-$(dirname "$0")/..}/tests/test_config"
 SWTPM_SETUP=${ROOT}/src/swtpm_setup/swtpm_setup
 SWTPM_CREATE_TPMCA=${SRCDIR}/samples/swtpm-create-tpmca
 SWTPM_LOCALCA=${ROOT}/src/swtpm_localca/swtpm_localca
-SWTPM=${ROOT}/src/swtpm/swtpm
 SWTPM_IOCTL=${ROOT}/src/swtpm_ioctl/swtpm_ioctl
 
 SWTPM_INTERFACE=socket+socket

--- a/tests/test_tpm2_chroot_chardev
+++ b/tests/test_tpm2_chroot_chardev
@@ -16,9 +16,7 @@ fi
 ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
-SWTPM=swtpm
-SWTPM_EXE=${SWTPM_EXE:-$ROOT/src/swtpm/$SWTPM}
-PID_FILE=/${SWTPM}.pid
+PID_FILE=/swtpm.pid
 
 source "${TESTDIR}/common"
 source "${TESTDIR}/test_common"

--- a/tests/test_tpm2_chroot_cuse
+++ b/tests/test_tpm2_chroot_cuse
@@ -21,9 +21,7 @@ fi
 ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
-SWTPM=swtpm
-SWTPM_EXE=${SWTPM_EXE:-$ROOT/src/swtpm/$SWTPM}
-PID_FILE=/${SWTPM}.pid
+PID_FILE=/swtpm.pid
 VTPM_NAME="vtpm-test-chroot"
 SWTPM_DEV_NAME="/dev/${VTPM_NAME}"
 

--- a/tests/test_tpm2_chroot_socket
+++ b/tests/test_tpm2_chroot_socket
@@ -16,9 +16,7 @@ fi
 ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:=$(dirname "$0")}
 
-SWTPM=swtpm
-SWTPM_EXE=${SWTPM_EXE:-$ROOT/src/swtpm/$SWTPM}
-PID_FILE=/${SWTPM}.pid
+PID_FILE=/swtpm.pid
 
 source "${TESTDIR}/common"
 source "${TESTDIR}/test_common"

--- a/tests/test_tpm2_ctrlchannel2
+++ b/tests/test_tpm2_ctrlchannel2
@@ -5,11 +5,8 @@
 ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
-SWTPM=swtpm
-SWTPM_EXE=${SWTPM_EXE:-$ROOT/src/swtpm/$SWTPM}
-SWTPM_IOCTL=${SWTPM_IOCTL:-$ROOT/src/swtpm_ioctl/swtpm_ioctl}
 TPMDIR="$(mktemp -d)" || exit 1
-PID_FILE=$TPMDIR/${SWTPM}.pid
+PID_FILE=$TPMDIR/swtpm.pid
 SOCK_PATH=$TPMDIR/sock
 LOGFILE=$TPMDIR/logfile
 VOLATILESTATE=$TPMDIR/volatile

--- a/tests/test_tpm2_libtpms_versions_profiles
+++ b/tests/test_tpm2_libtpms_versions_profiles
@@ -61,6 +61,11 @@ _EOF_
 # Copy swtpm source tree to workdir
 pushd "${SRCDIR}" &>/dev/null || exit 1
 
+if [ ! -d ".git" ]; then
+	echo "SKIP: This test must be run from a git checkout"
+	exit 77
+fi
+
 mkdir -p "${workdir}/swtpm"
 cp -rp . "${workdir}/swtpm"
 cd "${workdir}/swtpm" || exit 1

--- a/tests/test_tpm2_partial_reads
+++ b/tests/test_tpm2_partial_reads
@@ -33,8 +33,8 @@ function swtpm_read_n_bytes_fd100()
 
 trap "cleanup" EXIT
 
-[ "${SWTPM_INTERFACE}" == "cuse" ] && source test_cuse
 source common
+[ "${SWTPM_INTERFACE}" == "cuse" ] && source test_cuse
 skip_test_no_tpm20 "${SWTPM_EXE}"
 
 TPM_PATH=$TPM_PATH run_swtpm "${SWTPM_INTERFACE}" --tpm2

--- a/tests/test_tpm2_samples_create_tpmca.test
+++ b/tests/test_tpm2_samples_create_tpmca.test
@@ -40,11 +40,8 @@ ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:=$(dirname "$0")}
 SRCDIR=${abs_top_srcdir:-$(dirname "$0")/..}
 
-SWTPM_SETUP=${ROOT}/src/swtpm_setup/swtpm_setup
+source "${TESTDIR}/common"
 SWTPM_CREATE_TPMCA=${SRCDIR}/samples/swtpm-create-tpmca
-SWTPM_LOCALCA=${ROOT}/src/swtpm_localca/swtpm_localca
-SWTPM=${ROOT}/src/swtpm/swtpm
-SWTPM_IOCTL=${ROOT}/src/swtpm_ioctl/swtpm_ioctl
 
 SWTPM_INTERFACE=socket+socket
 SWTPM_SERVER_NAME=localhost

--- a/tests/test_tpm2_save_load_state_2
+++ b/tests/test_tpm2_save_load_state_2
@@ -20,11 +20,8 @@ TOOLSPATH=$(dirname "$(type -P "${PREFIX}startup")")
 ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
-SWTPM=swtpm
-SWTPM_EXE=${SWTPM_EXE:-$ROOT/src/swtpm/$SWTPM}
-SWTPM_IOCTL=$ROOT/src/swtpm_ioctl/swtpm_ioctl
 TPMDIR="$(mktemp -d)" || exit 1
-PID_FILE=$TPMDIR/${SWTPM}.pid
+PID_FILE=$TPMDIR/swtpm.pid
 SOCK_PATH=$TPMDIR/sock
 LOGFILE=$TPMDIR/logfile
 TMPFILE=$TPMDIR/tmpfile

--- a/tests/test_tpm2_save_load_state_3
+++ b/tests/test_tpm2_save_load_state_3
@@ -20,11 +20,8 @@ TOOLSPATH=$(dirname "$(type -P "${PREFIX}startup")")
 ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
-SWTPM=swtpm
-SWTPM_EXE=${SWTPM_EXE:-$ROOT/src/swtpm/$SWTPM}
-SWTPM_IOCTL=$ROOT/src/swtpm_ioctl/swtpm_ioctl
 TPMDIR="$(mktemp -d)" || exit 1
-PID_FILE=$TPMDIR/${SWTPM}.pid
+PID_FILE=$TPMDIR/swtpm.pid
 SOCK_PATH=$TPMDIR/sock
 LOGFILE=$TPMDIR/logfile
 TMPFILE=$TPMDIR/tmpfile

--- a/tests/test_tpm2_vtpm_proxy
+++ b/tests/test_tpm2_vtpm_proxy
@@ -11,12 +11,10 @@ fi
 ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
-SWTPM=swtpm
-SWTPM_EXE=$ROOT/src/swtpm/$SWTPM
 TPM_PATH="$(mktemp -d)" || exit 1
 STATE_FILE=$TPM_PATH/tpm2-00.permall
 VOLATILE_STATE_FILE=$TPM_PATH/tpm2-00.volatilestate
-PID_FILE=$TPM_PATH/${SWTPM}.pid
+PID_FILE=$TPM_PATH/swtpm.pid
 SOCK_PATH=$TPM_PATH/sock
 CMD_PATH=$TPM_PATH/cmd
 RESP_PATH=$TPM_PATH/resp
@@ -24,7 +22,7 @@ LOGFILE=$TPM_PATH/logfile
 
 function cleanup()
 {
-	pid=$(ps aux | grep "$SWTPM" | grep -E " file=${PID_FILE}\$" | gawk '{print $2}')
+	pid=$(ps aux | grep "swtpm" | grep -E " file=${PID_FILE}\$" | gawk '{print $2}')
 	if [ -n "$pid" ]; then
 		kill_quiet -9 "$pid"
 	fi
@@ -49,9 +47,9 @@ $SWTPM_EXE chardev \
 	${SWTPM_TEST_SECCOMP_OPT:+${SWTPM_TEST_SECCOMP_OPT}} \
 	--pid "file=$PID_FILE" &>"$LOGFILE" &
 sleep 0.5
-PID=$(ps aux | grep $SWTPM | grep -E " file=${PID_FILE}\$" | gawk '{print $2}')
+PID=$(ps aux | grep swtpm | grep -E " file=${PID_FILE}\$" | gawk '{print $2}')
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "$PID"; then
 	echo "Error: Chardev TPM did not start."

--- a/tests/test_vtpm_proxy
+++ b/tests/test_vtpm_proxy
@@ -11,12 +11,10 @@ fi
 ROOT=${abs_top_builddir:-$(dirname "$0")/..}
 TESTDIR=${abs_top_testdir:-$(dirname "$0")}
 
-SWTPM=swtpm
-SWTPM_EXE=${SWTPM_EXE:-$ROOT/src/swtpm/$SWTPM}
 TPM_PATH="$(mktemp -d)" || exit 1
 STATE_FILE=$TPM_PATH/tpm-00.permall
 VOLATILE_STATE_FILE=$TPM_PATH/tpm-00.volatilestate
-PID_FILE=$TPM_PATH/${SWTPM}.pid
+PID_FILE=$TPM_PATH/swtpm.pid
 SOCK_PATH=$TPM_PATH/sock
 CMD_PATH=$TPM_PATH/cmd
 RESP_PATH=$TPM_PATH/resp
@@ -24,7 +22,7 @@ LOGFILE=$TPM_PATH/logfile
 
 function cleanup()
 {
-	pid=$(ps aux | grep "$SWTPM" | grep -E " file=${PID_FILE}\$" | gawk '{print $2}')
+	pid=$(ps aux | grep "swtpm" | grep -E " file=${PID_FILE}\$" | gawk '{print $2}')
 	if [ -n "$pid" ]; then
 		kill_quiet -9 "$pid"
 	fi
@@ -46,9 +44,9 @@ $SWTPM_EXE chardev --vtpm-proxy \
 	${SWTPM_TEST_SECCOMP_OPT:+${SWTPM_TEST_SECCOMP_OPT}} \
 	--pid "file=$PID_FILE" &>"$LOGFILE" &
 sleep 0.5
-PID=$(ps aux | grep $SWTPM | grep -E " file=${PID_FILE}\$" | gawk '{print $2}')
+PID=$(ps aux | grep swtpm | grep -E " file=${PID_FILE}\$" | gawk '{print $2}')
 
-display_processes_by_name "$SWTPM"
+display_processes_by_name "swtpm"
 
 if ! kill_quiet -0 "$PID"; then
 	echo "Error: Chardev TPM did not start."


### PR DESCRIPTION
This PR cleans up the test cases so they all use the SWTPM_XYZ defines from file `common` so that all test cases can run 'installed'.