### PR TITLE
swtpm: Return error if more bytes received than user wanted to send

### DIFF
--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -695,14 +695,16 @@ int ctrlchannel_process_fd(int fd,
 
     case CMD_HASH_DATA:
         if (!*tpm_running)
-             goto err_not_running;
+            goto err_not_running;
 
         if (n < (ssize_t)offsetof(ptm_hdata, u.req.data)) /* rw */
-             goto err_bad_input;
+            goto err_bad_input;
 
         data = (ptm_hdata *)&input.body;
-        remain = htobe32(data->u.req.length);
+        remain = be32toh(data->u.req.length);
         n -= sizeof(data->u.req.length);
+        if (remain < n)
+            goto err_bad_input;
         /* n has the available number of bytes to hash */
 
         while (true) {


### PR DESCRIPTION
Return an error code if HASH_DATA received more bytes from the user than what the user indicated in the length field that he wanted to send. This avoids an integer underrun of the 'remain' variable in the loop that would then cause the loop to wanting to receive around 4GB of data.

Also fix some indentation issues.
Use be32toh instead of (the equivalent) htobe32 when reading from the packet.