### PR TITLE
fix: validate logfile path before first use and replace broken `stat()`-based check

### DIFF
--- a/src/swtpm_localca/swtpm_localca.c
+++ b/src/swtpm_localca/swtpm_localca.c
@@ -650,6 +650,7 @@ int main(int argc, char *argv[])
     gchar **config_file_lines = NULL;
     gchar **swtpm_cert_env = NULL;
     const struct passwd *curr_user;
+    int logfd;
     struct stat statbuf;
     int ret = 1;
 
@@ -737,19 +738,12 @@ int main(int argc, char *argv[])
     curr_user = getpwuid(getuid());
 
     if (gl_LOGFILE != NULL) {
-        FILE *tmpfile;
-
-        if (stat(gl_LOGFILE, &statbuf) == 0 &&
-            (statbuf.st_mode & S_IFMT) == S_IFLNK) {
-            fprintf(stderr, "Logfile must not be a symlink.\n");
+        logfd = open(gl_LOGFILE, O_WRONLY|O_APPEND|O_CREAT|O_NOFOLLOW, S_IRUSR|S_IWUSR|S_IRGRP);
+        if (logfd < 0) {
+            fprintf(stderr, "Cannot open logfile %s: %s\n", gl_LOGFILE, strerror(errno));
             goto error;
         }
-        tmpfile = fopen(gl_LOGFILE, "a"); // do not truncate
-        if (tmpfile == NULL) {
-            fprintf(stderr, "Cannot write to logfile %s.\n", gl_LOGFILE);
-            goto error;
-        }
-        fclose(tmpfile);
+        close(logfd);
     }
 
     if (access(optsfile, R_OK) != 0) {

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -1435,7 +1435,7 @@ int main(int argc, char *argv[])
     gchar **swtpm_prg_l = NULL;
     gchar **tmp_l = NULL;
     size_t i, n;
-    struct stat statbuf;
+    int logfd;
     const struct passwd *curr_user;
     struct group *curr_grp;
     char *endptr;
@@ -1662,6 +1662,15 @@ int main(int argc, char *argv[])
         }
     }
 
+    if (gl_LOGFILE != NULL) {
+        logfd = open(gl_LOGFILE, O_WRONLY|O_APPEND|O_CREAT|O_NOFOLLOW, S_IRUSR|S_IWUSR|S_IRGRP);
+        if (logfd < 0) {
+            fprintf(stderr, "Cannot open logfile %s: %s\n", gl_LOGFILE, strerror(errno));
+            goto error;
+        }
+        close(logfd);
+    }
+
     if (swtpm_prg == NULL) {
         logerr(gl_LOGFILE,
                "Default TPM 'swtpm' could not be found and was not provided using --tpm.\n");
@@ -1719,21 +1728,6 @@ int main(int argc, char *argv[])
         ownerpass = g_strdup(DEFAULT_OWNER_PASSWORD);
     if (!got_srkpass)
         srkpass = g_strdup(DEFAULT_SRK_PASSWORD);
-
-    if (gl_LOGFILE != NULL) {
-        FILE *tmpfile;
-        if (stat(gl_LOGFILE, &statbuf) == 0 &&
-            (statbuf.st_mode & S_IFMT) == S_IFLNK) {
-            fprintf(stderr, "Logfile must not be a symlink.\n");
-            goto error;
-        }
-        tmpfile = fopen(gl_LOGFILE, "a");
-        if (tmpfile == NULL) {
-            fprintf(stderr, "Cannot write to logfile %s.\n", gl_LOGFILE);
-            goto error;
-        }
-        fclose(tmpfile);
-    }
 
     // Check tpm_state_path directory and access rights
     if (tpm_state_path == NULL) {


### PR DESCRIPTION
The previous code attempted to detect symlinks using `stat()`, which is ineffective because it follows symlinks and therefore does not reliably report `S_IFLNK` for the path itself. As a result, the intended symlink check was not functioning as expected.

This change replaces the `stat()`-based check with `open(..., O_NOFOLLOW)`, which enforces the intended behavior at the point of use (consistent with `append_to_file()`). Errors are reported based on `errno` (e.g., `ELOOP`, `EACCES`, `EISDIR`) to preserve user-facing diagnostics.

In addition, `swtpm_setup` may call `logerr(gl_LOGFILE, ...)` before validating `gl_LOGFILE`. In such cases, logfile access fails earlier in `append_to_file()`, resulting in generic error messages and bypassing the intended validation logic.

To address this, logfile validation is moved earlier, before any `logerr(gl_LOGFILE, ...)` calls, so that invalid logfile paths are detected before first use.

## Testing

### Build / Test

```sh
./autogen.sh --prefix=/usr
make
make check
# => All checks passed.
```

### Unit Tests

```sh
make install
mkdir temp
cd temp

# create new log file (success)
swtpm_setup --tpm-state . --tpm2 --logfile ./newlog.log
# => stdout: TPM is listening on Unix socket.

rm tpm2-00.permall

# Overwrite existing log file (success)
echo "log" > existing.log
swtpm_setup --tpm-state . --tpm2 --logfile ./existing.log
# => stdout: TPM is listening on Unix socket.

rm tpm2-00.permall

# no write access (failure)
chmod -w ./existing.log
swtpm_setup --tpm-state . --tpm2 --logfile ./existing.log
# => stderr: Cannot open logfile ./existing.log: Permission denied

# directory name (failure)
mkdir logdir
swtpm_setup --tpm-state . --tpm2 --logfile ./logdir
# =>  stderr: Cannot open logfile ./logdir: Is a directory

# symlink (failure)
echo "log" > target.log
ln -s target.log symlink.log
swtpm_setup --tpm-state . --tpm2 --logfile ./symlink.log
# => stderr: Cannot open logfile ./symlink.log: Too many levels of symbolic links
```