### PR TITLE
Handle cases where json_reader_get_string_value returns NULL pointer

### DIFF
--- a/src/swtpm/utils.c
+++ b/src/swtpm/utils.c
@@ -493,6 +493,13 @@ int json_get_submap_value(const char *json_input, const char *field_name,
         return -1;
     }
     *value = g_strdup(json_reader_get_string_value(jr));
+    if (*value == NULL) {
+        /* value not a string */
+        logprintf(STDERR_FILENO,
+                  "'%s/%s' field in '%s' is not a string\n",
+                  field_name, field_name2, json_input);
+        return -1;
+    }
 
     return 0;
 }

--- a/src/swtpm_setup/profile.c
+++ b/src/swtpm_setup/profile.c
@@ -97,8 +97,13 @@ int check_json_profile(const gchar *swtpm_capabilities_json, const char *json_pr
     int ret;
 
     ret = json_get_map_value(json_profile, "Name", &name);
-    if (ret)
+    /* { "Name": null } does not lead to parser failure but return name = NULL */
+    if (ret || name == NULL) {
+        ret = 1;
+        logerr(gl_LOGFILE, "Failed to get 'Name' from profile '%s'.\n",
+               json_profile);
         return ret;
+    }
 
     if (strlen(name) > 32) {
         logerr(gl_LOGFILE, "Profile name must not exceed 32 characters.\n");

--- a/src/utils/swtpm_utils.c
+++ b/src/utils/swtpm_utils.c
@@ -474,6 +474,7 @@ int json_get_map_value(const char *json_input, const char *field_name,
         goto error_unref_jr;
     }
     *value = g_strdup(json_reader_get_string_value(jr));
+    /* caller should handle *value == NULL */
 
     ret = 0;
 


### PR DESCRIPTION
If '{"Name":null}' is provided to the parser, the 'null' will not cause a parser exception but return a NULL pointer when trying to get the value of "Name". In some cases the callers assume that a NULL pointer is never returned. Handle those cases where the NULL pointer would cause segmentation faults, particularly when the user provides the input (swtpm_setup patch).
