### PR TITLE
tests: Extend regex to allow for optional RSA-4096 keys

### DIFF
--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -52,8 +52,8 @@ exp='\{ "type": "swtpm_setup", '\
 '"features": \[ "tpm-1.2",( "tpm-2.0",)? "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", '\
 '"tpm12-not-need-root", "cmdarg-write-ek-cert-files", "cmdarg-create-config-files", '\
 '"cmdarg-reconfigure-pcr-banks"'\
-'(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")?, "cmdarg-profile", '\
-'"cmdarg-profile-remove-disabled" \], '\
+'(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")?(, "tpm2-rsa-keysize-4096")?, '\
+'"cmdarg-profile", "cmdarg-profile-remove-disabled" \], '\
 '"profiles": \[ [^]]*\], '\
 '"version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then

--- a/tests/_test_tpm2_print_capabilities
+++ b/tests/_test_tpm2_print_capabilities
@@ -30,7 +30,8 @@ exp='\{ "type": "swtpm", '\
 '"flags-opt-disable-auto-shutdown", "ctrl-opt-terminate", '${seccomp}'"cmdarg-key-fd", '\
 '"cmdarg-pwd-fd", "cmdarg-print-states", "cmdarg-chroot", "cmdarg-migration", '\
 '"nvram-backend-dir", "nvram-backend-file"'\
-'(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")?, "cmdarg-profile", '\
+'(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")?'\
+'(, "rsa-keysize-4096")?, "cmdarg-profile", '\
 '"cmdarg-print-profiles", "profile-opt-remove-disabled", "cmdarg-print-info", '\
 '"tpmstate-opt-lock" \], '\
 '"profiles": \{ "names": \[ [^]]*\], "algorithms": \{ [^\}]*\}, "commands": \{ [^\}]*\} }, '\
@@ -54,8 +55,8 @@ fi
 exp='\{ "type": "swtpm_setup", '\
 '"features": \[( "tpm-1.2",)? "tpm-2.0", "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", '\
 '"tpm12-not-need-root", "cmdarg-write-ek-cert-files", "cmdarg-create-config-files", '\
-'"cmdarg-reconfigure-pcr-banks"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")?, '\
-'"cmdarg-profile", "cmdarg-profile-remove-disabled" \], '\
+'"cmdarg-reconfigure-pcr-banks"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")?'\
+'(, "tpm2-rsa-keysize-4096")?, "cmdarg-profile", "cmdarg-profile-remove-disabled" \], '\
 '"profiles": \[ [^]]*\], '\
 '"version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then


### PR DESCRIPTION
libtpms v0.11 will support RSA-4096 keys. Adjust the test case regex for optional output of 'tpm2-rsa-keysize-4096'.