### PR TITLE
header: Remove _Static_assert and adjust comments

### DIFF
--- a/include/swtpm/tpm_ioctl.h
+++ b/include/swtpm/tpm_ioctl.h
@@ -51,11 +51,10 @@ struct ptm_est {
         struct {
             ptm_res tpm_result;
             unsigned char bit; /* TPM established bit */
-            unsigned char pad[3]; /* for m68k */
+            unsigned char pad[3]; /* force alignment  */
         } resp; /* response */
     } u;
 };
-_Static_assert(sizeof(struct ptm_est) == 8);
 
 /* PTM_RESET_TPMESTABLISHED: reset establishment bit */
 struct ptm_reset_est {


### PR DESCRIPTION
Remove the _Static_assert. Also adjust the comment for the forced alignment, which is only needed for m68k.