### PR TITLE
Cleanup and factor-out file reading and writing in directory backend

### DIFF
--- a/src/swtpm/utils.h
+++ b/src/swtpm/utils.h
@@ -76,6 +76,8 @@ ssize_t file_write(const char *filename, int flags, mode_t mode,
                    bool clear_umask, const void *buffer, size_t buflen);
 
 ssize_t read_eintr(int fd, void *buffer, size_t buflen);
+ssize_t file_read(const char *filename, void **buffer,
+                  bool do_chmod, mode_t mode);
 
 int json_get_submap_value(const char *json_input, const char *field_name,
                           const char *field_name2, char **value);

--- a/src/swtpm/utils.h
+++ b/src/swtpm/utils.h
@@ -72,6 +72,8 @@ char *fd_to_filename(int fd);
 
 ssize_t write_full(int fd, const void *buffer, size_t buflen);
 ssize_t writev_full(int fd, const struct iovec *iov, int iovcnt);
+ssize_t file_write(const char *filename, int flags, mode_t mode,
+                   bool clear_umask, const void *buffer, size_t buflen);
 
 ssize_t read_eintr(int fd, void *buffer, size_t buflen);
 


### PR DESCRIPTION
Remove the unused fsync code from the directory backend. It could cause TPM command timeouts if used.
Factor-out file reading and writing code.