### PR TITLE
debian: Add rule to allow usage of /var/tmp directory (QEMU)

### DIFF
--- a/debian/usr.bin.swtpm
+++ b/debian/usr.bin.swtpm
@@ -4,6 +4,7 @@
 #include <tunables/global>
 
 profile swtpm /usr/bin/swtpm {
+  #include <abstractions/user-tmp>
   #include <abstractions/base>
   #include <abstractions/openssl>
 


### PR DESCRIPTION
QEMU's functional tests need access to /var/tmp/**. To avoid the following
type of AppArmor permission failures add a rule that allows access to
/var/tmp/**.

 type=AVC msg=audit(1730829888.863:260): apparmor="DENIED" \
   operation="mknod" class="file" profile="swtpm" \
   name="/var/tmp/qemu_3r9txw7z/swtpm-socket" pid=3925 comm="swtpm" \
   requested_mask="c" denied_mask="c" fsuid=1000 ouid=1000FSUID="stefanb" \
   OUID="stefanb"

[ To run the QEMU's functional tests use the following command:
    make check-functional ]
