### PR TITLE
apparmor: add support for mkosi integration working directory

### DIFF
--- a/debian/usr.bin.swtpm
+++ b/debian/usr.bin.swtpm
@@ -33,6 +33,8 @@ profile swtpm /usr/bin/swtpm {
   /usr/share/swtpm/profiles/*.json r,  # distro profiles
   /etc/swtpm/profiles/*.json r,        # local profiles
   /tmp/** rwk,
+  # For mkosi integration https://github.com/systemd/mkosi
+  /work/tmp/** rwk,
 
   owner /dev/vtpmx rw,
   owner /etc/nsswitch.conf r,


### PR DESCRIPTION
mkosi integrates with swtpm to automatically set up and build VMs with vTPM support. The working directory is in an ephemeral namespace that appears as /work/tmp/, and apparmor stops swtpm from creating the local state files (lockfile, etc). Add a policy entry to allow this to work.