### PR TITLE
Fix SELinux related bugs in the swtpm.spec.in file

### DIFF
--- a/swtpm.spec.in
+++ b/swtpm.spec.in
@@ -122,6 +122,9 @@ make %{?_smp_mflags} check
 %make_install
 rm -f $RPM_BUILD_ROOT%{_libdir}/%{name}/*.{a,la,so}
 
+%pre selinux
+%selinux_relabel_pre -s %{selinuxtype}
+
 %post selinux
 for pp in /usr/share/selinux/packages/swtpm.pp \
           /usr/share/selinux/packages/swtpm_libvirt.pp \
@@ -131,7 +134,7 @@ done
 
 %postun selinux
 if [ $1 -eq  0 ]; then
-  for p in swtpm swtpm_libvirt swtpm_svirt; do
+  for p in swtpm_svirt swtpm_libvirt swtpm; do
     %selinux_modules_uninstall -s %{selinuxtype} $p
   done
 fi


### PR DESCRIPTION
Including changes to swtpm.spec.in as well, which I previously missed with [https://github.com/stefanberger/swtpm/pull/995](https://github.com/stefanberger/swtpm/pull/995)

• Uninstall ‘swptm_svirt’ selinux module first before uninstalling the ‘swtpm’ module.
• Add the %selinux_relabel_pre macro to back up the original file contexts lists.

Signed-off-by: Ajeeth Adithya [ajeeth.adithya@nutanix.com](mailto:ajeeth.adithya@nutanix.com)