### PR TITLE
swtpm_setup: Always log the active profile

### DIFF
--- a/include/swtpm/tpm_ioctl.h
+++ b/include/swtpm/tpm_ioctl.h
@@ -227,8 +227,14 @@ struct ptm_getinfo {
     } u;
 };
 
-#define SWTPM_INFO_TPMSPECIFICATION ((uint64_t)1 << 0)
-#define SWTPM_INFO_TPMATTRIBUTES    ((uint64_t)1 << 1)
+#define SWTPM_INFO_TPMSPECIFICATION   ((uint64_t)1 << 0)
+#define SWTPM_INFO_TPMATTRIBUTES      ((uint64_t)1 << 1)
+#define SWTPM_INFO_TPMFEATURES        ((uint64_t)1 << 2)
+#define SWTPM_INFO_RUNTIME_ALGORITHMS ((uint64_t)1 << 3)
+#define SWTPM_INFO_RUNTIME_COMMANDS   ((uint64_t)1 << 4)
+#define SWTPM_INFO_ACTIVE_PROFILE     ((uint64_t)1 << 5)
+#define SWTPM_INFO_AVAILABLE_PROFILES ((uint64_t)1 << 6)
+#define SWTPM_INFO_RUNTIME_ATTRIBUTES ((uint64_t)1 << 7)
 
 /*
  * PTM_LOCK_STORAGE: Lock the storage and retry n times

--- a/src/swtpm_setup/swtpm.h
+++ b/src/swtpm_setup/swtpm.h
@@ -56,6 +56,7 @@ struct swtpm2_ops {
                                gboolean lock_nvram, const unsigned char *data, size_t data_len);
     int (*write_platform_cert_nvram)(struct swtpm *self, gboolean lock_nvram,
                                      const unsigned char *data, size_t data_len);
+    char *(*get_active_profile)(struct swtpm *self);
 };
 
 /* common structure for swtpm object */


### PR DESCRIPTION
Extend the list of SWTPM_INFO flags with recently added flags for
TPMLIB_GetInfo. Use the CMD_GET_INFO control channel command to get
the currently active profile for a TPM 2 from swtpm and display it in
the log every time unless it is reconfigured.