### PR TITLE
Travis: Downgrade to setuptools 59.6.0 to avoid error in 71.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,7 @@ matrix:
            SWTPM_TEST_STORE_VOLATILE="1"
       before_script:
       - sudo apt-get -y install libtpm2-pkcs11-tools
+      - sudo pip install setuptools==59.6.0  # Default Jammy version
       - sudo pip install cpp-coveralls
       - p=$PWD; while [ "$PWD" != "/" ]; do chmod o+x . &>/dev/null ; cd .. ; done; cd $p
         && sudo mkdir src/swtpm/.libs


### PR DESCRIPTION
There seems to be a well known error in setuptools 71.x that prevents installation of cpp-coveralls on Travis now:

File "/usr/local/lib/python3.10/dist-packages/setuptools/_core_metadata.py", line 285, in _distribution_fullname

    canonicalize_version(version, strip_trailing_zero=False),

TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'

Fall back to the default version that is used in Ubuntu Jammy (59.6.0) since later versions also lead to the same error.

Link: https://github.com/pypa/setuptools/issues/4483