### PR TITLE
swtpm: Only display profile capabilities when --tpm2 is given

### DIFF
--- a/src/swtpm/capabilities.c
+++ b/src/swtpm/capabilities.c
@@ -247,6 +247,7 @@ int capabilities_print_json(bool cusetpm, TPMLIB_TPMVersion tpmversion)
     const char *nvram_backend_dir = "\"nvram-backend-dir\", ";
     const char *nvram_backend_file = "\"nvram-backend-file\"";
     g_autofree gchar *profiles = NULL;
+    bool is_tpm2 = tpmversion == TPMLIB_TPM_VERSION_2;
 
     /* ignore errors */
     TPMLIB_ChooseTPMVersion(tpmversion);
@@ -255,7 +256,7 @@ int capabilities_print_json(bool cusetpm, TPMLIB_TPMVersion tpmversion)
     if (ret < 0)
         goto cleanup;
 
-    if (tpmversion == TPMLIB_TPM_VERSION_2) {
+    if (is_tpm2) {
         ret = get_profiles(&profiles);
         if (ret < 0)
             goto cleanup;
@@ -290,9 +291,9 @@ int capabilities_print_json(bool cusetpm, TPMLIB_TPMVersion tpmversion)
          nvram_backend_dir,
          nvram_backend_file,
          keysizecaps  ? keysizecaps                    : "",
-         true         ? ", \"cmdarg-profile\""         : "",
-         true         ? ", \"cmdarg-print-profiles\""  : "",
-         true         ? ", \"profile-opt-remove-disabled\"" : "",
+         is_tpm2      ? ", \"cmdarg-profile\""         : "",
+         is_tpm2      ? ", \"cmdarg-print-profiles\""  : "",
+         is_tpm2      ? ", \"profile-opt-remove-disabled\"" : "",
          true         ? ", \"cmdarg-print-info\""      : "",
          true         ? ", \"tpmstate-opt-lock\""      : "",
          profiles     ? profiles                       : ""

--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -28,8 +28,7 @@ exp='\{ "type": "swtpm", '\
 '"features": \[ "tpm-1.2",( "tpm-2.0",)? '${noncuse}'"flags-opt-startup", '\
 '"flags-opt-disable-auto-shutdown", "ctrl-opt-terminate", '${seccomp}'"cmdarg-key-fd", '\
 '"cmdarg-pwd-fd", "cmdarg-print-states", "cmdarg-chroot", "cmdarg-migration", '\
-'"nvram-backend-dir", "nvram-backend-file", "cmdarg-profile", '\
-'"cmdarg-print-profiles", "profile-opt-remove-disabled", "cmdarg-print-info", '\
+'"nvram-backend-dir", "nvram-backend-file", "cmdarg-print-info", '\
 '"tpmstate-opt-lock" \], '\
 '"profiles": \{ \}, '\
 '"version": "[^"]*" \}'


### PR DESCRIPTION
Only display profile capabilities when --tpm2 is given since they are only relevant when a TPM 2 is used.

Adjust test cases.