### PR TITLE
cuse: add support to libfuse3 while avoid introducing breaking change

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -200,24 +200,24 @@ AC_ARG_WITH([cuse],
 )
 
 if test "$with_cuse" != "no"; then
-    LIBFUSE_CFLAGS=$(pkg-config fuse --cflags 2>/dev/null)
-    if test $? -ne 0; then
-        if test "$with_cuse" = "yes"; then
-            AC_MSG_ERROR("Is fuse-devel installed? -- could not get cflags for libfuse")
-        else
-            with_cuse=no
-        fi
-    else
+    if pkg-config fuse3; then
+        LIBFUSE_CFLAGS=$(pkg-config fuse3 --cflags)
+        LIBFUSE_LIBS=$(pkg-config fuse3 --libs)
         with_cuse=yes
+    elif pkg-config fuse; then
+        LIBFUSE_CFLAGS="$(pkg-config fuse --cflags) -DWITH_FUSE2"
+        LIBFUSE_LIBS=$(pkg-config fuse --libs)
+        with_cuse=yes
+    else
+        if test "$with_cuse" = "yes"; then
+            AC_MSG_ERROR("Is fuse3-devel or fuse-devel installed? -- could not found libfuse3 or libfuse")
+        fi
+        with_cuse=no
     fi
 fi
 
 dnl with_cuse is now yes or no
-if test "$with_cuse" != "no"; then
-    LIBFUSE_LIBS=$(pkg-config fuse --libs)
-    if test $? -ne 0; then
-        AC_MSG_ERROR("Is fuse-devel installed? -- could not get libs for libfuse")
-    fi
+if test "$with_cuse" = "yes"; then
     AC_SUBST([LIBFUSE_CFLAGS])
     AC_SUBST([LIBFUSE_LIBS])
     AC_DEFINE_UNQUOTED([WITH_CUSE], 1,
@@ -229,6 +229,7 @@ if test "$with_cuse" != "no"; then
     fi
     AC_SUBST([GTHREAD_LIBS])
 fi
+
 AM_CONDITIONAL([WITH_CUSE],[test "$with_cuse" = "yes"])
 AC_MSG_RESULT($with_cuse)
 
@@ -675,6 +676,8 @@ echo "        GLIB_LIBS = $GLIB_LIBS"
 echo "      GNUTLS_LIBS = $GNUTLS_LIBS"
 echo "         GMP_LIBS = $GMP_LIBS"
 echo "       GMP_CFLAGS = $GMP_CFLAGS"
+echo "   LIBFUSE_CFLAGS = $LIBFUSE_CFLAGS"
+echo "     LIBFUSE_LIBS = $LIBFUSE_LIBS"
 echo
 echo "TSS_USER=$TSS_USER"
 echo "TSS_GROUP=$TSS_GROUP"

--- a/src/swtpm/cuse_tpm.c
+++ b/src/swtpm/cuse_tpm.c
@@ -54,7 +54,12 @@
 #include <arpa/inet.h>
 #include <dirent.h>
 
+#ifdef WITH_FUSE2
 #include <fuse/cuse_lowlevel.h>
+#else
+#define FUSE_USE_VERSION 35
+#include <fuse3/cuse_lowlevel.h>
+#endif
 
 #include <glib.h>
 
@@ -1581,7 +1586,11 @@ ptm_cuse_lowlevel_main(int argc, char *argv[], const struct cuse_info *ci,
         return 1;
 
     if (param->seccomp_action == SWTPM_SECCOMP_ACTION_NONE && mt)
+#ifdef WITH_FUSE2
         ret = fuse_session_loop_mt(ptm_fuse_session);
+#else
+        ret = fuse_session_loop_mt(ptm_fuse_session, NULL);
+#endif
     else
         ret = fuse_session_loop(ptm_fuse_session);
 


### PR DESCRIPTION
libfuse2 contains unaddressed security issue. (libfuse/libfuse#15)

this patch adds a configuration flag `--with-fuse3`, when it is explicitly set, swtpm would be built against libfuse3 instead of libfuse2.

while `--with-fuse3` is not set, the package is built against libfuse2 as conventional, this avoid breaking existing build systems from various distros.

	- configure.ac: add flag `--with-fuse3`, which requires enabling explicitly
	- src/swtpm/cuse_tpm.c: add libfuse3 support, mainly MARCOs and `fuse_session_loop_mt()` reimplementation

with successful building and testing (returns 0) with both 2 configurations below, it seems the patched source is working?

```
autoreconf --install --force
./configure --with-cuse  # fuse2
make clean && make && make check
```

```
autoreconf --install --force
./configure --with-cuse --with-fuse3  # fuse3
make clean && make && make check
```