### PR TITLE
Apply the printf compiler attribute to logging functions to check formatting parameters

### DIFF
--- a/include/compiler_dependencies.h
+++ b/include/compiler_dependencies.h
@@ -10,6 +10,14 @@
 #ifndef _SWTPM_COMPILER_DEPENDENCIES_H
 #define _SWTPM_COMPILER_DEPENDENCIES_H
 
+#ifndef __clang__
+# define SWTPM_ATTRIBUTE_FORMAT(STRING_IDX, FIRST_TO_CHECK) \
+  __attribute__((format (printf, STRING_IDX, FIRST_TO_CHECK)))
+#else
+# define SWTPM_ATTRIBUTE_FORMAT(STRING_IDX, FIRST_TO_CHECK) \
+  __attribute__((__format__ (__printf__, STRING_IDX, FIRST_TO_CHECK)))
+#endif
+
 #ifdef __GNUC__ /* gcc and clang */
 # define SWTPM_ATTR_UNUSED __attribute__((unused))
 #endif

--- a/src/swtpm/logging.h
+++ b/src/swtpm/logging.h
@@ -41,14 +41,17 @@
 #include <unistd.h> /* STD???_FILENO */
 #include <stdbool.h>
 
+#include "compiler_dependencies.h"
+
 #define SUPPRESS_LOGGING       -1 /* suppress all logging */
 #define SUPPRESS_INFO_LOGGING  -2 /* suppress only info and warning messages */
 
 int log_init(const char *filename, bool truncate);
 int log_init_fd(int fd);
 int log_set_level(unsigned int level);
-ssize_t logprintf(int fd, const char *format, ...);
-ssize_t logprintfA(int fd, unsigned int indent, const char *format, ...);
+ssize_t logprintf(int fd, const char *format, ...) SWTPM_ATTRIBUTE_FORMAT(2, 3);
+ssize_t logprintfA(int fd, unsigned int indent, const char *format, ...)
+    SWTPM_ATTRIBUTE_FORMAT(3, 4);
 int log_check_string(const char *);
 int log_set_prefix(const char *);
 void log_global_free(void);

--- a/src/swtpm/options.c
+++ b/src/swtpm/options.c
@@ -49,6 +49,10 @@
 #include <grp.h>
 
 #include "options.h"
+#include "compiler_dependencies.h"
+
+static void option_error_set(char **error, const char *format, ...)
+    SWTPM_ATTRIBUTE_FORMAT(2, 3);
 
 static void
 option_error_set(char **error, const char *format, ...)

