### PR TITLE
Revert "swtpm: Print message in case error response is too long"

### DIFF
--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -919,13 +919,6 @@ int ctrlchannel_process_fd(int fd,
 send_resp:
     SWTPM_PrintAll(" Ctrl Rsp:", " ", output.body, min(out_len, 1024));
 
-    /* all error responses must only be 4 bytes long */
-    if (*res_p != htobe32(TPM_SUCCESS) && out_len != 4) {
-        logprintf(STDERR_FILENO, "Error: Response too long for cmd=0x%x : %u\n",
-                  be32toh(input.cmd), out_len);
-        out_len = sizeof(ptm_res);
-    }
-
     n = write_full(fd, output.body, out_len);
     if (n < 0) {
         logprintf(STDERR_FILENO,


### PR DESCRIPTION
This reverts commit 8d4b247e3da96708a78f790c10f1d4cdbad51e79 since CMD_GET_STATEBLOB can have more than 4 bytes in response when an error happened (long-standing protocol error).