### PR TITLE
swtpm_cert: Move error message about importing signing key into else …

### DIFF
--- a/src/swtpm_cert/ek-cert.c
+++ b/src/swtpm_cert/ek-cert.c
@@ -1436,11 +1436,13 @@ if (_err != GNUTLS_E_SUCCESS) {             \
         } else {
             err = gnutls_x509_privkey_import(sigkey, &datum, GNUTLS_X509_FMT_PEM);
         }
+        /* 'certtool --infile <sigkey_filename> -k' not working?? */
+        CHECK_GNUTLS_ERROR(err,
+                           "Could not import signing key %s: %s - Is the (gnutls) key corrupted?\n",
+                           sigkey_filename, gnutls_strerror(err));
     }
     gnutls_free(datum.data);
     datum.data = NULL;
-    CHECK_GNUTLS_ERROR(err, "Could not import signing key : %s\n",
-                       gnutls_strerror(err));
 
     err = gnutls_load_file(issuercert_filename, &datum);
     CHECK_GNUTLS_ERROR(err, "Could not read certificate from file %s : %s\n",


### PR DESCRIPTION
…branch

Move the error message about the failure to import a signing key into the else branch where it should be (all other branches of the if-then-else statement have a check already). Also mention the key's filename.