--- a/src/swtpm/swtpm_aes.c
+++ b/src/swtpm/swtpm_aes.c
@@ -84,7 +84,7 @@ TPM_RESULT SWTPM_SymmetricKeyData_Encrypt(unsigned char **encrypt_data,   /* out
                                           uint32_t u_ivec_length)		/* input */
 {
     TPM_RESULT          rc = 0;
-    uint32_t              pad_length;
+    uint32_t            pad_length;
     unsigned char       *decrypt_data_pad;
     unsigned char       ivec[SWTPM_AES256_BLOCK_SIZE];       /* initial chaining vector */
     TPM_SYMMETRIC_KEY_DATA *tpm_symmetric_key_data =
@@ -99,7 +99,7 @@ TPM_RESULT SWTPM_SymmetricKeyData_Encrypt(unsigned char **encrypt_data,   /* out
         if (u_ivec != NULL && u_ivec_length != userKeyLength) {
             logprintf(STDERR_FILENO,
                       "SWTPM_SymmetricKeyData_Encrypt: IV is %u bytes, "
-                      "but expected %u bytes\n", u_ivec_length,
+                      "but expected %zu bytes\n", u_ivec_length,
                       tpm_symmetric_key_token->userKeyLength);
             rc = TPM_ENCRYPT_ERROR;
         } else {
@@ -216,7 +216,7 @@ TPM_RESULT SWTPM_SymmetricKeyData_Decrypt(unsigned char **decrypt_data,   /* out
         if (u_ivec != NULL && u_ivec_length != userKeyLength) {
             logprintf(STDERR_FILENO,
                       "SWTPM_SymmetricKeyData_Decrypt: IV is %u bytes, "
-                      "but expected %u bytes\n", u_ivec_length, userKeyLength);
+                      "but expected %zu bytes\n", u_ivec_length, userKeyLength);
             rc = TPM_DECRYPT_ERROR;
         } else {
             if (u_ivec) {

--- a/src/swtpm/swtpm_debug.c
+++ b/src/swtpm/swtpm_debug.c
@@ -48,6 +48,10 @@
 
 #include "swtpm_debug.h"
 #include "logging.h"
+#include "compiler_dependencies.h"
+
+static int SWTPM_AppendPrintf(char **buffer, const char *fmt, ...)
+    SWTPM_ATTRIBUTE_FORMAT(2, 3);
 
 /*
  * SWTPM_AppendPrintf() print and append to buffer
@@ -110,7 +114,7 @@ void SWTPM_PrintAll(const char *string, const char *indentation,
             if (i && !( i % 16 )) {
                 SWTPM_AppendPrintf(&linebuffer, "\n");
 
-                logprintfA(STDERR_FILENO, 0, linebuffer);
+                logprintfA(STDERR_FILENO, 0, "%s", linebuffer);
 
                 free(linebuffer);
                 linebuffer = NULL;

--- a/src/swtpm/tlv.c
+++ b/src/swtpm/tlv.c
@@ -93,7 +93,8 @@ tlv_data_append(unsigned char **buffer, uint32_t *buffer_len,
 
     tmp = realloc(*buffer, (size_t)totlen);
     if (!tmp) {
-         logprintf(STDERR_FILENO, "Could not allocate %u bytes.\n", totlen);
+         logprintf(STDERR_FILENO, "Could not allocate %zu bytes.\n",
+                   (size_t)totlen);
          return TPM_FAIL;
     }
     *buffer = tmp;

--- a/src/swtpm/utils.c
+++ b/src/swtpm/utils.c
@@ -151,13 +151,13 @@ change_process_owner(const char *user)
 
     if (setgid(gid) < 0) {
         logprintf(STDERR_FILENO,
-                  "Error: setgid(%d) failed.\n",
+                  "Error: setgid(%ld) failed.\n",
                   gid);
         return -11;
     }
     if (setuid(uid) < 0) {
         logprintf(STDERR_FILENO,
-                  "Error: setuid(%d) failed.\n",
+                  "Error: setuid(%ld) failed.\n",
                   uid);
         return -12;
     }

--- a/src/swtpm_cert/ek-cert.c
+++ b/src/swtpm_cert/ek-cert.c
@@ -1602,7 +1602,7 @@ main(int argc, char *argv[])
 
         token = strtok(s, ",");
         do {
-            while (isspace(*token))
+            while (isspace((int)*token))
                 token++;
             equal = strchr(token, '=');
             if (equal) {

--- a/src/swtpm_localca/Makefile.am
+++ b/src/swtpm_localca/Makefile.am
@@ -15,6 +15,7 @@ noinst_HEADERS = \
 	swtpm_localca_utils.h
 
 swtpm_localca_CFLAGS = \
+	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/src/utils \
 	-I$(top_builddir)/src/utils \
 	$(MY_CFLAGS) \

--- a/src/swtpm_localca/swtpm_localca.c
+++ b/src/swtpm_localca/swtpm_localca.c
@@ -541,7 +541,7 @@ static int create_cert(unsigned long flags, const gchar *typ, const gchar *direc
     success = spawn_sync(NULL, cmd, swtpm_cert_env, G_SPAWN_DEFAULT, NULL, NULL,
                          &standard_output, &standard_error, &exit_status, &error);
     if (!success) {
-        logerr(gl_LOGFILE, "Could not run swtpm_cert: %s\n", error);
+        logerr(gl_LOGFILE, "Could not run swtpm_cert: %s\n", error->message);
         g_error_free(error);
         goto error;
     }

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -308,12 +308,12 @@ static int transfer(struct swtpm *self, void *buffer, size_t buffer_len,
     if (!use_ctrl) {
         if ((size_t)resplen < sizeof(struct tpm_resp_header)) {
             logerr(self->logfile,
-                   "Response for %s has only %d bytes.\n", cmdname, resplen);
+                   "Response for %s has only %zd bytes.\n", cmdname, resplen);
             return 1;
         }
     } else if ((size_t)resplen < 4) {
         logerr(self->logfile,
-               "Response for %s has only %d bytes.\n", cmdname, resplen);
+               "Response for %s has only %zd bytes.\n", cmdname, resplen);
         return 1;
     }
 
@@ -1056,7 +1056,7 @@ static int swtpm_tpm2_createprimary_ecc(struct swtpm *self, uint32_t primaryhand
     if (ektemplate) {
         if (*ektemplate_len < (size_t)public_len) {
             logerr(self->logfile, "Internal error: Need %zu bytes for ektemplate (ecc) but got only %zu\n",
-                   public_len, ektemplate_len);
+                   public_len, *ektemplate_len);
             return 1;
         }
         memcpy(ektemplate, public, public_len);
@@ -1868,7 +1868,7 @@ static int swtpm_tpm12_take_ownership(struct swtpm *self, const unsigned char ow
                                       }, (size_t)12,
                                       NULL);
     if (tpm_rsa_key_parms_len < 0) {
-        logerr(self->logfile, "Internal error in %s: out of memory\n");
+        logerr(self->logfile, "Internal error in %s: out of memory\n", __func__);
         goto error;
     }
 
@@ -1881,7 +1881,7 @@ static int swtpm_tpm12_take_ownership(struct swtpm *self, const unsigned char ow
                                   tpm_rsa_key_parms, tpm_rsa_key_parms_len,
                                   NULL);
     if (tpm_key_parms_len < 0) {
-        logerr(self->logfile, "Internal error in %s: out of memory\n");
+        logerr(self->logfile, "Internal error in %s: out of memory\n", __func__);
         goto error;
     }
 
@@ -1894,7 +1894,7 @@ static int swtpm_tpm12_take_ownership(struct swtpm *self, const unsigned char ow
                               (unsigned char[]){AS4BE(0), AS4BE(0), AS4BE(0)}, (size_t)12,
                               NULL);
     if (tpm_key12_len < 0) {
-        logerr(self->logfile, "Internal error in %s: out of memory\n");
+        logerr(self->logfile, "Internal error in %s: out of memory\n", __func__);
         goto error;
     }
 
@@ -1907,7 +1907,7 @@ static int swtpm_tpm12_take_ownership(struct swtpm *self, const unsigned char ow
                      tpm_key12, tpm_key12_len,
                      NULL);
     if (req_len < 0) {
-        logerr(self->logfile, "Internal error in %s: req is too small\n");
+        logerr(self->logfile, "Internal error in %s: req is too small\n", __func__);
         goto error;
     }
     SHA1(&req[6], req_len - 6, in_param_digest);
@@ -1918,7 +1918,7 @@ static int swtpm_tpm12_take_ownership(struct swtpm *self, const unsigned char ow
                                          &continue_auth_session, (size_t)1,
                                          NULL);
     if (in_auth_setup_params_len < 0) {
-        logerr(self->logfile, "Internal error in %s: out of memory\n");
+        logerr(self->logfile, "Internal error in %s: out of memory\n", __func__);
         goto error;
     }
 
@@ -1927,7 +1927,7 @@ static int swtpm_tpm12_take_ownership(struct swtpm *self, const unsigned char ow
                              in_auth_setup_params, in_auth_setup_params_len,
                              NULL);
     if (macinput_len < 0) {
-        logerr(self->logfile, "Internal error in %s: out of memory\n");
+        logerr(self->logfile, "Internal error in %s: out of memory\n", __func__);
         goto error;
     }
 
@@ -1941,7 +1941,7 @@ static int swtpm_tpm12_take_ownership(struct swtpm *self, const unsigned char ow
                  owner_auth, owner_auth_len,
                  NULL);
     if (len < 0) {
-        logerr(self->logfile, "Internal error in %s: req is too small\n");
+        logerr(self->logfile, "Internal error in %s: req is too small\n", __func__);
         goto error;
     }
     req_len += len;
@@ -1994,7 +1994,7 @@ static int swtpm_tpm12_nv_define_space(struct swtpm *self, uint32_t nvindex,
                                    zeroes, sizeof(zeroes),
                                    NULL);
     if (pcr_info_short_len < 0) {
-        logerr(self->logfile, "Internal error in %s: out of memory\n");
+        logerr(self->logfile, "Internal error in %s: out of memory\n", __func__);
         return 1;
     }
 
@@ -2010,7 +2010,7 @@ static int swtpm_tpm12_nv_define_space(struct swtpm *self, uint32_t nvindex,
                                    }, (size_t)13,
                                    NULL);
     if (nv_data_public_len < 0) {
-        logerr(self->logfile, "Internal error in %s: out of memory\n");
+        logerr(self->logfile, "Internal error in %s: out of memory\n", __func__);
         return 1;
     }
 
@@ -2020,7 +2020,7 @@ static int swtpm_tpm12_nv_define_space(struct swtpm *self, uint32_t nvindex,
                         zeroes, sizeof(zeroes),
                         NULL);
     if (req_len < 0) {
-        logerr(self->logfile, "Internal error in %s: out of memory\n");
+        logerr(self->logfile, "Internal error in %s: out of memory\n", __func__);
         return 1;
     }
 
@@ -2043,7 +2043,7 @@ static int swtpm_tpm12_nv_write_value(struct swtpm *self, uint32_t nvindex,
                         data, data_len,
                         NULL);
     if (req_len < 0) {
-        logerr(self->logfile, "Internal error in %s: out of memory\n");
+        logerr(self->logfile, "Internal error in %s: out of memory\n", __func__);
         return 1;
     }
 

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -1302,7 +1302,7 @@ static int change_process_owner(const char *user)
     }
 
     if (setuid(uid) != 0) {
-        logerr(gl_LOGFILE, "Error: setuid(%d) failed: %s\n", uid, strerror(errno));
+        logerr(gl_LOGFILE, "Error: setuid(%lld) failed: %s\n", uid, strerror(errno));
         goto error;
     }
 

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -357,7 +357,7 @@ error_unlink:
 }
 
 static int read_certificate_file(const gchar *certsdir, const gchar *filename,
-                                 gchar **filecontent, size_t *filecontent_len,
+                                 gchar **filecontent, gsize *filecontent_len,
                                  gchar **certfile)
 {
     *certfile = g_strjoin(G_DIR_SEPARATOR_S, certsdir, filename, NULL);
@@ -378,7 +378,7 @@ static int tpm2_persist_certificate(unsigned long flags, const gchar *certsdir,
 {
     g_autofree gchar *filecontent = NULL;
     g_autofree gchar *certfile = NULL;
-    size_t filecontent_len;
+    gsize filecontent_len;
     int ret;
 
     ret = read_certificate_file(certsdir, ftc->filename,

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -14,6 +14,7 @@ noinst_LTLIBRARIES = \
 	libswtpm_utils.la
 
 libswtpm_utils_la_CFLAGS = \
+	-I$(top_srcdir)/include \
 	$(MY_CFLAGS) \
 	$(CFLAGS) \
 	$(HARDENING_CFLAGS) \

--- a/src/utils/swtpm_utils.c
+++ b/src/utils/swtpm_utils.c
@@ -375,7 +375,7 @@ int write_to_tempfile(gchar **filename, const unsigned char *data, size_t data_l
 
     n = lseek(fd, 0, SEEK_SET);
     if (n < 0) {
-        logerr(gl_LOGFILE, "Could not seek(0) on file '%s': %s\n", filename, strerror(errno));
+        logerr(gl_LOGFILE, "Could not seek(0) on file '%s': %s\n", *filename, strerror(errno));
         goto error;
     }
     return fd;

--- a/src/utils/swtpm_utils.h
+++ b/src/utils/swtpm_utils.h
@@ -14,6 +14,8 @@
 
 #include <glib.h>
 
+#include "compiler_dependencies.h"
+
 #define min(X,Y) ((X) < (Y) ? (X) : (Y))
 #define ARRAY_LEN(a) (sizeof(a) / sizeof((a)[0]))
 
@@ -32,8 +34,8 @@
 extern gchar *gl_LOGFILE;
 
 void append_to_file(const char *pathname, const char *str);
-void logit(const char *logfile, const char *fmt, ...);
-void logerr(const char *logfile, const char *fmt, ...);
+void logit(const char *logfile, const char *fmt, ...) SWTPM_ATTRIBUTE_FORMAT(2, 3);
+void logerr(const char *logfile, const char *fmt, ...) SWTPM_ATTRIBUTE_FORMAT(2, 3);
 
 char *pathjoin(char *buffer, size_t bufferlen, const char *p1, const char *p2, const char *p3);
 


### PR DESCRIPTION
This PR adds the printf compiler attribute to logging functions to check formatting parameters and fixes the detected issues.
 