### PR TITLE
sample: Enable passing usual curve names secp256r1 or secp384r1

### DIFF
--- a/samples/swtpm-create-tpmca
+++ b/samples/swtpm-create-tpmca
@@ -392,7 +392,8 @@ The following options are supported:
                    default is ${TSS_TCSD_PORT_DEFAULT}
 --tpm2             Setup a CA that uses a TPM 2.0
 --algorithm <alg>  Key algorithm for created TPM 2 CA. Default is rsa2048.
-                   Possible values are: rsa2048, rsa3072, ecc256, ecc384
+                   Possible values are: rsa2048, rsa3072, ecc256 or secp256r1,
+                                        ecc384 or secp384r1
 --pid <pid>        Pimary object Id used by tpm2_ptool; only valid if --tpm2
                    is used
 --help, -h, -?     Display this help screen and exit
@@ -551,10 +552,14 @@ main() {
 		logerr "Unsupported key algorithms for TPM CA for a TPM 1.2 '${algorithm}'."
 		logerr "Only rsa2048 is supported."
 		return 1
-	fi
-	if ! [[ "${algorithm}" =~ ^(rsa2048|rsa3072|ecc256|ecc384)$ ]]; then
+	elif ! [[ "${algorithm}" =~ ^(rsa2048|rsa3072|ecc256|ecc384|secp256r1|secp384r1)$ ]]; then
 		logerr "Unsupported key algorithm for TPM CA '${algorithm}'. See --help."
 		return 1
+	else
+		case "${algorithm}" in
+		secp256r1) algorithm=ecc256;;
+		secp384r1) algorithm=ecc384;;
+		esac
 	fi
 
 	create_localca_cert "${flags}" "${dir}" "${outfile}" "${owner}" "${pid}" "${algorithm}"

--- a/tests/test_tpm2_samples_create_tpmca.test
+++ b/tests/test_tpm2_samples_create_tpmca.test
@@ -224,8 +224,9 @@ _EOF_
 	fi
 
 	case "${algorithm}" in
-	rsa2048)	exp_certsize=500;;	# cert should be ~541 bytes long; give some 'room'
-	ecc256)		exp_certsize=460;;	# cert should be ~476 bytes long; give some 'room'
+	rsa2048)	exp_certsize=500;; # cert should be ~541 bytes long; give some 'room'
+	ecc256)		exp_certsize=460;; # cert should be ~476 bytes long;    - " -
+	secp384r1)	exp_certsize=510;; # cert should be ~519 bytes long;    - " -
 	esac
 	if [ "$(get_filesize "${workdir}/ek.cert")" -lt "${exp_certsize}" ]; then
 		echo "Error: The certificate's size is dubious"
@@ -248,7 +249,7 @@ _EOF_
 
 		case "${algorithm}" in
 		rsa2048)	alg=RSA;;
-		ecc256)		alg=ECDSA;;
+		*)		alg=ECDSA;;
 		esac
 
 		# TPM 2.0; due to ecc: Key agreement
@@ -299,7 +300,10 @@ echo "Test 1: OK"
 run_test 1 "ecc256"
 echo "Test 2: OK"
 
-run_test 0
+run_test 1 "secp384r1"
 echo "Test 3: OK"
+
+run_test 0
+echo "Test 4: OK"
 
 exit 0


### PR DESCRIPTION
Enable passing the usual curve names of secp256r1 and secp384r1 instead of ecc256 and ecc384 on the command line of swtpm-create-tpmca.