### PR TITLE
swtpm_setup.c: add "socket" argument to custom swtpm call

### DIFF
--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -1472,6 +1472,11 @@ int main(int argc, char *argv[])
         case 'T': /* --tpm */
             g_free(swtpm_prg);
             swtpm_prg = g_strdup(optarg);
+            if (swtpm_prg) {
+                tmp = g_strconcat(swtpm_prg, " socket", NULL);
+                g_free(swtpm_prg);
+                swtpm_prg = tmp;
+            }
             break;
         case '_': /* --swtpm_ioctl */
             fprintf(stdout, "Warning: --swtpm_ioctl is deprecated and has no effect.");


### PR DESCRIPTION
When a custom swtpm binary is provided with --tpm path/to/swtpm, then swtpm_setup is currently not adding "swtpm socket" argument when calling swtpm --print-capabilities which results in swtpm_setup always failing. --tpm documentation does not mention that "socket" argument should be provided so add it automatically. As workaround, --tpm "path/to/swtpm socket" works but it should be the default just like when swtpm is found from PATH.

Fixes use of swtpm in yocto cross compile environment where paths to swtpm and swtpm_setup binaries provided by swtpm-native recipe change frequently due to
recipe specific sysroot environment.