### PR TITLE
swtpm_setup: Use DISTRO_PROFILES_DIR when listing profiles (fix path …

### DIFF
--- a/src/swtpm_setup/profile.c
+++ b/src/swtpm_setup/profile.c
@@ -373,7 +373,7 @@ int profile_printall(const gchar **swtpm_prg_l,
     if (ja)
         json_object_set_array_member(jo, "local", ja);
 
-    ja = profile_gather_dir(DATAROOTDIR "swtpm/profiles");
+    ja = profile_gather_dir(DISTRO_PROFILES_DIR);
     if (ja)
         json_object_set_array_member(jo, "distro", ja);
 


### PR DESCRIPTION
…issue)

When listing profiles, then the profiles in the distro directory did not show up since the directory formed by 'DATAROOTDIR "swtpm/profiles"' was missing a '/' at the end of DATAROOTDIR. Use DISTRO_PROFILES_DIR instead.