### PR TITLE
WIP: swtpm_cert: Enable CAs with ML-DSA key to sign a certifcate

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -220,6 +220,25 @@ AS_IF([test "x$with_gnutls" != "xno"],
         [with_gnutls=no]
     )
     AS_IF([test "x$with_gnutls" != "xno"],[with_gnutls="yes"])
+    AS_IF([test "x$with_gnutls" = "xyes"],
+          [AC_COMPILE_IFELSE(
+            [AC_LANG_PROGRAM(
+              [[
+                #include <gnutls/gnutls.h>
+                #include <stdio.h>
+              ]],
+              [[
+                printf("%d", GNUTLS_PK_MLDSA44);
+              ]]
+            )],
+            [
+             AC_MSG_RESULT("GnuTLS has ML-DSA support")
+             AC_DEFINE_UNQUOTED([GNUTLS_SUPPORTS_MLDSA], 1,
+                [whether GnuTLS support ML-DSA signing algorithm])
+            ],
+            [AC_MSG_RESULT("GnuTLS has no ML-DSA support")],
+          )]
+         )
     ]
 )
 


### PR DESCRIPTION
Test for GNUTLS_PK_MLDSA44 to detect whether GnuTLS supports ML-DSA.

Only SHAKE-256 can be used for hashing when ML-DSA is used for signing:

https://github.com/gnutls/gnutls/blob/df24a53136f188d77aaffe66316b0fb6ba720d40/lib/algorithms/sign.c#L405-L428

The problem is now that the size of NVRAM indices is limited to MAX_NV_INDEX_SIZE = 2048, which is too small for a certificate created even with ML-DSA-44, which is around 2757 bytes long.