### PR TITLE
tests: Extend test cases with RSA-4096 and default-v2 testing

### DIFF
--- a/tests/test_tpm2_parameters
+++ b/tests/test_tpm2_parameters
@@ -54,6 +54,16 @@ PARAMETERS_3072=(
 	"--createek --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --vmid test --lock-nvram --rsa-keysize 3072"
 )
 
+# Tests for 4096 bit RSA keys to be appended to above array if RSA 4096 keys are supported
+PARAMETERS_4096=(
+	"--createek --rsa-keysize 4096 --profile-name default-v2"
+	"--createek --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --vmid test --display --rsa-keysize 4096 --profile-name default-v2"
+	"--createek --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --vmid test --display --keyfile ${TESTDIR}/data/keyfile.txt --rsa-keysize 4096 --profile-name default-v2"
+	"--createek --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --vmid test --display --pwdfile ${TESTDIR}/data/pwdfile.txt --rsa-keysize 4096 --profile-name default-v2"
+	"--createek --allow-signing --decryption --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --vmid test --display --pwdfile ${TESTDIR}/data/pwdfile.txt --cipher aes-256-cbc --rsa-keysize 4096 --profile-name default-v2"
+	"--createek --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --vmid test --lock-nvram --rsa-keysize 4096 --profile-name default-v2"
+)
+
 # Open read-only file descriptors referenced in test cases
 exec 100<"${TESTDIR}/data/keyfile256bit.txt"
 exec 101<"${TESTDIR}/data/pwdfile.txt"
@@ -76,6 +86,9 @@ function cleanup()
 
 if $TPMAUTHORING --tpm2 --print-capabilities | grep -q tpm2-rsa-keysize-3072; then
 	PARAMETERS+=( "${PARAMETERS_3072[@]}" )
+fi
+if $TPMAUTHORING --tpm2 --print-capabilities | grep -q tpm2-rsa-keysize-4096; then
+	PARAMETERS+=( "${PARAMETERS_4096[@]}" )
 fi
 
 # swtpm_setup.conf points to the local create_certs.sh

--- a/tests/test_tpm2_swtpm_setup_create_cert
+++ b/tests/test_tpm2_swtpm_setup_create_cert
@@ -51,24 +51,36 @@ _EOF_
 
 export MY_SWTPM_LOCALCA="${SWTPM_LOCALCA}"
 
+profile="default-v1"
+if ${SWTPM_SETUP} \
+	--tpm2 \
+	--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}" \
+	--print-capabilities \
+	| grep '"default-v2"'; then
+	profile="default-v2"
+fi
+
 cat <<_EOF_ > "${workdir}/swtpm_setup.conf"
 create_certs_tool=\${MY_SWTPM_LOCALCA}
 create_certs_tool_config=${workdir}/swtpm-localca.conf
 create_certs_tool_options=${workdir}/swtpm-localca.options
-profile = {"Name": "default-v1"}
+profile = {"Name": "${profile}"}
 _EOF_
 
 # We need to adapt the PATH so the correct swtpm_cert is picked
 export PATH=${TOPBUILD}/src/swtpm_cert:${PATH}
 
 keysizes="2048"
-if ${SWTPM_SETUP} \
-	--tpm2 \
-	--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}" \
-	--print-capabilities |
-     grep -q tpm2-rsa-keysize-3072; then
-	keysizes+=" 3072"
-fi
+
+for keysize in 3072 4096; do
+	if ${SWTPM_SETUP} \
+		--tpm2 \
+		--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}" \
+		--print-capabilities |
+	     grep -q "tpm2-rsa-keysize-${keysize}"; then
+		keysizes+=" ${keysize}"
+	fi
+done
 
 for keysize in ${keysizes}; do
 	echo "Testing with RSA keysize $keysize"

--- a/tests/test_tpm2_swtpm_setup_profile
+++ b/tests/test_tpm2_swtpm_setup_profile
@@ -42,6 +42,16 @@ function cleanup()
 	fi
 }
 
+PROFILE_V2=""
+if ${SWTPM_SETUP} \
+	--tpm2 \
+	--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}" \
+	--print-capabilities \
+	| grep -q '"default-v2"' ; then
+	PROFILE_V2="default-v2"
+fi
+
+
 test_swtpm_setup_profile()
 {
 	local workdir="${1}"
@@ -310,7 +320,7 @@ exp_response="\{\"ActiveProfile\":\{\"Name\":\"custom:test\",.*,\"Algorithms\":\
 test_swtpm_setup_profile "${workdir}" "${profile}" "${exp_response}" "" "" "" "0"
 
 # --profile-remove-disabled must not have any effect on other profiles
-for p in null default-v1; do
+for p in null default-v1 ${PROFILE_V2}; do
 	profile="{\"Name\":\"${p}\"} --profile-remove-disabled fips-host"
 	exp_response="\{\"ActiveProfile\":\{\"Name\":\"${p}\",.*,\"Algorithms\":\".*,rsa-min-size=1024,.*,ecc-min-size=192,.*\",.*\}\}"
 	test_swtpm_setup_profile "${workdir}" "${profile}" "${exp_response}" "" "" "" "0"

--- a/tests/test_tpm2_swtpm_setup_profile_name
+++ b/tests/test_tpm2_swtpm_setup_profile_name
@@ -133,6 +133,23 @@ exp_response_default=$(echo "^\{\"ActiveProfile\":\{" \
                "\}\}\$"| tr -d " ")
 test_swtpm_setup_profile "${workdir}" "builtin:default-v1" "${exp_response_default}" "0"
 
+if ${SWTPM_SETUP} \
+	--tpm2 \
+	--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}" \
+	--print-capabilities \
+	| grep '"default-v2"'; then
+	# default-v2 is available
+	exp_response_default_v2=$(echo "^\{\"ActiveProfile\":\{" \
+               "\"Name\":\"default-v2\"," \
+               "\"StateFormatLevel\":[0-9]+,"\
+               "\"Commands\":\"[,x[:xdigit:]-]+\","\
+               "\"Algorithms\":\"[,=[:alnum:]-]+\","\
+               "(\"Attributes\":\"[,=[:alnum:]-]+\",)?"\
+               "\"Description\":\"This${SP}profile${SP}enables${SP}all${SP}[[:print:]]+\""\
+               "\}\}\$"| tr -d " ")
+	test_swtpm_setup_profile "${workdir}" "builtin:default-v2" "${exp_response_default_v2}" "0"
+fi
+
 # No local profile must be found
 output=$($SWTPM_SETUP \
 		--tpm2 \


### PR DESCRIPTION
RSA-4096 is enabled in libtpms v0.11 and requires that default-v2 profile be used. Extend existing test case with test for RSA-4096 and default-v2 profile.