### PR TITLE
swtpm: Print cmdarg-print-profiles as part of capabilities

### DIFF
--- a/man/man8/swtpm.pod
+++ b/man/man8/swtpm.pod
@@ -320,6 +320,9 @@ may contain the following:
       "features": [
         "tpm-1.2",
         "tpm-2.0",
+        "tpm-send-command-header",
+        "flags-opt-startup",
+        "flags-opt-disable-auto-shutdown",
         "cmdarg-seccomp",
         "cmdarg-key-fd",
         "cmdarg-pwd-fd",
@@ -328,14 +331,11 @@ may contain the following:
         "cmdarg-migration",
         "nvram-backend-dir",
         "nvram-backend-file",
-        "tpm-send-command-header",
-        "flags-opt-startup",
-        "flags-opt-disable-auto-shutdown",
         "rsa-keysize-1024",
         "rsa-keysize-2048",
         "rsa-keysize-3072",
         "cmdarg-profile",
-        "cmdarg-print-profile"
+        "cmdarg-print-profiles"
       ],
       "version": "0.7.0"
     }

--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -226,16 +226,17 @@ The output may contain the following:
     {
       "type": "swtpm_setup",
       "features": [
+        "tpm-1.2",
+        "tpm-2.0",
         "cmdarg-keyfile-fd",
         "cmdarg-pwdfile-fd",
+        "tpm12-not-need-root",
         "cmdarg-write-ek-cert-files",
         "cmdarg-create-config-files",
-	"cmdarg-reconfigure-pcr-banks",
+        "cmdarg-reconfigure-pcr-banks",
         "tpm2-rsa-keysize-2048",
         "tpm2-rsa-keysize-3072",
-        "tpm12-not-need-root",
-        "tpm-1.2",
-        "tpm-2.0"
+        "cmdarg-profile"
       ],
       "version": "0.7.0"
     }
@@ -285,6 +286,10 @@ TPM 1.2 setup is supported (libtpms is compiled with TPM 1.2 support).
 =item B<tpm-2.0> (since v0.7)
 
 TPM 2 setup is supported (libtpms is compiled with TPM 2 support).
+
+=item B<cmdarg-profile> (since v0.10)
+
+The I<--profile> option is supported.
 
 =back
 

--- a/src/swtpm/capabilities.c
+++ b/src/swtpm/capabilities.c
@@ -269,7 +269,7 @@ int capabilities_print_json(bool cusetpm, TPMLIB_TPMVersion tpmversion)
          "{ "
          "\"type\": \"swtpm\", "
          "\"features\": [ "
-             "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s"
+             "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s"
           " ], "
          "\"profiles\": { %s}, "
          "\"version\": \"" VERSION "\" "
@@ -290,6 +290,7 @@ int capabilities_print_json(bool cusetpm, TPMLIB_TPMVersion tpmversion)
          nvram_backend_file,
          keysizecaps  ? keysizecaps                    : "",
          true         ? ", \"cmdarg-profile\""         : "",
+         true         ? ", \"cmdarg-print-profiles\""  : "",
          profiles     ? profiles                       : ""
     );
 

--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -28,7 +28,8 @@ exp='\{ "type": "swtpm", '\
 '"features": \[ "tpm-1.2",( "tpm-2.0",)? '${noncuse}'"flags-opt-startup", '\
 '"flags-opt-disable-auto-shutdown", "ctrl-opt-terminate", '${seccomp}'"cmdarg-key-fd", '\
 '"cmdarg-pwd-fd", "cmdarg-print-states", "cmdarg-chroot", "cmdarg-migration", '\
-'"nvram-backend-dir", "nvram-backend-file"(, "cmdarg-profile")? \],'\
+'"nvram-backend-dir", "nvram-backend-file", "cmdarg-profile", '\
+'"cmdarg-print-profiles" \],'\
 '( "profiles": \{ \},)? '\
 '"version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then

--- a/tests/_test_tpm2_print_capabilities
+++ b/tests/_test_tpm2_print_capabilities
@@ -30,7 +30,8 @@ exp='\{ "type": "swtpm", '\
 '"flags-opt-disable-auto-shutdown", "ctrl-opt-terminate", '${seccomp}'"cmdarg-key-fd", '\
 '"cmdarg-pwd-fd", "cmdarg-print-states", "cmdarg-chroot", "cmdarg-migration", '\
 '"nvram-backend-dir", "nvram-backend-file"'\
-'(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")?(, "cmdarg-profile")? \],'\
+'(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")?, "cmdarg-profile", '\
+'"cmdarg-print-profiles" \],'\
 '( "profiles": \{ "names": \[ [^]]*\], "algorithms": \{ [^\}]*\}, "commands": \{ [^\}]*\} },)? '\
 '"version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then


### PR DESCRIPTION
Commit 96fe5afa forgot to add cmdarg-print-profiles to the list of capabilities. Also fix typo in the man page.

Fixes: 96fe5afa ("swtpm: Add support for --print-profiles option")