### PR TITLE
tests: Extend regex's with optional match for Attributes in profiles

### DIFF
--- a/tests/test_tpm2_swtpm_setup_profile
+++ b/tests/test_tpm2_swtpm_setup_profile
@@ -195,6 +195,7 @@ for profile in ${profiles}; do
 	               "\"StateFormatLevel\":[0-9]+,"\
 	               "\"Commands\":\"[,x[:xdigit:]-]+\","\
 	               "\"Algorithms\":\"[,=[:alnum:]-]+\","\
+	               "(\"Attributes\":\"[,=[:alnum:]-]+\",)?"\
 	               "\"Description\":\"[[:print:]]+\""\
 	               "\}\}\$"| tr -d " ")
 	test_swtpm_setup_profile \

--- a/tests/test_tpm2_swtpm_setup_profile_name
+++ b/tests/test_tpm2_swtpm_setup_profile_name
@@ -128,6 +128,7 @@ exp_response_default=$(echo "^\{\"ActiveProfile\":\{" \
                "\"StateFormatLevel\":[0-9]+,"\
                "\"Commands\":\"[,x[:xdigit:]-]+\","\
                "\"Algorithms\":\"[,=[:alnum:]-]+\","\
+               "(\"Attributes\":\"[,=[:alnum:]-]+\",)?"\
                "\"Description\":\"This${SP}profile${SP}enables${SP}all${SP}[[:print:]]+\""\
                "\}\}\$"| tr -d " ")
 test_swtpm_setup_profile "${workdir}" "builtin:default-v1" "${exp_response_default}" "0"


### PR DESCRIPTION
The default-v1 profile may soon also set Attributes in the JSON and therefore extend the regular expressions matching profiles to optionally match for Attributes.