### PR TITLE
samples: Support different key algorithms for created TPM 2 CA

### DIFF
--- a/man/man8/swtpm-create-tpmca.pod
+++ b/man/man8/swtpm-create-tpmca.pod
@@ -98,6 +98,11 @@ set to hold the PINs. If SWTPM_PKCS11_PIN is not set then the default PIN
 'swtpm-tpmca' will be used. SWTPM_PKCS11_SO_PIN is needed for creating the
 token and must be explicitly set as an environment variable.
 
+=item B<--algorithm algorithm>
+
+The TPM 2 CA's key algorithm. Supported values are rsa2048, rsa3072, ecc256,
+and ecc384. The default is rsa2048.
+
 =item B<--pid pimary-object-id>
 
 The primary object id that the tpm2_ptool returns upon 'init'.

--- a/samples/swtpm-create-tpmca
+++ b/samples/swtpm-create-tpmca
@@ -95,6 +95,7 @@ create_localca_cert() {
 	local outfile="$3"
 	local owner="$4"
 	local pid="$5" # TPM2 parameter
+	local algorithm="$6" # RSA or EC-key signing
 
 	local cakey=${dir}/swtpm-localca-rootca-privkey.pem
 	local cacert=${dir}/swtpm-localca-rootca-cert.pem
@@ -199,7 +200,7 @@ create_localca_cert() {
 			if ! msg=$(tpm2_ptool addkey \
 				"--label=${label}" \
 				"--userpin=${userpin}" \
-				--algorithm=rsa2048 \
+				"--algorithm=${algorithm}" \
 				"--key-label=${keylabel}" \
 				--id 1 2>&1);
 			then
@@ -390,6 +391,8 @@ The following options are supported:
 --tss-tcsd-port p  The TCP port on which tcsd is listening for connections;
                    default is ${TSS_TCSD_PORT_DEFAULT}
 --tpm2             Setup a CA that uses a TPM 2.0
+--algorithm <alg>  Key algorithm for created TPM 2 CA. Default is rsa2048.
+                   Possible values are: rsa2048, rsa3072, ecc256, ecc384
 --pid <pid>        Pimary object Id used by tpm2_ptool; only valid if --tpm2
                    is used
 --help, -h, -?     Display this help screen and exit
@@ -417,6 +420,7 @@ tpmtool_supports_srk_well_known()
 main() {
 	local flags=0
 	local dir outfile owner group msg pid
+	local algorithm="rsa2048"
 
 	if tpmtool_supports_srk_well_known; then
 		flags=$((flags | FLAG_TPMTOOL_SUPPORTS_SRK_WELL_KNOWN | FLAG_SRK_WELL_KNOWN))
@@ -469,6 +473,10 @@ main() {
 			;;
 		--tpm2)
 			flags=$((flags | FLAG_TPM2))
+			;;
+		--algorithm)
+			shift
+			algorithm="$1"
 			;;
 		--pid)
 			shift
@@ -539,7 +547,17 @@ main() {
 		return 1
 	fi
 
-	create_localca_cert "${flags}" "${dir}" "${outfile}" "${owner}" "${pid}"
+	if [ $((flags & FLAG_TPM2)) -eq 0 ] && [ "${algorithm}" != "rsa2048" ]; then
+		logerr "Unsupported key algorithms for TPM CA for a TPM 1.2 '${algorithm}'."
+		logerr "Only rsa2048 is supported."
+		return 1
+	fi
+	if ! [[ "${algorithm}" =~ ^(rsa2048|rsa3072|ecc256|ecc384)$ ]]; then
+		logerr "Unsupported key algorithm for TPM CA '${algorithm}'. See --help."
+		return 1
+	fi
+
+	create_localca_cert "${flags}" "${dir}" "${outfile}" "${owner}" "${pid}" "${algorithm}"
 	return $?
 } #main
 

--- a/tests/test_tpm2_samples_create_tpmca.test
+++ b/tests/test_tpm2_samples_create_tpmca.test
@@ -86,10 +86,12 @@ PATH=${ROOT}/src/swtpm_bios:${ROOT}/src/swtpm_cert:${PATH}
 
 # Run the tests
 # @param1: The vTPM for which the certificate is created is a TPM 2
+# @param2: The key algorithm for the created TPM 2 CA
 function run_test() {
 	local vtpm_is_tpm2="$1"
+	local algorithm="$2"
 
-	local tmp params certinfo regex regexs fil i skip
+	local tmp params certinfo regex regexs fil i skip exp_certsize
 
 	rm -rf "${workdir:?}"/*
 
@@ -163,6 +165,7 @@ _EOF_
 		--outfile "${SWTPM_LOCALCA_CONF}" \
 		--group tss \
 		--tpm2 \
+		${algorithm:+--algorithm "${algorithm}"} \
 		--pid "${PID}" 2>&1)"; then
 		echo "Error: Could not create TPM CA"
 		echo "${tmp}"
@@ -219,8 +222,12 @@ _EOF_
 		echo "Error: The CA did not produce a certificate"
 		exit 1
 	fi
-	#  cert was for example 541 bytes long
-	if [ "$(get_filesize "${workdir}/ek.cert")" -lt 500 ]; then
+
+	case "${algorithm}" in
+	rsa2048)	exp_certsize=500;;	# cert should be ~541 bytes long; give some 'room'
+	ecc256)		exp_certsize=460;;	# cert should be ~476 bytes long; give some 'room'
+	esac
+	if [ "$(get_filesize "${workdir}/ek.cert")" -lt "${exp_certsize}" ]; then
 		echo "Error: The certificate's size is dubious"
 		ls -l "${workdir}/ek.cert"
 		exit 1
@@ -237,9 +244,16 @@ _EOF_
 		'^[[:space:]]+Unknown extension 2.5.29.9 \(not critical\):$'
 		'^[[:space:]]+Hexdump: 3019301706056781050210310e300c0c03322e3002010002020092$')
 	if [ "${vtpm_is_tpm2}" -ne 0 ]; then
+		local alg
+
+		case "${algorithm}" in
+		rsa2048)	alg=RSA;;
+		ecc256)		alg=ECDSA;;
+		esac
+
 		# TPM 2.0; due to ecc: Key agreement
 		regexs+=('^[[:space:]]+Key agreement\.$'
-			 '^[[:space:]]+Signature Algorithm: RSA-SHA256$')
+			 '^[[:space:]]+Signature Algorithm: '"${alg}"'-SHA256$')
 	else
 		regexs+=('^[[:space:]]+Key encipherment\.$'
 			 '^[[:space:]]+Signature Algorithm: RSA-SHA1$')
@@ -279,10 +293,13 @@ _EOF_
 	SWTPM_PID=""
 } # run_test
 
-run_test 1
+run_test 1 "rsa2048"
 echo "Test 1: OK"
 
-run_test 0
+run_test 1 "ecc256"
 echo "Test 2: OK"
+
+run_test 0
+echo "Test 3: OK"
 
 exit 0


### PR DESCRIPTION
Extend swtpm-create-tpm to support rsa2048 (default), rsa3072, ecc256 (NIST P256), and ecc384 (NIST P384) for the created TPM 2 CA. The names are taken from the output of:

  tpm2_ptool addkey --help

ecc521 does not seem to work with the TPM 2 stack even though it is advertised as a possible option.

Extend an existing test case to create an ecc256 key and extend man page.