### PR TITLE
man: Improve swtpm_setup --tpm option documentation

### DIFF
--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -37,10 +37,18 @@ will be used.
 Path where the TPM's state will be written to; this is a mandatory argument.
 Prefix with dir:// to use directory backend, or file:// to use linear file.
 
-=item B<--tpm <path to executable>>
+=item B<--tpm "path-to-executable socket">
 
-Path to the TPM executable; this is an optional argument and
-by default the swtpm executable found in the PATH will be used.
+Path to the TPM executable; this is an optional argument and by default the
+swtpm executable found in the PATH will be used. To use 'swtpm' with this
+parameter it is necessary to pass along the 'socket' parameter. To emulate
+the default behavior this option could be used as follows:
+
+=over 2
+
+--tpm "$(type -P swtpm) socket"
+
+=back
 
 =item B<--tpm2>
 

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -923,7 +923,7 @@ static void usage(const char *prgname, const char *default_config_file)
         "\n"
         "--tpmstate <dir> : This is an alias for --tpm-state <dir>.\n"
         "\n"
-        "--tpm <executable>\n"
+        "--tpm '<path-to-executable> socket'\n"
         "                 : Path to the TPM executable; this is an optional argument and\n"
         "                   by default 'swtpm' in the PATH is used.\n"
         "\n"


### PR DESCRIPTION
Improve the swtpm_setup --tpm option documentation that did not mention that the socket option must be passed along when swtpm is being used.