### PR TITLE
swtpm: Fix comparison of integers with different signedness

### DIFF
--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -707,7 +707,7 @@ int ctrlchannel_process_fd(int fd,
         data = (ptm_hdata *)&input.body;
         remain = be32toh(data->u.req.length);
         n -= sizeof(data->u.req.length);
-        if (remain < n)
+        if (n < 0 || remain < (uint32_t)n)
             goto err_bad_input;
         /* n has the available number of bytes to hash */
 


### PR DESCRIPTION
Fix the following issue reported when compiling on m68k:
```
ctrlchannel.c: In function 'ctrlchannel_process_fd': ctrlchannel.c:710:20: error: comparison of integer expressions of
   different signedness: 'uint32_t' {aka 'unsigned int'} and 'ssize_t'
   {aka 'int'} [-Werror=sign-compar ]
  710 |         if (remain < n)
      |                    ^
```