### PR TITLE
swtpm: Fix build error on 32bit systems due to inconsistent _FILE_OFF…

### DIFF
--- a/src/swtpm/mainloop.c
+++ b/src/swtpm/mainloop.c
@@ -40,6 +40,8 @@
    It reads a TPM request, processes the ordinal, and writes the response
 */
 
+#include <config.h>
+
 #include <errno.h>
 #include <stdio.h>
 #include <stdint.h>

--- a/src/swtpm/tpmlib.h
+++ b/src/swtpm/tpmlib.h
@@ -38,6 +38,8 @@
 #ifndef _SWTPM_TPMLIB_H_
 #define _SWTPM_TPMLIB_H_
 
+#include <config.h> /* ensure consistent definition of _FILE_OFFSET_BITS */
+
 #include <stdint.h>
 #include <stdbool.h>
 


### PR DESCRIPTION
…SET_BITS

Fix the following build error due to missing include of config.h where _FILE_OFFSET_BITS is defined and leads to different sizes of off_t depending on whether it is defined and/or included:

tpmlib.h:76:7: error: type of 'tpmlib_handle_tcg_tpm2_cmd_header' does not match original declaration [-Werror=lto-type-mismatch]
   76 | off_t tpmlib_handle_tcg_tpm2_cmd_header(const unsigned char *command,
      |       ^
tpmlib.c:576:7: note: return value type mismatch
  576 | off_t tpmlib_handle_tcg_tpm2_cmd_header(const unsigned char *command,
      |       ^
tpmlib.c:576:7: note: 'tpmlib_handle_tcg_tpm2_cmd_header' was previously declared here
tpmlib.c:576:7: note: code may be misoptimized unless '-fno-strict-aliasing' is used
lto1: all warnings being treated as errors
lto-wrapper: fatal error: gcc returned 1 exit status

Link: https://bugzilla.redhat.com/show_bug.cgi?id=2334600
Fixes: 599e2436d4 ("configure.ac: enable 64-bit file API on 32-bit systems")