### PR TITLE
swtpm_setup: Do not pass a TPM 2 profile to swtpm when reconfiguring

### DIFF
--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -1816,6 +1816,15 @@ int main(int argc, char *argv[])
         goto error;
     }
 
+    if ((flags & SETUP_RECONFIGURE_F) &&
+         (json_profile ||
+          json_profile_name ||
+          json_profile_file ||
+          json_profile_fd > 0)) {
+            logerr(gl_LOGFILE, "Reconfiguration does not accept a (new) profile.\n");
+            goto error;
+    }
+
     if (json_profile_name) {
         if (profile_name_check(json_profile_name) < 0)
             goto error;
@@ -1842,9 +1851,14 @@ int main(int argc, char *argv[])
         }
     }
 
-    /* read default profile from swtpm_setup.conf */
+    /*
+     * Read default profile from swtpm_setup.conf;
+     * Do not read it when --reconfigure'ing
+     */
     if ((flags & SETUP_TPM2_F) != 0 &&
-        json_profile == NULL && json_profile_fd < 0) {
+        json_profile == NULL && json_profile_fd < 0 &&
+        (flags & SETUP_RECONFIGURE_F) == 0) {
+
         json_profile_fd = get_default_profile_fd(config_file_lines);
         if (json_profile_fd == -2)
             goto error;

--- a/tests/test_tpm2_swtpm_setup_create_cert
+++ b/tests/test_tpm2_swtpm_setup_create_cert
@@ -55,6 +55,7 @@ cat <<_EOF_ > "${workdir}/swtpm_setup.conf"
 create_certs_tool=\${MY_SWTPM_LOCALCA}
 create_certs_tool_config=${workdir}/swtpm-localca.conf
 create_certs_tool_options=${workdir}/swtpm-localca.options
+profile = {"Name": "default-v1"}
 _EOF_
 
 # We need to adapt the PATH so the correct swtpm_cert is picked


### PR DESCRIPTION
Ensure that no profile is passed to the TPM 2 when it is to be reconfigured by:

- Showing an error if user tries to pass a profile when also --reconfigure is passed
- Not taking the default profile from the swtpm_setup.conf configuration file if the user did not pass a profile

Extend an existing test case with a default profile in its swtpm_setup.conf so that the above 2nd item is tested.
