### PR TITLE
swtpm_setup: Accept profiles with name starting with 'custom:'

### DIFF
--- a/src/swtpm_setup/profile.c
+++ b/src/swtpm_setup/profile.c
@@ -90,6 +90,15 @@ int check_json_profile(const gchar *swtpm_capabilities_json, const char *json_pr
     if (ret)
         return ret;
 
+    if (strlen(name) > 32) {
+        logerr(gl_LOGFILE, "Profile name must not exceed 32 characters.\n");
+        return 1;
+    }
+
+    /* 'custom:' prefix is accepted */
+    if (!strncmp(name, "custom:", 7))
+        return 0;
+
     ret = get_profile_names(swtpm_capabilities_json, &profile_names);
     if (ret)
         goto error;

--- a/tests/test_tpm2_swtpm_setup_profile
+++ b/tests/test_tpm2_swtpm_setup_profile
@@ -226,7 +226,7 @@ test_custom_profile_sfls()
 		sfl=$(cut -d":" -f1 <<< "${sfls}")
 		exp_sfl=$(cut -d":" -f2 <<< "${sfls}")
 		exp_fail=$(cut -d":" -f3 <<< "${sfls}")
-		profile="{\"Name\":\"custom\",\"Commands\":\"${cmds}\",\"StateFormatLevel\":${sfl}}"
+		profile="{\"Name\":\"custom:test-sfl-${slf}\",\"Commands\":\"${cmds}\",\"StateFormatLevel\":${sfl}}"
 		exp_response=".*,\"StateFormatLevel\":${exp_sfl},.*"
 		test_swtpm_setup_profile \
 			"${workdir}" "${profile}" "${exp_response}" "" "" "" "${exp_fail}"
@@ -267,7 +267,7 @@ algos="${implemented_algos[*]}"
 algos=$(echo "${algos}" | sed "s/sha1//" | tr -s ' ')
 # Format profile
 a=$(echo "${algos}" | sed -e 's/ /,/g' -e 's/,$//')
-profile="{\"Name\":\"custom\",\"Algorithms\":\"${a}\"}"
+profile="{\"Name\":\"custom:no-sha1\",\"Algorithms\":\"${a}\"}"
 
 # Check PCR bank sha1 is not available: tssgetcapability -cap 5
 test_swtpm_setup_profile \


### PR DESCRIPTION
Accept profiles that start their name with 'custom:' and do not exceed 32 characters. The content of these profiles will be derived from the built-in 'custom' profile unless Algorithms, Commands, or Attributes are provided on the command line.

Adjust a test case to test with profile name starting with 'custom:'.