### PR TITLE
Some fixes to run tests on BSDs

### DIFF
--- a/src/swtpm/check_algos.c
+++ b/src/swtpm/check_algos.c
@@ -211,7 +211,9 @@ unsigned char rsa1024_der[] = {
   0xea, 0xe6, 0xf3, 0xfb, 0x37, 0xfc, 0x8f, 0x60, 0xae, 0x29
 };
 
-static int check_cipher(const char *ciphername, unsigned int _1, unsigned int _2)
+static int check_cipher(const char *ciphername,
+                        unsigned int unused1 SWTPM_ATTR_UNUSED,
+                        unsigned int unused2 SWTPM_ATTR_UNUSED)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
     EVP_CIPHER *c = EVP_CIPHER_fetch(NULL, ciphername, NULL);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -178,6 +178,7 @@ EXTRA_DIST = \
 	patches/0010-Adjust-test-cases-for-OpenSSL-3.patch \
 	patches/0012-Disable-Nuvoton-commands.patch \
 	patches/libtpm.patch \
+	sed-inplace \
 	softhsm_setup \
 	test_clientfds.py \
 	test_setdatafd.py \
@@ -232,7 +233,7 @@ install-data-hook:
 	mkdir -p $(DESTDIR)$(testdir)
 	cd $(srcdir) && for file in $(EXTRA_DIST); do ./fileinstall "$$file" "$(DESTDIR)$(testdir)/$$file" ; done
 	echo "$(TESTS)" > $(DESTDIR)$(testdir)/tests
-	sed -i '/SWTPM_TEST_UNINSTALLED=1/d' $(DESTDIR)$(testdir)/common
+	$(srcdir)/sed-inplace '/SWTPM_TEST_UNINSTALLED=1/d' $(DESTDIR)$(testdir)/common
 
 uninstall-hook:
 	cd $(DESTDIR)$(testdir) && rm -f $(EXTRA_DIST) tests

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -169,6 +169,7 @@ EXTRA_DIST = \
 	data/tpm2state5/signature.bin \
 	data/tpm2state5/tpm2-00.permall \
 	data/tpm2state6/tpm2-00.permall \
+	fileinstall \
 	patches/0001-Deactivate-test-cases-accessing-rootcerts.txt.patch \
 	patches/0002-Implement-powerup-for-swtpm.patch \
 	patches/0003-Set-CRYPTOLIBRARY-to-openssl.patch \
@@ -229,7 +230,7 @@ testdir = $(libexecdir)/installed-tests/$(PACKAGE)
 
 install-data-hook:
 	mkdir -p $(DESTDIR)$(testdir)
-	cd $(srcdir) && for file in $(EXTRA_DIST); do install -D "$$file" "$(DESTDIR)$(testdir)/$$file" ; done
+	cd $(srcdir) && for file in $(EXTRA_DIST); do ./fileinstall "$$file" "$(DESTDIR)$(testdir)/$$file" ; done
 	echo "$(TESTS)" > $(DESTDIR)$(testdir)/tests
 	sed -i '/SWTPM_TEST_UNINSTALLED=1/d' $(DESTDIR)$(testdir)/common
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -231,7 +231,7 @@ testdir = $(libexecdir)/installed-tests/$(PACKAGE)
 
 install-data-hook:
 	mkdir -p $(DESTDIR)$(testdir)
-	cd $(srcdir) && for file in $(EXTRA_DIST); do ./fileinstall "$$file" "$(DESTDIR)$(testdir)/$$file" ; done
+	cd $(srcdir) && for file in test_config $(EXTRA_DIST); do ./fileinstall "$$file" "$(DESTDIR)$(testdir)/$$file" ; done
 	echo "$(TESTS)" > $(DESTDIR)$(testdir)/tests
 	$(srcdir)/sed-inplace '/SWTPM_TEST_UNINSTALLED=1/d' $(DESTDIR)$(testdir)/common
 

--- a/tests/fileinstall
+++ b/tests/fileinstall
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-) ]]; then
+	install -D "$1" "$2"
+else
+	mkdir -p "$(dirname "$2")"
+	install "$1" "$2"
+fi

--- a/tests/sed-inplace
+++ b/tests/sed-inplace
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-) ]]; then
+	sed -i "$1" "$2"
+else
+	sed -i '' "$1" "$2"
+fi

--- a/tests/test_samples_create_tpmca
+++ b/tests/test_samples_create_tpmca
@@ -22,12 +22,18 @@ SRCDIR=${abs_top_srcdir:-$(dirname "$0")/..}
 
 PATH=$ROOT/src/swtpm:$PATH
 
-source "${abs_top_builddir:-$(dirname "$0")/..}/tests/test_config"
+source "${TESTDIR}/test_config"
+source "${TESTDIR}/common"
 
-SWTPM_SETUP=${ROOT}/src/swtpm_setup/swtpm_setup
-SWTPM_CREATE_TPMCA=${SRCDIR}/samples/swtpm-create-tpmca
-SWTPM_LOCALCA=${ROOT}/src/swtpm_localca/swtpm_localca
-SWTPM_IOCTL=${ROOT}/src/swtpm_ioctl/swtpm_ioctl
+if [ -n "${SWTPM_TEST_UNINSTALLED}" ]; then
+	SWTPM_CREATE_TPMCA=${SRCDIR}/samples/swtpm-create-tpmca
+else
+	SWTPM_CREATE_TPMCA=/usr/share/swtpm/swtpm-create-tpmca
+fi
+if [ ! -x "${SWTPM_CREATE_TPMCA}" ]; then
+	echo "Could not find swtpm-create-tpmca"
+	exit 77
+fi
 
 SWTPM_INTERFACE=socket+socket
 SWTPM_SERVER_NAME=localhost
@@ -75,7 +81,6 @@ function cleanup()
 }
 
 trap "cleanup" SIGTERM EXIT
-source "${TESTDIR}/common"
 skip_test_no_tpm12 "${SWTPM_EXE}"
 
 PATH=${ROOT}/src/swtpm_bios:${ROOT}/src/swtpm_cert:${PATH}


### PR DESCRIPTION
This PR provides some fixes to also support installed tests on BSDs where the install and sed tools work a little different than on Linux. Also fix an issue with unused function parameters that went unnoticed on Linux.