### PR TITLE
swtpm: Indent 'Tested' output of tested algorithm by one more space

### DIFF
--- a/src/swtpm/check_algos.c
+++ b/src/swtpm/check_algos.c
@@ -582,7 +582,7 @@ _check_ossl_algorithms_are_disabled(const gchar *const*algorithms,
                           disabled_type & DISABLED_BY_FIPS ? "(FIPS)" : "",
                           display);
             } else {
-                logprintf(STDOUT_FILENO, " Tested: %s\n", display);
+                logprintf(STDOUT_FILENO, "  Tested: %s\n", display);
             }
         }
     }


### PR DESCRIPTION
Move the 'Tested: tdes' type of debugging output one more indentation level up so that they can be filtered-out easier from control and data channel communication.