### PR TITLE
swtpm: Use TPMLIB_WasManufactured to check whether profile was applied

### DIFF
--- a/man/man8/swtpm.pod
+++ b/man/man8/swtpm.pod
@@ -473,8 +473,8 @@ enables.
 
 The profile can only be set the very first time that a TPM 2 instance is
 started and for as long as no state file exists. The profile cannot be changed
-anymore afterwards and, if passed again using this option, will be silently
-ignored.
+anymore afterwards and, if passed again using this option, an error will
+occur.
 
 Note that profiles may disable algorithms that are considered mandatory for
 a TPM 2, such as RSA-PSS. However, FIPS-enforcement on the host disables

--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -580,6 +580,7 @@ int ctrlchannel_process_fd(int fd,
                       "Error: Could not initialize the TPM\n");
         } else {
             *tpm_running = true;
+            SWTPM_G_FREE(mlp->json_profile);
         }
 
         *res_p = htobe32(res);

--- a/src/swtpm/cuse_tpm.c
+++ b/src/swtpm/cuse_tpm.c
@@ -1186,6 +1186,7 @@ static void ptm_ioctl(fuse_req_t req, int cmd, void *arg,
                           "Error: Could not initialize the TPM.\n");
             } else {
                 tpm_running = true;
+                SWTPM_G_FREE(g_json_profile);
             }
             init_p->u.resp.tpm_result = res;
             fuse_reply_ioctl(req, 0, init_p, sizeof(*init_p));
@@ -1900,6 +1901,7 @@ int swtpm_cuse_main(int argc, char **argv, const char *prgname, const char *ifac
             goto err_unlock;
         }
         tpm_running = true;
+        SWTPM_G_FREE(g_json_profile);
     }
 
     if (param.startupType != _TPM_ST_NONE) {

--- a/src/swtpm/swtpm.c
+++ b/src/swtpm/swtpm.c
@@ -58,6 +58,7 @@
 #include "swtpm_debug.h"
 #include "swtpm_io.h"
 #include "swtpm_nvstore.h"
+#include "swtpm_utils.h"
 #include "server.h"
 #include "common.h"
 #include "logging.h"
@@ -567,6 +568,7 @@ int swtpm_main(int argc, char **argv, const char *prgname, const char *iface)
                                mlp.json_profile)))
             goto error_no_tpm;
         tpm_running = true;
+        SWTPM_G_FREE(mlp.json_profile);
     }
 
     if (install_sighandlers(notify_fd, sigterm_handler) < 0)

--- a/src/swtpm/swtpm_chardev.c
+++ b/src/swtpm/swtpm_chardev.c
@@ -58,6 +58,7 @@
 #include "swtpm_debug.h"
 #include "swtpm_io.h"
 #include "swtpm_nvstore.h"
+#include "swtpm_utils.h"
 #include "common.h"
 #include "locality.h"
 #include "logging.h"
@@ -615,6 +616,7 @@ int swtpm_chardev_main(int argc, char **argv, const char *prgname, const char *i
                                mlp.json_profile)))
             goto error_no_tpm;
         tpm_running = true;
+        SWTPM_G_FREE(mlp.json_profile);
     }
 
     if (install_sighandlers(notify_fd, sigterm_handler) < 0)

--- a/src/swtpm/tpmlib.c
+++ b/src/swtpm/tpmlib.c
@@ -255,6 +255,13 @@ TPM_RESULT tpmlib_start(uint32_t flags, TPMLIB_TPMVersion tpmversion,
         return res;
     }
 
+    if (json_profile != NULL && tpmversion == TPMLIB_TPM_VERSION_2 &&
+        !TPMLIB_WasManufactured()) {
+        logprintf(STDERR_FILENO,
+                  "Error: Profile could not be applied to an existing TPM 2 instance.\n");
+        return TPM_FAIL;
+    }
+
     if (lock_nvram && (res = SWTPM_NVRAM_Lock_Storage(0)) != TPM_SUCCESS)
         goto error_terminate;
 


### PR DESCRIPTION
Use TPMLIB_WasManufactured to check whether a profile was applied since a new instance was created. If a profile was given and no new TPM 2 instance was created then display an error message and exit with an error code. This avoids silently ignoring a provided profile that was not applied since the TPM 2 instance already existed.

Make sure that a profile is only applied once by swtpm by clearing the json_profile once TPMLIB_MainInit succeeded.