### PR TITLE
Introduce structure for PTM_GET_CAPABILITY

### DIFF
--- a/include/swtpm/tpm_ioctl.h
+++ b/include/swtpm/tpm_ioctl.h
@@ -31,6 +31,16 @@
 
 typedef uint32_t ptm_res;
 
+/* PTM_GET_CAPABILITY: Get supported capabilities (ioctl's) */
+struct ptm_cap_n {
+    union {
+        struct {
+            ptm_res tpm_result; /* will always be TPM_SUCCESS (0) */
+            uint32_t caps;
+        } resp; /* response */
+    } u;
+};
+
 /* PTM_GET_TPMESTABLISHED: get the establishment bit */
 struct ptm_est {
     union {
@@ -250,7 +260,8 @@ struct ptm_lockstorage {
     } u;
 };
 
-typedef uint64_t ptm_cap;
+typedef uint64_t ptm_cap; /* CUSE-only; use ptm_cap_n otherwise */
+typedef struct ptm_cap_n ptm_cap_n;
 typedef struct ptm_est ptm_est;
 typedef struct ptm_reset_est ptm_reset_est;
 typedef struct ptm_loc ptm_loc;

--- a/man/man3/swtpm_ioctls.pod
+++ b/man/man3/swtpm_ioctls.pod
@@ -101,6 +101,20 @@ The PTM_LOCK_STORAGE ioctl or CMD_LOCK_STORAGE command is supported.
 
 =back
 
+=item B<PTM_GET_CAPABILITY / CMD_GET_CAPABILITY, ptm_cap_n>
+
+The ptm_cap_n data structure can be used for non-CUSE swtpm and
+looks as follows:
+
+ struct ptm_cap_n {
+    union {
+       struct {
+           ptm_res tpm_result; /* will always be TPM_SUCCESS (0) */
+           uint32_t caps;
+       } resp; /* response */
+    } u;
+ };
+
 =item B<PTM_INIT / CMD_INIT, ptm_init>
 
 This ioctl must be used to initialize the TPM. It must be sent to the

--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -919,6 +919,13 @@ int ctrlchannel_process_fd(int fd,
 send_resp:
     SWTPM_PrintAll(" Ctrl Rsp:", " ", output.body, min(out_len, 1024));
 
+    /* all error responses must only be 4 bytes long */
+    if (*res_p != htobe32(TPM_SUCCESS) && out_len != 4) {
+        logprintf(STDERR_FILENO, "Error: Response too long for cmd=0x%x : %u\n",
+                  be32toh(input.cmd), out_len);
+        out_len = sizeof(ptm_res);
+    }
+
     n = write_full(fd, output.body, out_len);
     if (n < 0) {
         logprintf(STDERR_FILENO,

--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -438,9 +438,9 @@ wait_chunk:
     return recvd;
 }
 
-static uint64_t get_ptm_caps_supported(TPMLIB_TPMVersion tpmversion)
+static uint32_t get_ptm_caps_supported(TPMLIB_TPMVersion tpmversion)
 {
-    uint64_t caps =
+    uint32_t caps =
               PTM_CAP_INIT
             | PTM_CAP_SHUTDOWN
             | PTM_CAP_GET_TPMESTABLISHED
@@ -509,7 +509,7 @@ int ctrlchannel_process_fd(int fd,
     int *data_fd = NULL;
 
     /* Write-only */
-    ptm_cap *ptm_caps = (ptm_cap *)&output.body;
+    ptm_cap_n *ptm_caps_n = (ptm_cap_n *)&output.body;
     ptm_res *res_p = (ptm_res *)&output.body;
     ptm_est *te = (ptm_est *)&output.body;
     ptm_getconfig *pgc = (ptm_getconfig *)&output.body;
@@ -552,9 +552,11 @@ int ctrlchannel_process_fd(int fd,
 
     switch (be32toh(input.cmd)) {
     case CMD_GET_CAPABILITY:
-        *ptm_caps = htobe64(get_ptm_caps_supported(mlp->tpmversion));
+        /* must always succeed */
+        ptm_caps_n->u.resp.tpm_result = htobe32(TPM_SUCCESS);
+        ptm_caps_n->u.resp.caps = htobe32(get_ptm_caps_supported(mlp->tpmversion));
 
-        out_len = sizeof(*ptm_caps);
+        out_len = sizeof(*ptm_caps_n);
         break;
 
     case CMD_INIT:


### PR DESCRIPTION
Introduce a structure for PTM_GET_CAPABILITY control command so that its response structure looks like the one of all the other commands. So far it has been using a plain 64 bit number. Now the upper 32bits of this number are used for the tpm_result, which is always 0, as it was up to now, and the lower 32bits are the capability flags, of which only 17 are used so far. Adjust swtpm control channel related command support code to also use the new structure.