### PR TITLE
migrate to libfuse3 as fuse2 contains unaddressed security issue

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -200,10 +200,10 @@ AC_ARG_WITH([cuse],
 )
 
 if test "$with_cuse" != "no"; then
-    LIBFUSE_CFLAGS=$(pkg-config fuse --cflags 2>/dev/null)
+    LIBFUSE_CFLAGS="$(pkg-config fuse3 --cflags 2>/dev/null)  -DFUSE_USE_VERSION=35"
     if test $? -ne 0; then
         if test "$with_cuse" = "yes"; then
-            AC_MSG_ERROR("Is fuse-devel installed? -- could not get cflags for libfuse")
+            AC_MSG_ERROR("Is fuse3-devel installed? -- could not get cflags for libfuse3")
         else
             with_cuse=no
         fi
@@ -214,9 +214,9 @@ fi
 
 dnl with_cuse is now yes or no
 if test "$with_cuse" != "no"; then
-    LIBFUSE_LIBS=$(pkg-config fuse --libs)
+    LIBFUSE_LIBS=$(pkg-config fuse3 --libs)
     if test $? -ne 0; then
-        AC_MSG_ERROR("Is fuse-devel installed? -- could not get libs for libfuse")
+        AC_MSG_ERROR("Is fuse3-devel installed? -- could not get libs for libfuse3")
     fi
     AC_SUBST([LIBFUSE_CFLAGS])
     AC_SUBST([LIBFUSE_LIBS])

--- a/src/swtpm/cuse_tpm.c
+++ b/src/swtpm/cuse_tpm.c
@@ -54,7 +54,7 @@
 #include <arpa/inet.h>
 #include <dirent.h>
 
-#include <fuse/cuse_lowlevel.h>
+#include <fuse3/cuse_lowlevel.h>
 
 #include <glib.h>
 
@@ -1581,7 +1581,7 @@ ptm_cuse_lowlevel_main(int argc, char *argv[], const struct cuse_info *ci,
         return 1;
 
     if (param->seccomp_action == SWTPM_SECCOMP_ACTION_NONE && mt)
-        ret = fuse_session_loop_mt(ptm_fuse_session);
+        ret = fuse_session_loop_mt(ptm_fuse_session, NULL);
     else
         ret = fuse_session_loop(ptm_fuse_session);
 


### PR DESCRIPTION
migrate to libfuse3 as fuse2 contains unaddressed security issue (libfuse/libfuse#15)

 - configure.ac: update fuse package name
 - src/swtpm/cuse_tpm.c: migrate invocation of `fuse_session_loop_mt()`

with successful invocation of the below commands, it seems the patched source is working?

```
autoreconf --install --force
./configure --with-cuse
make
make check
```