### PR TITLE
CI/CD: Avoid caching of container build to get latest libtpms version

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -73,8 +73,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
           #platforms: linux/amd64,linux/arm/v7,linux/arm/v6
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          no-cache: true
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Avoid caching of container builds to get latest libtpms version and therefore pass tests that depend on changes to libtpms.