### PR TITLE
tests: Ignore SC2329 'This function is never invoked.'

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -257,7 +257,7 @@ check-display:
 syntax-check:
 # SC2009: Consider using pgrep instead of grepping ps output.
 # SC2317: (info): Command appears to be unreachable. Check usage (or ignore if invoked indirectly).
-	shellcheck -e SC2009,SC2317 \
+	shellcheck -e SC2009,SC2317,SC2329 \
 		$(TESTS) $(TEST_UTILS) $(filter _test_%,$(EXTRA_DIST)) softhsm_setup installed-runner.sh
 
 check: check-am check-display


### PR DESCRIPTION
Ignore SC2329 which is reported on the cleanup function that is invoked by 'trap' but not recognized by ShellCheck 1.11. Since there are not many functions in the scripts, have this error ignored via command line option rather than going into each file individually and annotating the cleanup function.