### PR TITLE
Address some issues detected by Bob IDE

### DIFF
--- a/src/swtpm_cert/ek-cert.c
+++ b/src/swtpm_cert/ek-cert.c
@@ -351,12 +351,13 @@ create_ecc_from_x_and_y(unsigned char *ecc_x, unsigned int ecc_x_len,
         exp_len = 528/8;
     } else {
         fprintf(stderr, "Unsupported ECC curve id: %s\n", ecc_curveid);
-        return NULL;
+        goto cleanup;
     }
     if (ecc_x_len > exp_len || ecc_y_len > exp_len) {
         fprintf(stderr,
                 "EC X or Y parameter exceeds expected size of %zu bytes\n",
                 exp_len);
+        goto cleanup;
     }
     buffer = g_malloc0(1 + 2 * exp_len);
     buffer[0] = 0x4;

--- a/src/swtpm_cert/ek-cert.c
+++ b/src/swtpm_cert/ek-cert.c
@@ -242,6 +242,10 @@ static unsigned char *hex_str_to_bin(const char *hexstr, int *modulus_len)
     char val1, val2;
 
     len = strlen(hexstr);
+    if (len > 10 * 1024) {
+        fprintf(stderr, "Unreasonably long hex string of %d bytes.\n", len);
+        return NULL;
+    }
 
     if ((len & 1) != 0) {
         fprintf(stderr, "Got an odd number of hex digits (%d).\n", len);

--- a/src/swtpm_cert/ek-cert.c
+++ b/src/swtpm_cert/ek-cert.c
@@ -1170,7 +1170,7 @@ main(int argc, char *argv[])
     int err;
     int cert_file_fd;
     const char *subject = NULL;
-    int days = 365;
+    long days = 365;
     char *sigkeypass = NULL;
     char *parentkeypass = NULL;
     unsigned char ser_number[21];
@@ -1192,6 +1192,7 @@ main(int argc, char *argv[])
     long int spec_revision = ~0;
     int flags = 0;
     bool is_ecc = false;
+    char *endptr;
     static struct option long_options[] = {
         {"pubkey", required_argument, NULL, 'p'},
         {"modulus", required_argument, NULL, 'm'},
@@ -1268,7 +1269,13 @@ main(int argc, char *argv[])
             ecc_curveid = optarg;
             break;
         case 'e': /* --exponent */
-            exponent = strtol(optarg, NULL, 0);
+            errno = 0;
+            exponent = strtol(optarg, &endptr, 0);
+            if (errno || endptr == optarg || *endptr != '\0') {
+                fprintf(stderr, "Could not parse the exponent '%s'.\n",
+                        optarg);
+                goto cleanup;
+            }
             if (exponent == 0) {
                 fprintf(stderr, "Exponent is wrong and cannot be 0.\n");
                 goto cleanup;
@@ -1319,7 +1326,18 @@ main(int argc, char *argv[])
             subject = optarg;
             break;
         case 'd': /* --days */
-            days = atoi(optarg);
+            errno = 0;
+            days = strtol(optarg, &endptr, 0);
+            if (errno || endptr == optarg || *endptr != '\0') {
+                fprintf(stderr, "Could not parse the number of days '%s'.\n",
+                        optarg);
+                goto cleanup;
+            }
+            if (days > INT_MAX) {
+                fprintf(stderr, "Days value of '%s' is outside valid range.\n",
+                        optarg);
+                goto cleanup;
+            }
             break;
         case 'r': /* --serial */
             if (gmp_sscanf(optarg, "%Zd", serial) != 1) {
@@ -1360,14 +1378,26 @@ main(int argc, char *argv[])
             spec_family = optarg;
             break;
         case '8': /* --tpm-spec-level */
-            spec_level = strtol(optarg, NULL, 0);
+            errno = 0;
+            spec_level = strtol(optarg, &endptr, 0);
+            if (errno || endptr == optarg || *endptr != '\0') {
+                fprintf(stderr, "Could not parse the spec level '%s'.\n",
+                        optarg);
+                goto cleanup;
+            }
             if (spec_level < 0) {
                 fprintf(stderr, "--tpm-spec-level must pass a positive number.\n");
                 goto cleanup;
             }
             break;
         case '9': /* --tpm-spec-revision */
-            spec_revision = strtol(optarg, NULL, 0);
+            errno = 0;
+            spec_revision = strtol(optarg, &endptr, 0);
+            if (errno || endptr == optarg || *endptr != '\0') {
+                fprintf(stderr, "Could not parse the spec revision '%s'.\n",
+                        optarg);
+                goto cleanup;
+            }
             if (spec_revision < 0) {
                 fprintf(stderr, "--tpm-spec-revision must pass a positive number.\n");
                 goto cleanup;


### PR DESCRIPTION
Address some issue detected by Bob IDE:
- unchecked failures during strtol numbers parsing
- possible unreasonable large memory allocation after user passed in large hex number (for modulus for example)
- failure to return NULL when EC key coordinates exceed expected sizes