### PR TITLE
swtpm_ioctl: double default poll timeout

### DIFF
--- a/src/swtpm_ioctl/tpm_ioctl.c
+++ b/src/swtpm_ioctl/tpm_ioctl.c
@@ -91,7 +91,7 @@
 #endif
 
 /* poll timeout that takes into account a busy swtpm creating a key */
-#define DEFAULT_POLL_TIMEOUT 10000 /* ms */
+#define DEFAULT_POLL_TIMEOUT 20000 /* ms */
 
 static unsigned long ioctl_to_cmd(unsigned long ioctlnum)
 {


### PR DESCRIPTION
On very slow architectures the 10s timeout is too slow and can fail tests. For example on MIPS:

https://buildd.debian.org/status/fetch.php?pkg=swtpm&arch=mipsel&ver=0.7.1-1.1&stamp=1684146306&raw=0 https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1036101

Double it to 20s, which has been used for ~2 years in Debian and has proven to be sufficient to avoid spurious failures.