### PR TITLE
Fix some issues preventing the build on GNU/Hurd systems from succeeding

### DIFF
--- a/include/swtpm/tpm_ioctl.h
+++ b/include/swtpm/tpm_ioctl.h
@@ -23,6 +23,10 @@
 #include <sys/ioccom.h>
 #endif
 
+#ifdef __gnu_hurd__
+#include <mach/x86_64/ioccom.h>
+#endif
+
 /*
  * Every response from a command involving a TPM command execution must hold
  * the ptm_res as the first element.
@@ -293,7 +297,7 @@ typedef struct ptm_lockstorage ptm_lockstorage;
 #define PTM_CAP_SEND_COMMAND_HEADER (1 << 15)
 #define PTM_CAP_LOCK_STORAGE       (1 << 16)
 
-#if !defined(_WIN32) && !defined(__GNU__)
+#if !defined(_WIN32)
 enum {
     PTM_GET_CAPABILITY     = _IOR('P', 0, ptm_cap),
     PTM_INIT               = _IOWR('P', 1, ptm_init),

--- a/src/swtpm/swtpm_nvstore_linear_file.c
+++ b/src/swtpm/swtpm_nvstore_linear_file.c
@@ -7,7 +7,9 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 #include <sys/ioctl.h>
-#include <sys/mount.h>
+#ifndef __gnu_hurd__
+# include <sys/mount.h>
+#endif
 #include <fcntl.h>
 
 #include <libtpms/tpm_types.h>

--- a/src/swtpm_setup/swtpm_backend_dir.c
+++ b/src/swtpm_setup/swtpm_backend_dir.c
@@ -13,6 +13,10 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
+#ifdef __gnu_hurd__
+# define PATH_MAX 4096 /* no limit on GNU/Hurd systems */
+#endif
+
 #include "swtpm.h"
 #include "swtpm_utils.h"
 

--- a/tests/common
+++ b/tests/common
@@ -715,7 +715,7 @@ function run_swtpm_bios()
 # @1: filename
 function get_filesize()
 {
-	if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-) ]]; then
+	if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-|GNU) ]]; then
 		stat -c%s "$1"
 	else
 		# OpenBSD
@@ -741,7 +741,7 @@ function get_filemode()
 # @1: filename
 function get_fileowner()
 {
-	if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-) ]]; then
+	if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-|GNU) ]]; then
 		stat -c"%u %g" "$1"
 	else
 		# BSDs
@@ -754,7 +754,7 @@ function get_fileowner()
 # @1: filename
 function get_fileowner_names()
 {
-	if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-) ]]; then
+	if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-|GNU) ]]; then
 		stat -c"%U %G" "$1"
 	else
 		# BSDs
@@ -772,7 +772,7 @@ function get_sha1_file()
 		return
 	fi
 	case "$(uname -s)" in
-	Linux|CYGWIN*)
+	Linux|CYGWIN*|GNU)
 		sha1sum "$1" | cut -f1 -d" "
 		;;
 	Darwin)

--- a/tests/sed-inplace
+++ b/tests/sed-inplace
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-) ]]; then
+if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-|GNU) ]]; then
 	sed -i "$1" "$2"
 else
 	sed -i '' "$1" "$2"


### PR DESCRIPTION
The build of swtpm currently fails on GNU/Hurd systems due to some issues related to header files. Fix them.
However, the test cases require either netstat or ss tools, of which neither seems to be available. Therefore, `--disable-tests` needs to be passed to configure script. Also socat 1.7.x seems broken and cannot run the unix command socket tests.