### PR TITLE
configure.ac: Use pkgconf macros, use m4sh, remove obsolete sections

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,21 +82,21 @@ AS_IF([test "x$with_selinux" != "xno"],
 
 AM_CONDITIONAL([WITH_SELINUX], [test "x$with_selinux" = "xyes"])
 
-if test "$prefix" = "/usr" && test "$sysconfdir" = '${prefix}/etc'; then
-	sysconfdir="/etc"
-fi
-if test "$prefix" = "" && test "$datarootdir" = '${prefix}/share'; then
-	datarootdir="/usr/share"
-fi
-if test "$prefix" = "/usr" && test "$localstatedir" = '${prefix}/var'; then
-	localstatedir="/var"
-fi
-if test "x$prefix" = "xNONE"; then
-	prefix="/usr/local"
-fi
-if test "x$exec_prefix" = "xNONE"; then
-	exec_prefix=$prefix
-fi
+AS_IF([test "$prefix" = "/usr" && test "$sysconfdir" = '${prefix}/etc'],
+    [sysconfdir="/etc"]
+)
+AS_IF([test "$prefix" = "" && test "$datarootdir" = '${prefix}/share'],
+    [datarootdir="/usr/share"]
+)
+AS_IF([test "$prefix" = "/usr" && test "$localstatedir" = '${prefix}/var'],
+    [localstatedir="/var"]
+)
+AS_IF([test "x$prefix" = "xNONE"],
+    [prefix="/usr/local"]
+)
+AS_IF([test "x$exec_prefix" = "xNONE"],
+    [exec_prefix=$prefix]
+)
 SYSCONFDIR=`eval echo $sysconfdir`
 DATAROOTDIR=`eval echo $datarootdir`
 LOCALSTATEDIR=`eval echo $localstatedir`

--- a/configure.ac
+++ b/configure.ac
@@ -52,31 +52,6 @@ dnl Allow 64-bit file API on 32-bit systems. Without the change even small
 dnl files will fail to stat any files on filesystems with 64-bit inodes.
 AC_SYS_LARGEFILE
 
-DEBUG=""
-AC_MSG_CHECKING([for debug-enabled build])
-AC_ARG_ENABLE(debug, AS_HELP_STRING([--enable-debug],[create a debug build]),
-  [if test "$enableval" = "yes"; then
-     DEBUG="yes"
-     AC_MSG_RESULT([yes])
-   else
-     DEBUG="no"
-     AC_MSG_RESULT([no])
-   fi],
-  [DEBUG="no",
-   AC_MSG_RESULT([no])])
-
-dnl If the user has not set CFLAGS, do something appropriate
-test_CFLAGS=${CFLAGS+set}
-if test "$test_CFLAGS" != set; then
-	if test "$DEBUG" = "yes"; then
-		CFLAGS="-O0 -g -DDEBUG"
-	else
-		CFLAGS="-g -O2"
-	fi
-elif test "$DEBUG" = "yes"; then
-	CFLAGS="$CFLAGS -O0 -g -DDEBUG"
-fi
-
 AC_C_CONST
 AC_C_INLINE
 


### PR DESCRIPTION
This cleans up configure.ac, the hard coding of the pkgconf is causing cross compile problems. The non-m4sh can cause problems with pkgconf macros though. These patches fix that up. 

