### PR TITLE
tests: cuse: Create /dev/null in chroot environment

### DIFF
--- a/tests/test_tpm2_chroot_cuse
+++ b/tests/test_tpm2_chroot_cuse
@@ -59,6 +59,7 @@ for OPTION in --chroot -R; do
 	fi
 
 	mkdir "$TPMDIR/dev"
+	mknod -m 0666 "$TPMDIR/dev/null" c 1 3     #  due to daemonize_prep()
 	mknod -m 0666 "$TPMDIR/dev/urandom" c 1 9
 	mknod -m 0666 "$TPMDIR/dev/cuse" c 10 203
 


### PR DESCRIPTION
Due to the usage of daemonize_prep() by the CUSE swtpm create /dev/null in the chroot environment.

Suggested-by: Corigne <nathanjodoin@gmail.com>