### PR TITLE
debian: Do not user parallel testing to avoid timeouts

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -13,7 +13,7 @@ override_dh_install:
 	dh_apparmor -pswtpm --profile-name=usr.bin.swtpm
 
 override_dh_auto_test:
-	SWTPM_TEST_SECCOMP_OPT="--seccomp action=none" make -j4 check VERBOSE=1
+	SWTPM_TEST_SECCOMP_OPT="--seccomp action=none" make check VERBOSE=1
 
 override_dh_clean:
 	dh_clean --exclude=man/man8/swtpm-localca.8


### PR DESCRIPTION
The build for RISC-V causes timeouts when running tests in parallel due to the CPU being emulated. Avoid the timeouts by not running parallel tests.