### PR TITLE
WIP: Add support for libtpms v0.11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -144,7 +144,7 @@ AS_IF([test "$OPENSSL_CLITOOL" != "yes"],
 
 PKG_CHECK_MODULES([LIBTASN1],[libtasn1])
 
-PKG_CHECK_MODULES([LIBTPMS],[libtpms >= 0.10])
+PKG_CHECK_MODULES([LIBTPMS],[libtpms >= 0.11])
 
 
 AC_CHECK_LIB(c, clock_gettime, LIBRT_LIBS="", LIBRT_LIBS="-lrt")

--- a/src/swtpm/mainloop.c
+++ b/src/swtpm/mainloop.c
@@ -135,6 +135,9 @@ int mainLoop(struct mainLoopParams *mlp, int notify_fd, bool tpm_running)
     uint32_t            ack = htobe32(0);
     struct tpm2_resp_prefix respprefix;
     uint32_t            lastCommand;
+    enum TPMLIB_TPMProperty prop = (mlp->tpmversion == TPMLIB_TPM_VERSION_1_2)
+        ? TPMPROP_TPM_BUFFER_MAX
+        : TPMPROP_TPM2_BUFFER_MAX;
 
     /* poolfd[] indexes */
     enum {
@@ -147,7 +150,7 @@ int mainLoop(struct mainLoopParams *mlp, int notify_fd, bool tpm_running)
 
     TPM_DEBUG("mainLoop:\n");
 
-    max_command_length = tpmlib_get_tpm_property(TPMPROP_TPM_BUFFER_MAX) +
+    max_command_length = tpmlib_get_tpm_property(prop) +
                          sizeof(struct tpm2_send_command_prefix);
 
     command = malloc(max_command_length);

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -1038,7 +1038,7 @@ static const struct iak_params {
             .keysize = 4096/8,
             .symkey_len = 0,
             .off = 0x5a,
-            .duration = TPM2_DURATION_LONG,
+            .duration = TPM2_DURATION_EXTRA_LONG,
         },
         .keytype = "RSA 4096",
     }
@@ -1207,7 +1207,7 @@ static const struct idevid_params {
             .keysize = 4096/8,
             .symkey_len = 0,
             .off = 0x68,
-            .duration = TPM2_DURATION_LONG,
+            .duration = TPM2_DURATION_EXTRA_LONG,
         },
         .keytype = "RSA 4096",
     }

--- a/tests/_test_tpm2_setbuffersize
+++ b/tests/_test_tpm2_setbuffersize
@@ -46,8 +46,8 @@ if ! run_swtpm_ioctl "${SWTPM_INTERFACE}" -b 0 > "${OUTFILE}"; then
 fi
 cat "${OUTFILE}"
 
-if ! grep "TPM buffersize" "${OUTFILE}" | grep -q 4096; then
-	echo "Error: The TPM buffersize of the ${SWTPM_INTERFACE} TPM is not 4096."
+if ! grep "TPM buffersize" "${OUTFILE}" | grep -q -E "(4096|8192)$"; then
+	echo "Error: The TPM buffersize of the ${SWTPM_INTERFACE} TPM is not 4096 or 8192."
 	exit 1
 fi
 


### PR DESCRIPTION
This PR adds support for libtpms v0.11:
- requires libtpms v0.11 for swtpm v0.11
- libtpms v0.11: the buffer sizes will be increased to 8192 bytes
- swtpm_cert can work with MLDSA certs (but certs are very large)