### PR TITLE
swtpm_setup: Also check respbuffer_len for possible NULL pointer (CID…

### DIFF
--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -315,7 +315,7 @@ static int transfer(struct swtpm *self, void *buffer, size_t buffer_len,
         return 1;
     }
 
-    if (respbuffer) {
+    if (respbuffer && respbuffer_len) {
         /* give caller response even if command failed */
         *respbuffer_len = min((size_t)resplen, respbuffer_size);
         memcpy(respbuffer, resp, *respbuffer_len);


### PR DESCRIPTION
… 466756)

respbuffer_len is a pointer that may be NULL but will not be NULL when respbuffer is not NULL. Nevertheless, also check it for NULL pointer before accessing it.