### PR TITLE
swtpm: Close connection_fd.fd before assigning new value (CID 459830)

### DIFF
--- a/src/swtpm/mainloop.c
+++ b/src/swtpm/mainloop.c
@@ -190,8 +190,12 @@ int mainLoop(struct mainLoopParams *mlp, int notify_fd, bool tpm_running)
     while (!g_mainloop_terminate) {
 
         while (rc == 0) {
-            if (mlp->flags & MAIN_LOOP_FLAG_USE_FD)
-                connection_fd.fd = mlp->fd;
+            if (mlp->flags & MAIN_LOOP_FLAG_USE_FD) {
+                if (connection_fd.fd != mlp->fd) {
+                    SWTPM_IO_Disconnect(&connection_fd);
+                    connection_fd.fd = mlp->fd;
+                }
+            }
 
             struct pollfd pollfds[] = {
                 [DATA_CLIENT_FD] = {


### PR DESCRIPTION
Coverity complains that the assignment of connection_fd.fd = mlp->fd leaks the value of connection_fd.fd. However, the logic is so that this cannot happen because further down in the loop:

1) only when connection_fd.fd < 0, then pollfds[DATA_SERVER_FD] gets
   a value
2) connection_fd.fd = accept() only happens if 1) happened

However, if mlp->flags & MAIN_LOOP_FLAG_USE_FD is != 0 then connection_fd was assigned a value and 1) never happens.

=> Fix the Coverity complaint even though it is a false positive.