### PR TITLE
configure.ac: enable 64-bit file API on 32-bit systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,10 @@ AC_CANONICAL_HOST
 AM_INIT_AUTOMAKE([foreign 1.6])
 AM_SILENT_RULES([yes])
 
+# Allow 64-bit file API on 32-bit systems. Without the change even small
+# files will fail to stat any files on filesystems with 64-bit inodes.
+AC_SYS_LARGEFILE
+
 DEBUG=""
 AC_MSG_CHECKING([for debug-enabled build])
 AC_ARG_ENABLE(debug, AS_HELP_STRING([--enable-debug],[create a debug build]),

--- a/src/swtpm_setup/swtpm_backend_dir.c
+++ b/src/swtpm_setup/swtpm_backend_dir.c
@@ -6,6 +6,8 @@
  * Refactored as module: Stefan Reiter, stefan@pimaker.at
  */
 
+#include "config.h"
+
 #include <errno.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
My local filesystem is btrfs with a long life. It's inodes ecxeed 32-bit
space and that causes test failures in `swtpm` on `i686-linux`
containers:

    FAIL: test_parameters
    FAIL: test_swtpm_setup_file_backend
    FAIL: test_swtpm_setup_overwrite
    FAIL: test_tpm2_swtpm_setup_create_cert
    FAIL: test_tpm2_swtpm_setup_overwrite
    FAIL: test_swtpm_setup_create_cert
    FAIL: test_tpm2_parameters

The example test failure log looks this way:

    FAIL: test_migration_key
    ========================

    Need to be root to run test with CUSE interface.
    Need to be root to run test with CUSE interface.
    ==== Starting swtpm with interfaces socket+socket ====
    Test 1: Ok
    ==== Starting swtpm with interfaces socket+socket ====
    Test 2: Ok
    ==== Starting swtpm with interfaces socket+socket ====
    swtpm: Missing migration key to decrypt volatilestate
    Test 3: Ok
    ==== Starting swtpm with interfaces socket+socket ====
    Could not stat file '/build/tests/data/migkey1/volatilestate.bin': Value too large for defined data type
    Error: Could not load encrypted volatile state into TPM.
    FAIL test_migration_key (exit status: 1)

The `stat()` fails because inode value exceeds 32-bit value:

    $ stat /build/tests/data/migkey1/volatilestate.bin
      File: /build/tests/data/migkey1/volatilestate.bin
      Size: 1290            Blocks: 8          IO Block: 4096   regular file
    Device: 0,30    Inode: 9639547569  Links: 1
    ...

The change fixes all the test failures. To fix
`test_tpm2_swtpm_setup_create_cert` I also had to include `config.h`
into `swtpm_backend_dir.c` to get 64-bit file open there as well.

Signed-off-by: Sergei Trofimovich <slyich@gmail.com>