### PR TITLE
swtpm: Check for good entropy source in chroot environment

### DIFF
--- a/src/swtpm/utils.c
+++ b/src/swtpm/utils.c
@@ -53,6 +53,8 @@
 
 #include <json-glib/json-glib.h>
 
+#include <openssl/rand.h>
+
 #include "utils.h"
 #include "logging.h"
 #include "tpmlib.h"
@@ -162,6 +164,13 @@ do_chroot(const char *path)
                   strerror(errno));
         return -1;
     }
+
+    if (!RAND_status()) {
+        logprintf(STDERR_FILENO,
+                  "Error: no good entropy source in chroot environment\n");
+        return -1;
+    }
+
     return 0;
 }
 

--- a/tests/test_tpm2_chroot_socket
+++ b/tests/test_tpm2_chroot_socket
@@ -51,7 +51,7 @@ for OPTION in --chroot -R; do
 		--pid "file=$PID_FILE" \
 		--tpm2 \
 		--flags not-need-init \
-		${SWTPM_TEST_SECCOMP_OPT:+${SWTPM_TEST_SECCOMP_OPT}} &>/dev/null &
+		${SWTPM_TEST_SECCOMP_OPT:+${SWTPM_TEST_SECCOMP_OPT}} &
 	PID=$!
 
 	if wait_for_file "$TPMDIR/$PID_FILE" 3; then


### PR DESCRIPTION
Very old OpenSSL versions (e.g., 1.1.0i) are using /dev/urandom to get entropy while newer ones are using the getrandom syscall that does not need the device file. In some environments access to the created /dev/urandom device file may not work (EACCESS; chroot test case) and then OpenSSL will start failing operations that depend on good entropy. Therefore, check the status of the random number generator after chroot.