### PR TITLE
Enable building with libtpms v0.11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@
 #       This file is derived from tpm-tool's configure.in.
 #
 
-AC_INIT([swtpm],[0.10.1])
+AC_INIT([swtpm],[0.10.2])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR(Makefile.am)
 AC_CONFIG_HEADERS([config.h])

--- a/swtpm.spec
+++ b/swtpm.spec
@@ -8,7 +8,7 @@
 
 Summary: TPM Emulator
 Name:           swtpm
-Version:        0.10.1
+Version:        0.10.2
 Release:        1%{?dist}
 License:        BSD-3-Clause
 Url:            https://github.com/stefanberger/swtpm

--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -52,8 +52,8 @@ exp='\{ "type": "swtpm_setup", '\
 '"features": \[ "tpm-1.2",( "tpm-2.0",)? "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", '\
 '"tpm12-not-need-root", "cmdarg-write-ek-cert-files", "cmdarg-create-config-files", '\
 '"cmdarg-reconfigure-pcr-banks"'\
-'(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")?, "cmdarg-profile", '\
-'"cmdarg-profile-remove-disabled" \], '\
+'(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")?(, "tpm2-rsa-keysize-4096")?, '\
+'"cmdarg-profile", "cmdarg-profile-remove-disabled" \], '\
 '"profiles": \[ [^]]*\], '\
 '"version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then

--- a/tests/_test_tpm2_print_capabilities
+++ b/tests/_test_tpm2_print_capabilities
@@ -30,7 +30,8 @@ exp='\{ "type": "swtpm", '\
 '"flags-opt-disable-auto-shutdown", "ctrl-opt-terminate", '${seccomp}'"cmdarg-key-fd", '\
 '"cmdarg-pwd-fd", "cmdarg-print-states", "cmdarg-chroot", "cmdarg-migration", '\
 '"nvram-backend-dir", "nvram-backend-file"'\
-'(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")?, "cmdarg-profile", '\
+'(, "rsa-keysize-1024")?(, "rsa-keysize-2048")?(, "rsa-keysize-3072")?'\
+'(, "rsa-keysize-4096")?, "cmdarg-profile", '\
 '"cmdarg-print-profiles", "profile-opt-remove-disabled", "cmdarg-print-info", '\
 '"tpmstate-opt-lock" \], '\
 '"profiles": \{ "names": \[ [^]]*\], "algorithms": \{ [^\}]*\}, "commands": \{ [^\}]*\} }, '\
@@ -54,8 +55,8 @@ fi
 exp='\{ "type": "swtpm_setup", '\
 '"features": \[( "tpm-1.2",)? "tpm-2.0", "cmdarg-keyfile-fd", "cmdarg-pwdfile-fd", '\
 '"tpm12-not-need-root", "cmdarg-write-ek-cert-files", "cmdarg-create-config-files", '\
-'"cmdarg-reconfigure-pcr-banks"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")?, '\
-'"cmdarg-profile", "cmdarg-profile-remove-disabled" \], '\
+'"cmdarg-reconfigure-pcr-banks"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")?'\
+'(, "tpm2-rsa-keysize-4096")?, "cmdarg-profile", "cmdarg-profile-remove-disabled" \], '\
 '"profiles": \[ [^]]*\], '\
 '"version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then


### PR DESCRIPTION
Libtpms v0.11 supports RSA-4096 bit keys and therefore we have to adjust the test cases to allow for optional advertisement of these keys through `tpm2-rsa-keysize-4096`. Also, there's currently nothing in (future) libtpms v0.11 that would not allow us to use it with swtpm v0.10.x.
