### PR TITLE
swtpm: Use custom profile's Algorithms when removing FIPS-disabled ones

### DIFF
--- a/src/swtpm/profile.c
+++ b/src/swtpm/profile.c
@@ -51,10 +51,12 @@ int profile_remove_fips_disabled_algorithms(char **json_profile,
         return -1;
 
     if (ret == -2) {
-        info_data = TPMLIB_GetInfo(TPMLIB_INFO_RUNTIME_ALGORITHMS);
-
-        ret = json_get_submap_value(info_data, "RuntimeAlgorithms", "Implemented",
-                                    &value);
+        info_data = TPMLIB_GetInfo(TPMLIB_INFO_AVAILABLE_PROFILES);
+        /* In the AvailableProfiles entry get the custom profile's Algorithms */
+        ret = json_get_array_entry_value(info_data,
+                                         "AvailableProfiles",
+                                         "Name", "custom", "Algorithms",
+                                         &value);
         if (ret)
             return -1;
     }

--- a/src/swtpm/utils.h
+++ b/src/swtpm/utils.h
@@ -81,6 +81,10 @@ int json_get_map_key_value(const char *json_input,
                            const char *key, char **value);
 int json_set_map_key_value(char **json_input,
                            const char *key, const char *value);
+int json_get_array_entry_value(const char *json_input,
+                               const char *field0_name,
+                               const char *field1_name, const char *field1_value,
+                               const char *field2_name, char **value);
 
 ssize_t strv_strncmp(const gchar *const*str_array, const gchar *s, size_t n);
 


### PR DESCRIPTION
Use the custom profile's Algorithms when adjusting them for FIPS mode, rather than the list of all implemented Algorithms. The list of implemented Algorithms contains for example elliptic curve identifiers, such as ecc-nist-p192, ecc-nist-p224, ecc-nist-p256, ecc-nist-p384, ecc-nist-p521, ecc-bn-p256, ecc-bn-p638, that are not part of the custom profile but are enabled with the ecc-min-size=192, ecc-nist, and ecc-bn shortcuts there. Using the algorithms of the custom profile avoids confusion since otherwise the additional ecc-nist-* and ecc-bn-* algorithm identifiers appear in the modified custom profile even though the were not part of the original one.

Test:

  swtpm_setup --tpm2 --tpmstate . --overwrite \
     --profile-name custom --profile-remove-disabled fips-host

  before:
  ...,ecc,ecc-min-size=224,ecc-nist,ecc-bn,ecc-nist-p224,ecc-nist-p256,
      ecc-nist-p384,ecc-nist-p521,ecc-bn-p256,ecc-bn-p638,ecc-sm2-p256,...

  now:

  ...,ecc,ecc-min-size=224,ecc-nist,ecc-bn,ecc-sm2-p256,...