### PR TITLE
Add support for creating IAK and IDevID keys and certificates (v2)

### DIFF
--- a/man/man8/swtpm_localca.pod
+++ b/man/man8/swtpm_localca.pod
@@ -41,7 +41,7 @@ The following options are supported:
 =item B<--type type>
 
 This parameter indicates the type of certificate to create. The type parameter may
-be one of the following: I<ek>, or I<platform>
+be one of the following: I<ek>, I<platform>, I<iak>, I<idevid>
 
 =item B<--dir dir>
 

--- a/man/man8/swtpm_localca.pod
+++ b/man/man8/swtpm_localca.pod
@@ -87,6 +87,11 @@ TPM specification parameters that describe the specification that was
 followed for the TPM implementation. The parameters will be passed
 to swtpm_cert for the creation of the EK certificate.
 
+=item B<--tpm-serial-num>
+
+The TPM's serial number that will become part of the certificate. This parameter
+is necessary for IAK and IDevID certificates.
+
 =item B<--tpm2>
 
 Create TPM 2 compliant certificates.

--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -113,6 +113,8 @@ I<ek2keyalgo> entry in the I<swtpm_setup.conf> configuration file.
 =item B<--iakkeyalgo <key algorithm>> (since v0.11)
 
 Choose the key algorithm for the IAK key that can be used for signing.
+An IAK requires an EK certificate to be created to refer to in its own
+certificate.
 
 Valid values are: ecc_nist_p256 or secp256r1, ecc_nist_p384 or secp384r1,
 ecc_nist_p521 or secp521r1, rsa2048, rsa3072, rsa4096.
@@ -125,6 +127,8 @@ The IAK key will be persisted at 0x81020001.
 =item B<--idevidkeyalgo <key algorithm>> (since v0.11)
 
 Choose the key algorithm for the IDevID key that can be used for signing.
+An IDevID requires an EK certificate to be created to refer to in its own
+certificate.
 
 For valid values see the description of the B<--iakkeyalgo> option.
 

--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -110,6 +110,29 @@ For valid values see the description of the B<--ek1keyalgo> option.
 It is possible to choose a default 2nd endorsement key algorithm with an
 I<ek2keyalgo> entry in the I<swtpm_setup.conf> configuration file.
 
+=item B<--iakkeyalgo <key algorithm>> (since v0.11)
+
+Choose the key algorithm for the IAK key that can be used for signing.
+
+Valid values are: ecc_nist_p256 or secp256r1, ecc_nist_p384 or secp384r1,
+ecc_nist_p521 or secp521r1, rsa2048, rsa3072, rsa4096.
+
+It is possible to choose a default IAK key algorithm with an I<iakkeyalgo>
+entry in the I<swtpm_setup.conf> configuration file.
+
+The IAK key will be persisted at 0x81020001.
+
+=item B<--idevidkeyalgo <key algorithm>> (since v0.11)
+
+Choose the key algorithm for the IDevID key that can be used for signing.
+
+For valid values see the description of the B<--iakkeyalgo> option.
+
+It is possible to choose a default IDevID key algorithm with an I<idevidkeyalgo>
+entry in the I<swtpm_setup.conf> configuration file.
+
+The IDevID key will be persisted at 0x81020000.
+
 =item B<--take-ownership>
 
 Take ownership; this option implies --createek. This option is only available for TPM 1.2.
@@ -336,7 +359,9 @@ The output may contain the following:
         "cmdarg-profile",
         "cmdarg-profile-remove-disabled",
         "cmdarg-ek1keyalgo",
-        "cmdarg-ek2keyalgo"
+        "cmdarg-ek2keyalgo,"
+        "cmdarg-iakkeyalgo,"
+        "cmdarg-idevidkeyalgo"
       ],
       "version": "0.7.0"
     }
@@ -403,6 +428,14 @@ The I<--ek1keyalgo> option is supported.
 =item B<cmdarg-ek2keyalgo> (since v0.11)
 
 The I<--ek2keyalgo> option is supported.
+
+=item B<cmdarg-iakkeyalgo> (since v0.11)
+
+The I<--iakkeyalgo> option is supported.
+
+=item B<cmdarg-idevidkeyalgo> (since v0.11)
+
+The I<--idevidkeyalgo> option is supported.
 
 =back
 

--- a/src/swtpm_cert/ek-cert.c
+++ b/src/swtpm_cert/ek-cert.c
@@ -1604,6 +1604,8 @@ int main(int argc, char *argv[])
         switch (certtype) {
         case CERT_TYPE_PLATFORM:
         case CERT_TYPE_EK:
+        case CERT_TYPE_IAK:
+        case CERT_TYPE_IDEVID:
             if (!subject)
                 break;
 
@@ -1629,16 +1631,6 @@ int main(int argc, char *argv[])
                 }
                 token = strtok(NULL, ",");
             } while (token);
-            break;
-        case CERT_TYPE_IAK:
-        case CERT_TYPE_IDEVID:
-            name = X509_NAME_new();
-            CHECK_OSSL_NULLPTR1(name, "Out of memory");
-            CHECK_OSSL_RETURN1(
-                X509_NAME_add_entry_by_txt(name, "serialNumber", MBSTRING_ASC,
-                                           (unsigned char *)tpm_serial_num,
-                                           -1, -1, 0) != 1,
-                "X509_NAME_add_entry_by_txt failed.\n");
             break;
         case CERT_TYPE_AIK:
             break;

--- a/src/swtpm_localca/swtpm_localca.c
+++ b/src/swtpm_localca/swtpm_localca.c
@@ -501,11 +501,13 @@ static int create_cert(unsigned long flags, const gchar *typ, const gchar *direc
 
     cmd = concat_arrays(cmd, tpm_attr_params, TRUE);
 
-    if (strcmp(typ, "platform") == 0) {
-        certfile = g_strjoin(G_DIR_SEPARATOR_S, directory, "platform.cert", NULL);
+    if (strcmp(typ, "platform") == 0 || strcmp(typ, "iak") == 0 || strcmp(typ, "idevid") == 0) {
+        g_autofree gchar *certfn = g_strconcat(typ, ".cert", NULL);
+
+        certfile = g_strjoin(G_DIR_SEPARATOR_S, directory, certfn, NULL);
         cmd = concat_arrays(cmd,
                             (const gchar *[]){
-                                "--type", "platform",
+                                "--type", typ,
                                 "--out-cert", certfile,
                                 NULL},
                             TRUE);
@@ -530,7 +532,7 @@ static int create_cert(unsigned long flags, const gchar *typ, const gchar *direc
     if (strcmp(typ, "ek") == 0)
         certtype = "EK";
     else
-        certtype = "platform";
+        certtype = typ;
 #if 0
     {
         g_autofree gchar *join = g_strjoinv(" ", cmd);

--- a/src/swtpm_localca/swtpm_localca.c
+++ b/src/swtpm_localca/swtpm_localca.c
@@ -370,8 +370,8 @@ static int create_cert(unsigned long flags, const gchar *typ, const gchar *direc
                        const gchar **tpm_attr_params, const gchar *signkey,
                        const gchar *signkey_password, const gchar *issuercert,
                        const gchar **swtpm_cert_env,
-                       const gchar *certserial, const gchar *lockfile,
-                       const gchar *optsfile)
+                       const gchar *certserial, const gchar *tpm_serial_num,
+                       const gchar *lockfile, const gchar *optsfile)
 {
     gchar ** optsfile_lines = NULL;
     g_autofree const gchar **options = NULL;
@@ -429,10 +429,21 @@ static int create_cert(unsigned long flags, const gchar *typ, const gchar *direc
         g_strfreev(split);
     }
 
-    if (vmid != NULL)
-        subject = g_strdup_printf("CN=%s", vmid);
-    else
-        subject = g_strdup("CN=unknown");
+    if (strcmp(typ, "ek") == 0 || strcmp(typ, "platform") == 0) {
+        subject = g_strdup_printf("CN=%s",
+                                  vmid ? vmid : "unknown");
+    } else if (strcmp(typ, "iak") == 0 || strcmp(typ, "idevid") == 0) {
+        subject = g_strdup_printf("serialNumber=%s",
+                                  vmid ? vmid : "unknown");
+    }
+
+    if ((flags & SETUP_TPM2_F) && tpm_serial_num)
+        options = concat_arrays(options,
+                                (const gchar *[]){
+                                    "--tpm-serial-num",
+                                    tpm_serial_num,
+                                    NULL
+                                }, TRUE);
 
     if (flags & SETUP_TPM2_F)
         options = concat_arrays(options, (const gchar *[]){"--tpm2", NULL}, TRUE);
@@ -576,6 +587,7 @@ static void usage(const char *prgname)
         "--tpm-manufacturer s  The manufacturer of the TPM; e.g., id:00001014\n"
         "--tpm-model s         The model of the TPM; e.g., 'swtpm'\n"
         "--tpm-version i       The (firmware) version of the TPM; e.g., id:20160511\n"
+        "--tpm-serial-num s    The string representing the serial number of the TPM\n"
         "--tpm2                Generate a certificate for a TPM 2\n"
         "--allow-signing       The TPM 2's EK can be used for signing\n"
         "--decryption          The TPM 2's EK can be used for decryption\n"
@@ -606,6 +618,7 @@ int main(int argc, char *argv[])
         {"tpm-manufacturer", required_argument, NULL, 'a'},
         {"tpm-model", required_argument, NULL, 'm'},
         {"tpm-version", required_argument, NULL, 's'},
+        {"tpm-serial-num", required_argument, NULL, 'S'},
         {"tpm2", no_argument, NULL, '2'},
         {"allow-signing", no_argument, NULL, 'i'},
         {"decryption", no_argument, NULL, 'y'},
@@ -627,6 +640,7 @@ int main(int argc, char *argv[])
     g_autofree gchar *signkey_password = NULL;
     g_autofree gchar *issuercert = NULL;
     g_autofree gchar *certserial = NULL;
+    g_autofree gchar *tpm_serial_num = NULL;
     gchar **tpm_spec_params = NULL;
     gchar **tpm_attr_params = NULL;
     gchar **config_file_lines = NULL;
@@ -694,6 +708,10 @@ int main(int argc, char *argv[])
                               g_strdup(optarg),
                               NULL
                           }, TRUE);
+            break;
+        case 'S': /* --tpm-serial-num */
+            g_free(tpm_serial_num);
+            tpm_serial_num = g_strdup(optarg);
             break;
         case '2': /* --tpm2 */
             flags |= SETUP_TPM2_F;
@@ -870,7 +888,8 @@ int main(int argc, char *argv[])
     ret = create_cert(flags, typ, directory, key_params, vmid,
                       (const char **)tpm_spec_params, (const char **)tpm_attr_params,
                       signkey, signkey_password, issuercert,
-                      (const char **)swtpm_cert_env, certserial, lockfile, optsfile);
+                      (const char **)swtpm_cert_env, certserial, tpm_serial_num,
+                      lockfile, optsfile);
 
 out:
 error:

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -422,12 +422,12 @@ static const struct swtpm_cops swtpm_cops = {
 #define TPM2_ALG_SHA256   0x000b
 #define TPM2_ALG_SHA384   0x000c
 #define TPM2_ALG_SHA512   0x000d
-#define TPM2_ALG_SHA3_256 0x0027
-#define TPM2_ALG_SHA3_384 0x0028
-#define TPM2_ALG_SHA3_512 0x0029
 #define TPM2_ALG_NULL     0x0010
 #define TPM2_ALG_SM3      0x0012
 #define TPM2_ALG_ECC      0x0023
+#define TPM2_ALG_SHA3_256 0x0027
+#define TPM2_ALG_SHA3_384 0x0028
+#define TPM2_ALG_SHA3_512 0x0029
 #define TPM2_ALG_CFB      0x0043
 
 #define TPM2_CAP_PCRS     0x00000005
@@ -560,6 +560,8 @@ struct pk_params {
     uint32_t keyflags;
     const unsigned char *nonce;
     size_t nonce_len;
+    const unsigned char *nonce2; // For ECC if nonce != nonce2
+    size_t nonce2_len;
     uint16_t hashalg;
     const unsigned char *authpolicy;
     size_t authpolicy_len;
@@ -1409,7 +1411,8 @@ static int swtpm_tpm2_createprimary_ecc(struct swtpm *self, uint32_t primaryhand
                   symkeydata, symkeydata_len,
                   pk_params->schemedata, pk_params->schemedata_len,
                   pk_params->nonce, pk_params->nonce_len,
-                  pk_params->nonce, pk_params->nonce_len,
+                  pk_params->nonce2 ? pk_params->nonce2     : pk_params->nonce,
+                  pk_params->nonce2 ? pk_params->nonce2_len : pk_params->nonce_len,
                   NULL);
     if (public_len < 0) {
         logerr(self->logfile, "Internal error in %s: memconcat failed\n", __func__);

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -563,6 +563,9 @@ struct pk_params {
     uint16_t hashalg;
     const unsigned char *authpolicy;
     size_t authpolicy_len;
+#define SCHEMEDATA_SIZE 8
+    unsigned char schemedata[SCHEMEDATA_SIZE];
+    size_t schemedata_len;
     unsigned int symkey_len;
     int duration;
     size_t off; // offset of public key in TPM response
@@ -640,6 +643,10 @@ static const struct ek_params {
             .hashalg = TPM2_ALG_SHA256,
             .authpolicy = PolicyA_SHA256,
             .authpolicy_len = sizeof(PolicyA_SHA256),
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_NULL), AS2BE(2048), AS4BE(0)
+             },
+            .schemedata_len = 8,
             .symkey_len = 128,
             .duration = TPM2_DURATION_LONG,
             .keysize = 2048 / 8,
@@ -658,6 +665,10 @@ static const struct ek_params {
             .hashalg = TPM2_ALG_SHA384,
             .authpolicy = PolicyB_SHA384,
             .authpolicy_len = sizeof(PolicyB_SHA384),
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_NULL), AS2BE(3072), AS4BE(0)
+             },
+            .schemedata_len = 8,
             .symkey_len = 256,
             .duration = TPM2_DURATION_LONG,
             .keysize = 3072 / 8,
@@ -676,6 +687,10 @@ static const struct ek_params {
             .hashalg = TPM2_ALG_SHA384,
             .authpolicy = PolicyB_SHA384,
             .authpolicy_len = sizeof(PolicyB_SHA384),
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_NULL), AS2BE(4096), AS4BE(0)
+             },
+            .schemedata_len = 8,
             .symkey_len = 256,
             .duration = TPM2_DURATION_EXTRA_LONG,
             .keysize = 4096 / 8,
@@ -752,6 +767,10 @@ static const struct spk_params {
             .hashalg = TPM2_ALG_SHA256,
             .authpolicy = null_authpolicy,
             .authpolicy_len = 0,
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_NULL), AS2BE(2048), AS4BE(0)
+             },
+            .schemedata_len = 8,
             .keysize = 2048/8,
             .symkey_len = 128,
             .off = 44,
@@ -767,6 +786,10 @@ static const struct spk_params {
             .hashalg = TPM2_ALG_SHA384,
             .authpolicy = null_authpolicy,
             .authpolicy_len = 0,
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_NULL), AS2BE(3072), AS4BE(0)
+             },
+            .schemedata_len = 8,
             .keysize = 3072/8,
             .symkey_len = 256,
             .off = 44,
@@ -782,6 +805,10 @@ static const struct spk_params {
             .hashalg = TPM2_ALG_SHA384,
             .authpolicy = null_authpolicy,
             .authpolicy_len = 0,
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_NULL), AS2BE(4096), AS4BE(0)
+             },
+            .schemedata_len = 8,
             .keysize = 4096/8,
             .symkey_len = 256,
             .off = 44,
@@ -1274,9 +1301,7 @@ static int swtpm_tpm2_createprimary_rsa(struct swtpm *self, uint32_t primaryhand
                   }, (size_t)10,
                   pk_params->authpolicy, pk_params->authpolicy_len,
                   symkeydata, symkeydata_len,
-                  (unsigned char[]) {
-                      AS2BE(TPM2_ALG_NULL), AS2BE(pk_params->keysize * 8), AS4BE(0)
-                  }, (size_t)8,
+                  pk_params->schemedata, pk_params->schemedata_len,
                   pk_params->nonce, pk_params->nonce_len,
                   NULL);
     if (public_len < 0) {

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -529,6 +529,15 @@ static const unsigned char PolicyB_SHA512[64] = {
     0x6D, 0xB5, 0xB6, 0x07, 0x1A, 0xF9, 0x9B, 0xEA
 };
 
+/* SPK: fixedTPM, fixedParent, sensitiveDataOrigin, userWithAuth, noDA, restricted, decrypt */
+#define KEYFLAGS_SPK ((1<<1) /* fixedTPM */ \
+                    | (1<<4) /* fixedParent */ \
+                    | (1<<5) /* sensitiveDataOrigin */ \
+                    | (1<<6) /* userWithAuth */ \
+                    | (1<<10) /* noDA */ \
+                    | (1<<16) /* restricted */ \
+                    | (1<<17)) /* decrypt */
+
 static const struct bank_to_name {
     uint16_t hashAlg;
     const char *name;
@@ -548,6 +557,7 @@ struct pk_params {
     enum keyalgo keyalgo;
     uint16_t keyalgo_param; // RSA key size or ECC curve Id
     const char *keydescription;
+    uint32_t keyflags;
     const unsigned char *nonce;
     size_t nonce_len;
     uint16_t hashalg;
@@ -555,6 +565,7 @@ struct pk_params {
     size_t authpolicy_len;
     unsigned int symkey_len;
     int duration;
+    size_t off; // offset of public key in TPM response
     unsigned keysize;
 };
 
@@ -598,7 +609,7 @@ static const struct ek_params {
             .keysize = 48,
         },
         .ek_handle = TPM2_EK_ECC_SECP384R1_HANDLE,
-        .keytype = "ECC",
+        .keytype = "rsa384r1",
         .nvindex_ekcert = TPM2_NV_INDEX_ECC_SECP384R1_HI_EKCERT,
         .nvindex_template = TPM2_NV_INDEX_ECC_SECP384R1_HI_EKTEMPLATE,
     }, {
@@ -616,7 +627,7 @@ static const struct ek_params {
             .keysize = 66,
         },
         .ek_handle = TPM2_EK_ECC_SECP521R1_HANDLE,
-        .keytype = "ECC",
+        .keytype = "secp521r1",
         .nvindex_ekcert = TPM2_NV_INDEX_ECC_SECP521R1_HI_EKCERT,
         .nvindex_template = TPM2_NV_INDEX_ECC_SECP521R1_HI_EKTEMPLATE,
     }, {
@@ -685,6 +696,7 @@ static const struct spk_params {
         .pk = {
             .keyalgo = KEYALGO_ECC,
             .keyalgo_param = TPM2_ECC_NIST_P256,
+            .keyflags = KEYFLAGS_SPK,
             .nonce = NONCE_ECC_256,
             .nonce_len = sizeof(NONCE_ECC_256),
             .hashalg = TPM2_ALG_SHA256,
@@ -692,12 +704,14 @@ static const struct spk_params {
             .authpolicy_len = 0,
             .keysize = 32,
             .symkey_len = 128,
+            .off = 42,
             .duration = TPM2_DURATION_LONG,
         }
    }, {
         .pk = {
             .keyalgo = KEYALGO_ECC,
             .keyalgo_param = TPM2_ECC_NIST_P384,
+            .keyflags = KEYFLAGS_SPK,
             /* per "TCG TPM v2.0 Provisioning Guidance v1.0" page 37
              * -> "Ek Credential Profile 2.0" rev.14 section 2.1.5.2:
              * template for NIST P256 uses 2 identical 32-byte all-zero nonces
@@ -710,12 +724,14 @@ static const struct spk_params {
             .authpolicy_len = 0,
             .keysize = 48,
             .symkey_len = 256,
+            .off = 42,
             .duration = TPM2_DURATION_LONG,
         },
     }, {
         .pk = {
             .keyalgo = KEYALGO_ECC,
             .keyalgo_param = TPM2_ECC_NIST_P521,
+            .keyflags = KEYFLAGS_SPK,
             .nonce = NONCE_ECC_521,
             .nonce_len = sizeof(NONCE_ECC_521),
             .hashalg = TPM2_ALG_SHA512,
@@ -723,7 +739,53 @@ static const struct spk_params {
             .authpolicy_len = 0,
             .keysize = 66,
             .symkey_len = 256,
+            .off = 42,
             .duration = TPM2_DURATION_LONG,
+       },
+    }, {
+        .pk = {
+            .keyalgo = KEYALGO_RSA,
+            .keyalgo_param = 2048,
+            .keyflags = KEYFLAGS_SPK,
+            .nonce = NONCE_RSA2048,
+            .nonce_len = sizeof(NONCE_RSA2048),
+            .hashalg = TPM2_ALG_SHA256,
+            .authpolicy = null_authpolicy,
+            .authpolicy_len = 0,
+            .keysize = 2048/8,
+            .symkey_len = 128,
+            .off = 44,
+            .duration = TPM2_DURATION_LONG,
+       },
+    }, {
+        .pk = {
+            .keyalgo = KEYALGO_RSA,
+            .keyalgo_param = 3072,
+            .keyflags = KEYFLAGS_SPK,
+            .nonce = NONCE_RSA3072,
+            .nonce_len = sizeof(NONCE_RSA3072),
+            .hashalg = TPM2_ALG_SHA384,
+            .authpolicy = null_authpolicy,
+            .authpolicy_len = 0,
+            .keysize = 3072/8,
+            .symkey_len = 256,
+            .off = 44,
+            .duration = TPM2_DURATION_LONG,
+       },
+    }, {
+        .pk = {
+            .keyalgo = KEYALGO_RSA,
+            .keyalgo_param = 4096,
+            .keyflags = KEYFLAGS_SPK,
+            .nonce = NONCE_RSA4096,
+            .nonce_len = sizeof(NONCE_RSA4096),
+            .hashalg = TPM2_ALG_SHA384,
+            .authpolicy = null_authpolicy,
+            .authpolicy_len = 0,
+            .keysize = 4096/8,
+            .symkey_len = 256,
+            .off = 44,
+            .duration = TPM2_DURATION_EXTRA_LONG,
        },
     }
 };
@@ -1357,63 +1419,29 @@ static int swtpm_tpm2_createprimary_spk_ecc(struct swtpm *self,
         AS2BE(TPM2_ALG_NULL), AS2BE(curveid), AS2BE(TPM2_ALG_NULL)
     };
     size_t schemedata_len = sizeof(schemedata);
-    // keyflags: fixedTPM, fixedParent, sensitiveDataOrigin, userWithAuth
-    //           noDA, restricted, decrypt
-    unsigned int keyflags = 0x00030472;
     const struct spk_params *spks;
-    size_t off = 42;
 
     spks = get_spk_params(self, KEYALGO_ECC, keyalgo_param);
     if (!spks)
         return 1;
 
-    return swtpm_tpm2_createprimary_ecc(self, TPM2_RH_OWNER, keyflags,
+    return swtpm_tpm2_createprimary_ecc(self, TPM2_RH_OWNER, spks->pk.keyflags,
                                         schemedata, schemedata_len,
-                                        &spks->pk, off, curr_handle,
+                                        &spks->pk, spks->pk.off, curr_handle,
                                         NULL, 0, NULL, NULL);
 }
 
-static int swtpm_tpm2_createprimary_spk_rsa(struct swtpm *self, unsigned int rsa_keysize,
+static int swtpm_tpm2_createprimary_spk_rsa(struct swtpm *self, unsigned int keyalgo_param,
                                             uint32_t *curr_handle)
 {
-    // keyflags: fixedTPM, fixedParent, sensitiveDataOrigin, userWithAuth
-    //           noDA, restricted, decrypt
-    unsigned int keyflags = 0x00030472;
-    const unsigned char authpolicy[0] = { };
-    size_t authpolicy_len = sizeof(authpolicy);
-    struct pk_params pk_params = {
-        .authpolicy = authpolicy,
-        .authpolicy_len = authpolicy_len,
-        .keysize = rsa_keysize / 8,
-        .duration = TPM2_DURATION_LONG,
-    };
-    size_t off = 44;
+    const struct spk_params *spks;
 
-    switch (rsa_keysize) {
-    case 2048:
-        pk_params.nonce = NONCE_RSA2048;
-        pk_params.nonce_len = sizeof(NONCE_RSA2048);
-        pk_params.hashalg = TPM2_ALG_SHA256;
-        pk_params.symkey_len = 128;
-        break;
-    case 3072:
-        pk_params.nonce = NONCE_RSA3072;
-        pk_params.nonce_len = sizeof(NONCE_RSA3072);
-        pk_params.hashalg = TPM2_ALG_SHA384;
-        pk_params.symkey_len = 256;
-        break;
-    case 4096:
-        pk_params.nonce = NONCE_RSA4096;
-        pk_params.nonce_len = sizeof(NONCE_RSA4096);
-        pk_params.hashalg = TPM2_ALG_SHA384;
-        pk_params.symkey_len = 256;
-        break;
-    default:
+    spks = get_spk_params(self, KEYALGO_RSA, keyalgo_param);
+    if (!spks)
         return 1;
-    }
 
-    return swtpm_tpm2_createprimary_rsa(self, TPM2_RH_OWNER, keyflags,
-                                        &pk_params, off, curr_handle,
+    return swtpm_tpm2_createprimary_rsa(self, TPM2_RH_OWNER, spks->pk.keyflags,
+                                        &spks->pk, spks->pk.off, curr_handle,
                                         NULL, 0, NULL, NULL);
 }
 

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -2370,6 +2370,36 @@ static int swtpm_tpm2_write_idevid_cert_nvram(struct swtpm *self, gboolean lock_
                                        lock_nvram, "", "IDevID certificate");
 }
 
+static int swtpm_tpm2_get_capability(struct swtpm *self, uint32_t cap, uint32_t prop,
+                                     uint32_t *res)
+{
+    struct tpm2_get_capability_req {
+        struct tpm_req_header hdr;
+        uint32_t cap;
+        uint32_t prop;
+        uint32_t count;
+    } __attribute__((packed)) req = {
+        .hdr = TPM_REQ_HEADER_INITIALIZER(TPM2_ST_NO_SESSIONS, sizeof(req), TPM2_CC_GETCAPABILITY),
+        .cap = htobe32(cap),
+        .prop = htobe32(prop),
+        .count = htobe32(1),
+    };
+    unsigned char tpmresp[27];
+    size_t tpmresp_len = sizeof(tpmresp);
+    uint32_t val;
+    int ret;
+
+    ret = transfer(self, &req, sizeof(req), "TPM2_GetCapability", FALSE,
+                   tpmresp, &tpmresp_len, TPM2_DURATION_SHORT);
+    if (ret != 0)
+        return 1;
+
+    memcpy(&val, &tpmresp[23], sizeof(val));
+    *res = be32toh(val);
+
+    return 0;
+}
+
 static const struct swtpm2_ops swtpm_tpm2_ops = {
     .shutdown = swtpm_tpm2_shutdown,
     .create_spk = swtpm_tpm2_create_spk,
@@ -2383,6 +2413,7 @@ static const struct swtpm2_ops swtpm_tpm2_ops = {
     .write_iak_cert_nvram = swtpm_tpm2_write_iak_cert_nvram,
     .write_idevid_cert_nvram = swtpm_tpm2_write_idevid_cert_nvram,
     .get_active_profile = swtpm_tpm2_get_active_profile,
+    .get_capability = swtpm_tpm2_get_capability,
 };
 
 /*

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -589,6 +589,10 @@ static const struct ek_params {
             .hashalg = TPM2_ALG_SHA256,
             .authpolicy = PolicyA_SHA256,
             .authpolicy_len = sizeof(PolicyA_SHA256),
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_NULL), AS2BE(TPM2_ECC_NIST_P256), AS2BE(TPM2_ALG_NULL)
+             },
+            .schemedata_len = 6,
             .symkey_len = 128,
             .duration = TPM2_DURATION_LONG,
             .keysize = 32,
@@ -607,6 +611,10 @@ static const struct ek_params {
             .hashalg = TPM2_ALG_SHA384,
             .authpolicy = PolicyB_SHA384,
             .authpolicy_len = sizeof(PolicyB_SHA384),
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_NULL), AS2BE(TPM2_ECC_NIST_P384), AS2BE(TPM2_ALG_NULL)
+             },
+            .schemedata_len = 6,
             .symkey_len = 256,
             .duration = TPM2_DURATION_LONG,
             .keysize = 48,
@@ -625,6 +633,10 @@ static const struct ek_params {
             .hashalg = TPM2_ALG_SHA512,
             .authpolicy = PolicyB_SHA512,
             .authpolicy_len = sizeof(PolicyB_SHA512),
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_NULL), AS2BE(TPM2_ECC_NIST_P521), AS2BE(TPM2_ALG_NULL)
+             },
+            .schemedata_len = 6,
             .symkey_len = 256,
             .duration = TPM2_DURATION_LONG,
             .keysize = 66,
@@ -717,6 +729,10 @@ static const struct spk_params {
             .hashalg = TPM2_ALG_SHA256,
             .authpolicy = null_authpolicy,
             .authpolicy_len = 0,
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_NULL), AS2BE(TPM2_ECC_NIST_P256), AS2BE(TPM2_ALG_NULL)
+             },
+            .schemedata_len = 6,
             .keysize = 32,
             .symkey_len = 128,
             .off = 42,
@@ -737,6 +753,10 @@ static const struct spk_params {
             .hashalg = TPM2_ALG_SHA384,
             .authpolicy = null_authpolicy,
             .authpolicy_len = 0,
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_NULL), AS2BE(TPM2_ECC_NIST_P384), AS2BE(TPM2_ALG_NULL),
+             },
+            .schemedata_len = 6,
             .keysize = 48,
             .symkey_len = 256,
             .off = 42,
@@ -752,6 +772,10 @@ static const struct spk_params {
             .hashalg = TPM2_ALG_SHA512,
             .authpolicy = null_authpolicy,
             .authpolicy_len = 0,
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_NULL), AS2BE(TPM2_ECC_NIST_P521), AS2BE(TPM2_ALG_NULL)
+             },
+            .schemedata_len = 6,
             .keysize = 66,
             .symkey_len = 256,
             .off = 42,
@@ -1352,7 +1376,6 @@ err_too_short:
 
 /* Create an ECC key with the given parameters */
 static int swtpm_tpm2_createprimary_ecc(struct swtpm *self, uint32_t primaryhandle, unsigned int keyflags,
-                                        const unsigned char *schemedata, size_t schemedata_len,
                                         const struct pk_params *pk_params,
                                         size_t off, uint32_t *curr_handle,
                                         unsigned char *ektemplate, size_t *ektemplate_len,
@@ -1384,7 +1407,7 @@ static int swtpm_tpm2_createprimary_ecc(struct swtpm *self, uint32_t primaryhand
                   }, (size_t)10,
                   pk_params->authpolicy, pk_params->authpolicy_len,
                   symkeydata, symkeydata_len,
-                  schemedata, schemedata_len,
+                  pk_params->schemedata, pk_params->schemedata_len,
                   pk_params->nonce, pk_params->nonce_len,
                   pk_params->nonce, pk_params->nonce_len,
                   NULL);
@@ -1439,11 +1462,6 @@ static int swtpm_tpm2_createprimary_spk_ecc(struct swtpm *self,
                                             unsigned int keyalgo_param,
                                             uint32_t *curr_handle)
 {
-    uint16_t curveid = (uint16_t)keyalgo_param;
-    const unsigned char schemedata[] = {
-        AS2BE(TPM2_ALG_NULL), AS2BE(curveid), AS2BE(TPM2_ALG_NULL)
-    };
-    size_t schemedata_len = sizeof(schemedata);
     const struct spk_params *spks;
 
     spks = get_spk_params(self, KEYALGO_ECC, keyalgo_param);
@@ -1451,7 +1469,6 @@ static int swtpm_tpm2_createprimary_spk_ecc(struct swtpm *self,
         return 1;
 
     return swtpm_tpm2_createprimary_ecc(self, TPM2_RH_OWNER, spks->pk.keyflags,
-                                        schemedata, schemedata_len,
                                         &spks->pk, spks->pk.off, curr_handle,
                                         NULL, 0, NULL, NULL);
 }
@@ -1512,10 +1529,6 @@ static int swtpm_tpm2_createprimary_ek_ecc(struct swtpm *self, const struct ek_p
                                            unsigned char *ektemplate, size_t *ektemplate_len,
                                            gchar **ekparam, const char **key_description)
 {
-    const unsigned char schemedata[] = {
-        AS2BE(TPM2_ALG_NULL), AS2BE(ekps->pk.keyalgo_param), AS2BE(TPM2_ALG_NULL)
-    };
-    size_t schemedata_len = sizeof(schemedata);
     struct pk_params pkps;
     unsigned int keyflags;
     size_t off;
@@ -1562,7 +1575,6 @@ static int swtpm_tpm2_createprimary_ek_ecc(struct swtpm *self, const struct ek_p
     }
 
     ret = swtpm_tpm2_createprimary_ecc(self, TPM2_RH_ENDORSEMENT, keyflags,
-                                       schemedata, schemedata_len,
                                        &pkps, off, curr_handle,
                                        ektemplate, ektemplate_len, ekparam,
                                        key_description);

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -424,6 +424,8 @@ static const struct swtpm_cops swtpm_cops = {
 #define TPM2_ALG_SHA512   0x000d
 #define TPM2_ALG_NULL     0x0010
 #define TPM2_ALG_SM3      0x0012
+#define TPM2_ALG_RSAPSS   0x0016
+#define TPM2_ALG_ECDSA    0x0018
 #define TPM2_ALG_ECC      0x0023
 #define TPM2_ALG_SHA3_256 0x0027
 #define TPM2_ALG_SHA3_384 0x0028
@@ -460,13 +462,19 @@ static const struct swtpm_cops swtpm_cops = {
 #define TPM2_NV_INDEX_ECC_SECP521R1_HI_EKCERT     0x01c00018
 #define TPM2_NV_INDEX_ECC_SECP521R1_HI_EKTEMPLATE 0x01c00019
 
+#define TPM2_NV_INDEX_IAK_CERT       0x01c90100
+#define TPM2_NV_INDEX_IDEVID_CERT    0x01c90200
+
 #define TPM2_EK_RSA_HANDLE           0x81010001
 #define TPM2_EK_RSA3072_HANDLE       0x8101001c
 #define TPM2_EK_RSA4096_HANDLE       0x8101001e
 #define TPM2_EK_ECC_SECP256R1_HANDLE 0x8101000a
 #define TPM2_EK_ECC_SECP384R1_HANDLE 0x81010016
 #define TPM2_EK_ECC_SECP521R1_HANDLE 0x81010018
+
 #define TPM2_SPK_HANDLE              0x81000001
+#define TPM2_IDEVID_HANDLE           0x81020000
+#define TPM2_IAK_HANDLE              0x81020001
 
 #define TPM2_DURATION_SHORT      ( 2000 /* ms */ * ARCH_PROCESSING_DELAY_FACTOR)
 #define TPM2_DURATION_MEDIUM     ( 7500 /* ms */ * ARCH_PROCESSING_DELAY_FACTOR)
@@ -502,6 +510,9 @@ static const unsigned char NONCE_RSA4096[2+0x200] = {AS2BE(0x200), 0, };
 static const unsigned char NONCE_ECC_256[2+0x20] = {AS2BE(0x20), 0, };
 static const unsigned char NONCE_ECC_384[2+0x30] = {AS2BE(0x30), 0, };
 static const unsigned char NONCE_ECC_521[2+0x42] = {AS2BE(0x42), 0, };
+static const unsigned char NONCE_IDEVID[2+6] = {AS2BE(6),
+                                                0x49, 0x44, 0x45, 0x56, 0x49, 0x44 };
+static const unsigned char NONCE_IAK[2+3] = {AS2BE(3), 0x49, 0x41, 0x4b };
 
 static const unsigned char PolicyA_SHA256[32] = {
     0x83, 0x71, 0x97, 0x67, 0x44, 0x84, 0xb3, 0xf8, 0x1a, 0x90, 0xcc, 0x8d,
@@ -538,6 +549,23 @@ static const unsigned char PolicyB_SHA512[64] = {
                     | (1<<16) /* restricted */ \
                     | (1<<17)) /* decrypt */
 
+/* IAK: fixedTPM, fixedParent, sensitiveDataOrigin, adminWithPolicy, restricted, sign */
+#define KEYFLAGS_IAK ((1<<1) /* fixedTPM */ \
+                    | (1<<4) /* fixedParent */ \
+                    | (1<<5) /* sensitiveDataOrigin */ \
+                    | (1<<6) /* userWithAuth */ \
+                    | (1<<7) /* adminWithPolicy */ \
+                    | (1<<16) /* restricted */ \
+                    | (1<<18)) /* sign */
+
+/* IDevID: fixedTPM, fixedParent, sensitiveDataOrigin, adminWithPolicy, sign */
+#define KEYFLAGS_IDEVID ((1<<1) /* fixedTPM */ \
+                       | (1<<4) /* fixedParent */ \
+                       | (1<<5) /* sensitiveDataOrigin */ \
+                       | (1<<6) /* userWithAuth */ \
+                       | (1<<7) /* adminWithPolicy */ \
+                       | (1<<18)) /* sign */
+
 static const struct bank_to_name {
     uint16_t hashAlg;
     const char *name;
@@ -565,7 +593,7 @@ struct pk_params {
     uint16_t hashalg;
     const unsigned char *authpolicy;
     size_t authpolicy_len;
-#define SCHEMEDATA_SIZE 8
+#define SCHEMEDATA_SIZE 10
     unsigned char schemedata[SCHEMEDATA_SIZE];
     size_t schemedata_len;
     unsigned int symkey_len;
@@ -843,6 +871,348 @@ static const struct spk_params {
     }
 };
 
+
+static const unsigned char Attestation_PolicyIDevIDKey_SHA256[32] = {
+    0x54, 0x37, 0x18, 0x23, 0x26, 0xe4, 0x14, 0xfc,
+    0xa7, 0x97, 0xd5, 0xf1, 0x74, 0x61, 0x5a, 0x16,
+    0x41, 0xf6, 0x12, 0x55, 0x79, 0x7c, 0x3a, 0x2b,
+    0x22, 0xc2, 0x1d, 0x12, 0x0b, 0x2d, 0x1e, 0x07,
+};
+
+static const unsigned char Attestation_PolicyIDevIDKey_SHA384[48] = {
+    0x12, 0x9d, 0x94, 0xeb, 0xf8, 0x45, 0x56, 0x65,
+    0x2c, 0x6e, 0xef, 0x43, 0xbb, 0xb7, 0x57, 0x51,
+    0x2a, 0xc8, 0x7e, 0x52, 0xbe, 0x7b, 0x34, 0x9c,
+    0xa6, 0xce, 0x4d, 0x82, 0x6f, 0x74, 0x9f, 0xcf,
+    0x67, 0x2f, 0x51, 0x71, 0x6c, 0x5c, 0xbb, 0x60,
+    0x5f, 0x31, 0x3b, 0xf3, 0x45, 0xaa, 0xb3, 0x12,
+};
+
+static const unsigned char Attestation_PolicyIDevIDKey_SHA512[64] = {
+    0x80, 0x60, 0xd1, 0xfb, 0x31, 0x71, 0x6a, 0x29,
+    0xe4, 0x8a, 0x6e, 0x5f, 0xec, 0xe0, 0x88, 0xbc,
+    0xfc, 0x1b, 0x27, 0x8f, 0xc1, 0x62, 0x25, 0x5e,
+    0x81, 0xc3, 0xec, 0xa3, 0x54, 0x4c, 0xd4, 0x4a,
+    0xf9, 0x44, 0x10, 0xc3, 0x71, 0x5d, 0x56, 0x1c,
+    0xcc, 0xd9, 0xe3, 0x9a, 0x6c, 0xb2, 0x64, 0x6d,
+    0x43, 0x53, 0x5b, 0xb5, 0x4e, 0xa8, 0x87, 0x10,
+    0xde, 0xb5, 0xf7, 0x83, 0x6b, 0xd9, 0xb5, 0x86
+};
+
+static const struct iak_params {
+    struct pk_params pk;
+    const char *keytype;
+} iak_params[] = {
+    {
+        .pk = {
+            .keyalgo = KEYALGO_ECC,
+            .keyalgo_param = TPM2_ECC_NIST_P256,
+            .keydescription = "secp256r1",
+            .keyflags = KEYFLAGS_IAK,
+            .nonce = NONCE_IAK,
+            .nonce_len = sizeof(NONCE_IAK),
+            .nonce2 = NONCE_EMPTY,
+            .nonce2_len = sizeof(NONCE_EMPTY),
+            .hashalg = TPM2_ALG_SHA256,
+            .authpolicy = Attestation_PolicyIDevIDKey_SHA256,
+            .authpolicy_len = sizeof(Attestation_PolicyIDevIDKey_SHA256),
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_ECDSA), AS2BE(TPM2_ALG_SHA256),
+                AS2BE(TPM2_ECC_NIST_P256), AS2BE(TPM2_ALG_NULL),
+            },
+            .schemedata_len = 8,
+            .keysize = 32,
+            .symkey_len = 0,
+            .off = 0x48,
+            .duration = TPM2_DURATION_LONG,
+        },
+        .keytype = "secp256r1",
+   }, {
+        .pk = {
+            .keyalgo = KEYALGO_ECC,
+            .keyalgo_param = TPM2_ECC_NIST_P384,
+            .keydescription = "secp384r1",
+            .keyflags = KEYFLAGS_IAK,
+            .nonce = NONCE_IAK,
+            .nonce_len = sizeof(NONCE_IAK),
+            .nonce2 = NONCE_EMPTY,
+            .nonce2_len = sizeof(NONCE_EMPTY),
+            .hashalg = TPM2_ALG_SHA384,
+            .authpolicy = Attestation_PolicyIDevIDKey_SHA384,
+            .authpolicy_len = sizeof(Attestation_PolicyIDevIDKey_SHA384),
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_ECDSA), AS2BE(TPM2_ALG_SHA384),
+                AS2BE(TPM2_ECC_NIST_P384), AS2BE(TPM2_ALG_NULL),
+            },
+            .schemedata_len = 8,
+            .keysize = 48,
+            .symkey_len = 0,
+            .off = 0x58,
+            .duration = TPM2_DURATION_LONG,
+        },
+        .keytype = "secp384r1",
+    }, {
+        .pk = {
+            .keyalgo = KEYALGO_ECC,
+            .keyalgo_param = TPM2_ECC_NIST_P521,
+            .keydescription = "secp521r1",
+            .keyflags = KEYFLAGS_IAK,
+            .nonce = NONCE_IAK,
+            .nonce_len = sizeof(NONCE_IAK),
+            .nonce2 = NONCE_EMPTY,
+            .nonce2_len = sizeof(NONCE_EMPTY),
+            .hashalg = TPM2_ALG_SHA512,
+            .authpolicy = Attestation_PolicyIDevIDKey_SHA512,
+            .authpolicy_len = sizeof(Attestation_PolicyIDevIDKey_SHA512),
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_ECDSA), AS2BE(TPM2_ALG_SHA512),
+                AS2BE(TPM2_ECC_NIST_P521), AS2BE(TPM2_ALG_NULL),
+            },
+            .schemedata_len = 8,
+            .keysize = 66,
+            .symkey_len = 0,
+            .off = 0x68,
+            .duration = TPM2_DURATION_LONG,
+       },
+        .keytype = "secp521r1",
+    }, {
+        .pk = {
+            .keyalgo = KEYALGO_RSA,
+            .keyalgo_param = 2048,
+            .keydescription = "rsa2048",
+            .keyflags = KEYFLAGS_IAK,
+            .nonce = NONCE_IAK,
+            .nonce_len = sizeof(NONCE_IAK),
+            .hashalg = TPM2_ALG_SHA256,
+            .authpolicy = Attestation_PolicyIDevIDKey_SHA256,
+            .authpolicy_len = sizeof(Attestation_PolicyIDevIDKey_SHA256),
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_RSAPSS), AS2BE(TPM2_ALG_SHA256),
+                AS2BE(2048), AS4BE(0),
+            },
+            .schemedata_len = 10,
+            .keysize = 2048/8,
+            .symkey_len = 0,
+            .off = 0x4a,
+            .duration = TPM2_DURATION_LONG,
+        },
+        .keytype = "RSA 2048",
+   }, {
+        .pk = {
+            .keyalgo = KEYALGO_RSA,
+            .keyalgo_param = 3072,
+            .keydescription = "rsa3072",
+            .keyflags = KEYFLAGS_IAK,
+            .nonce = NONCE_IAK,
+            .nonce_len = sizeof(NONCE_IAK),
+            .hashalg = TPM2_ALG_SHA384,
+            .authpolicy = Attestation_PolicyIDevIDKey_SHA384,
+            .authpolicy_len = sizeof(Attestation_PolicyIDevIDKey_SHA384),
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_RSAPSS), AS2BE(TPM2_ALG_SHA384),
+                AS2BE(3072), AS4BE(0),
+            },
+            .schemedata_len = 10,
+            .keysize = 3072/8,
+            .symkey_len = 0,
+            .off = 0x5a,
+            .duration = TPM2_DURATION_LONG,
+        },
+        .keytype = "RSA 3072",
+    }, {
+        .pk = {
+            .keyalgo = KEYALGO_RSA,
+            .keyalgo_param = 4096,
+            .keydescription = "rsa4096",
+            .keyflags = KEYFLAGS_IAK,
+            .nonce = NONCE_IAK,
+            .nonce_len = sizeof(NONCE_IAK),
+            .hashalg = TPM2_ALG_SHA384,
+            .authpolicy = Attestation_PolicyIDevIDKey_SHA384,
+            .authpolicy_len = sizeof(Attestation_PolicyIDevIDKey_SHA384),
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_RSAPSS), AS2BE(TPM2_ALG_SHA384),
+                AS2BE(4096), AS4BE(0),
+            },
+            .schemedata_len = 10,
+            .keysize = 4096/8,
+            .symkey_len = 0,
+            .off = 0x5a,
+            .duration = TPM2_DURATION_LONG,
+        },
+        .keytype = "RSA 4096",
+    }
+};
+
+static const unsigned char Signing_PolicyIDevIDKey_SHA256[32] = {
+    0xad, 0x6b, 0x3a, 0x22, 0x84, 0xfd, 0x69, 0x8a,
+    0x07, 0x10, 0xbf, 0x5c, 0xc1, 0xb9, 0xbd, 0xf1,
+    0x5e, 0x25, 0x32, 0xe3, 0xf6, 0x01, 0xfa, 0x4b,
+    0x93, 0xa6, 0xa8, 0xfa, 0x8d, 0xe5, 0x79, 0xea
+};
+
+static const unsigned char Signing_PolicyIDevIDKey_SHA384[48] = {
+    0x4d, 0xb1, 0xaa, 0x83, 0x6d, 0x0b, 0x56, 0x15,
+    0xdf, 0x6e, 0xe5, 0x3a, 0x40, 0xef, 0x70, 0xc6,
+    0x1c, 0x21, 0x7f, 0x43, 0x03, 0xd4, 0x46, 0x95,
+    0x92, 0x59, 0x72, 0xbc, 0x92, 0x70, 0x06, 0xcf,
+    0xa5, 0xcb, 0xdf, 0x6d, 0xc1, 0x8c, 0x4d, 0xbe,
+    0x32, 0x9b, 0x2f, 0x15, 0x42, 0xc3, 0xdd, 0x33
+};
+
+static const unsigned char Signing_PolicyIDevIDKey_SHA512[64] = {
+    0x7d, 0xd7, 0x50, 0x0f, 0xd6, 0xc1, 0xb9, 0x4f,
+    0x97, 0xa6, 0xaf, 0x91, 0x0d, 0xa1, 0x47, 0x30,
+    0x1e, 0xf2, 0x8f, 0x66, 0x2f, 0xee, 0x06, 0xf2,
+    0x25, 0xa4, 0xcc, 0xad, 0xda, 0x3b, 0x4e, 0x6b,
+    0x38, 0xe6, 0x6b, 0x2f, 0x3a, 0xd5, 0xde, 0xe1,
+    0xa0, 0x50, 0x3c, 0xd2, 0xda, 0xed, 0xb1, 0xe6,
+    0x8c, 0xfe, 0x4f, 0x84, 0xb0, 0x3a, 0x8c, 0xd2,
+    0x2b, 0xb6, 0xa9, 0x76, 0xf0, 0x71, 0xa7, 0x2f
+};
+
+static const struct idevid_params {
+    struct pk_params pk;
+    const char *keytype;
+} idevid_params[] = {
+    {
+        .pk = {
+            .keyalgo = KEYALGO_ECC,
+            .keyalgo_param = TPM2_ECC_NIST_P256,
+            .keydescription = "secp256r1",
+            .keyflags = KEYFLAGS_IDEVID,
+            .nonce = NONCE_IDEVID,
+            .nonce_len = sizeof(NONCE_IDEVID),
+            .nonce2 = NONCE_EMPTY,
+            .nonce2_len = sizeof(NONCE_EMPTY),
+            .hashalg = TPM2_ALG_SHA256,
+            .authpolicy = Signing_PolicyIDevIDKey_SHA256,
+            .authpolicy_len = sizeof(Signing_PolicyIDevIDKey_SHA256),
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_ECDSA), AS2BE(TPM2_ALG_SHA256),
+                AS2BE(TPM2_ECC_NIST_P256), AS2BE(TPM2_ALG_NULL),
+            },
+            .schemedata_len = 8,
+            .keysize = 32,
+            .symkey_len = 0,
+            .off = 0x48,
+            .duration = TPM2_DURATION_LONG,
+        },
+        .keytype = "secp256r1",
+   }, {
+        .pk = {
+            .keyalgo = KEYALGO_ECC,
+            .keyalgo_param = TPM2_ECC_NIST_P384,
+            .keydescription = "secp384r1",
+            .keyflags = KEYFLAGS_IDEVID,
+            .nonce = NONCE_IDEVID,
+            .nonce_len = sizeof(NONCE_IDEVID),
+            .nonce2 = NONCE_EMPTY,
+            .nonce2_len = sizeof(NONCE_EMPTY),
+            .hashalg = TPM2_ALG_SHA384,
+            .authpolicy = Signing_PolicyIDevIDKey_SHA384,
+            .authpolicy_len = sizeof(Signing_PolicyIDevIDKey_SHA384),
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_ECDSA), AS2BE(TPM2_ALG_SHA384),
+                AS2BE(TPM2_ECC_NIST_P384), AS2BE(TPM2_ALG_NULL),
+            },
+            .schemedata_len = 8,
+            .keysize = 48,
+            .symkey_len = 0,
+            .off = 0x58,
+            .duration = TPM2_DURATION_LONG,
+        },
+        .keytype = "secp384r1",
+    }, {
+        .pk = {
+            .keyalgo = KEYALGO_ECC,
+            .keyalgo_param = TPM2_ECC_NIST_P521,
+            .keydescription = "secp521r1",
+            .keyflags = KEYFLAGS_IDEVID,
+            .nonce = NONCE_IDEVID,
+            .nonce_len = sizeof(NONCE_IDEVID),
+            .nonce2 = NONCE_EMPTY,
+            .nonce2_len = sizeof(NONCE_EMPTY),
+            .hashalg = TPM2_ALG_SHA512,
+            .authpolicy = Signing_PolicyIDevIDKey_SHA512,
+            .authpolicy_len = sizeof(Signing_PolicyIDevIDKey_SHA512),
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_ECDSA), AS2BE(TPM2_ALG_SHA512),
+                AS2BE(TPM2_ECC_NIST_P521), AS2BE(TPM2_ALG_NULL),
+            },
+            .schemedata_len = 8,
+            .keysize = 66,
+            .symkey_len = 0,
+            .off = 0x68,
+            .duration = TPM2_DURATION_LONG,
+        },
+        .keytype = "secp521r1",
+    }, {
+        .pk = {
+            .keyalgo = KEYALGO_RSA,
+            .keyalgo_param = 2048,
+            .keydescription = "rsa2048",
+            .keyflags = KEYFLAGS_IDEVID,
+            .nonce = NONCE_IDEVID,
+            .nonce_len = sizeof(NONCE_IDEVID),
+            .hashalg = TPM2_ALG_SHA256,
+            .authpolicy = Signing_PolicyIDevIDKey_SHA256,
+            .authpolicy_len = sizeof(Signing_PolicyIDevIDKey_SHA256),
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_NULL), AS2BE(2048), AS4BE(0)
+             },
+            .schemedata_len = 8,
+            .keysize = 2048/8,
+            .symkey_len = 0,
+            .off = 0x48,
+            .duration = TPM2_DURATION_LONG,
+        },
+        .keytype = "RSA 2048",
+   }, {
+        .pk = {
+            .keyalgo = KEYALGO_RSA,
+            .keyalgo_param = 3072,
+            .keydescription = "rsa3072",
+            .keyflags = KEYFLAGS_IDEVID,
+            .nonce = NONCE_IDEVID,
+            .nonce_len = sizeof(NONCE_IDEVID),
+            .hashalg = TPM2_ALG_SHA384,
+            .authpolicy = Signing_PolicyIDevIDKey_SHA384,
+            .authpolicy_len = sizeof(Signing_PolicyIDevIDKey_SHA384),
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_NULL), AS2BE(3072), AS4BE(0)
+             },
+            .schemedata_len = 8,
+            .keysize = 3072/8,
+            .symkey_len = 0,
+            .off = 0x58,
+            .duration = TPM2_DURATION_LONG,
+        },
+        .keytype = "RSA 3072",
+    }, {
+        .pk = {
+            .keyalgo = KEYALGO_RSA,
+            .keyalgo_param = 4096,
+            .keydescription = "rsa4096",
+            .keyflags = KEYFLAGS_IDEVID,
+            .nonce = NONCE_IDEVID,
+            .nonce_len = sizeof(NONCE_IDEVID),
+            .hashalg = TPM2_ALG_SHA384,
+            .authpolicy = Signing_PolicyIDevIDKey_SHA384,
+            .authpolicy_len = sizeof(Signing_PolicyIDevIDKey_SHA384),
+            .schemedata = (unsigned char[SCHEMEDATA_SIZE]) {
+                AS2BE(TPM2_ALG_NULL), AS2BE(4096), AS4BE(0)
+             },
+            .schemedata_len = 8,
+            .keysize = 4096/8,
+            .symkey_len = 0,
+            .off = 0x68,
+            .duration = TPM2_DURATION_LONG,
+        },
+        .keytype = "RSA 4096",
+    }
+};
+
 static const struct ek_params *get_ek_params(struct swtpm *self,
                                              enum keyalgo keyalgo,
                                              unsigned int keyalgo_param)
@@ -873,6 +1243,40 @@ static const struct spk_params *get_spk_params(struct swtpm *self,
         }
     }
     logerr(self->logfile, "Internal error: Unsupported SRK keyalgo and keyalgo_param: %u/%u\n",
+           keyalgo, keyalgo_param);
+    return NULL;
+}
+
+static const struct iak_params *get_iak_params(struct swtpm *self,
+                                               enum keyalgo keyalgo,
+                                               unsigned int keyalgo_param)
+{
+    size_t i;
+
+    for (i = 0; i < ARRAY_LEN(iak_params); i++) {
+        if (iak_params[i].pk.keyalgo == keyalgo &&
+            iak_params[i].pk.keyalgo_param == keyalgo_param) {
+            return &iak_params[i];
+        }
+    }
+    logerr(self->logfile, "Internal error: Unsupported IAK keyalgo and keyalgo_param: %u/%u\n",
+           keyalgo, keyalgo_param);
+    return NULL;
+}
+
+static const struct idevid_params *get_idevid_params(struct swtpm *self,
+                                                     enum keyalgo keyalgo,
+                                                     unsigned int keyalgo_param)
+{
+    size_t i;
+
+    for (i = 0; i < ARRAY_LEN(idevid_params); i++) {
+        if (idevid_params[i].pk.keyalgo == keyalgo &&
+            idevid_params[i].pk.keyalgo_param == keyalgo_param) {
+            return &idevid_params[i];
+        }
+    }
+    logerr(self->logfile, "Internal error: Unsupported IDevID keyalgo and keyalgo_param: %u/%u\n",
            keyalgo, keyalgo_param);
     return NULL;
 }
@@ -1504,6 +1908,7 @@ static int swtpm_tpm2_create_spk(struct swtpm *self, enum keyalgo keyalgo,
     case KEYALGO_RSA:
         ret = swtpm_tpm2_createprimary_spk_rsa(self, keyalgo_param, &curr_handle);
         break;
+    case KEYALGO_NONE:
     default:
         ret = 1;
     }
@@ -1524,6 +1929,87 @@ static int swtpm_tpm2_create_spk(struct swtpm *self, enum keyalgo keyalgo,
 
     return ret;
 }
+
+static int swtpm_tpm2_create_iak(struct swtpm *self,
+                                 enum keyalgo keyalgo, unsigned int keyalgo_param,
+                                 gchar **keyparam, const gchar **key_description)
+{
+    const struct iak_params *iaks;
+    uint32_t curr_handle = 0;
+    int ret;
+
+    iaks = get_iak_params(self, keyalgo, keyalgo_param);
+    if (!iaks)
+        return 1;
+
+    switch (keyalgo) {
+    case KEYALGO_RSA:
+        ret = swtpm_tpm2_createprimary_rsa(self, TPM2_RH_ENDORSEMENT, iaks->pk.keyflags,
+                                           &iaks->pk, iaks->pk.off, &curr_handle,
+                                           NULL, 0, keyparam, key_description);
+        break;
+    case KEYALGO_ECC:
+        ret = swtpm_tpm2_createprimary_ecc(self, TPM2_RH_ENDORSEMENT, iaks->pk.keyflags,
+                                           &iaks->pk, iaks->pk.off, &curr_handle,
+                                           NULL, 0, keyparam, key_description);
+        break;
+    case KEYALGO_NONE:
+    default:
+        return 1;
+    }
+
+    if (ret != 0)
+        return 1;
+
+    ret = swtpm_tpm2_evictcontrol(self, curr_handle, TPM2_IAK_HANDLE);
+    if (ret == 0)
+        logit(self->logfile,
+              "Successfully created %s IAK primary key with handle 0x%x.\n",
+              iaks->keytype, TPM2_IAK_HANDLE);
+
+    return swtpm_tpm2_flushcontext(self, curr_handle);
+}
+
+static int swtpm_tpm2_create_idevid(struct swtpm *self,
+                                    enum keyalgo keyalgo, unsigned int keyalgo_param,
+                                    gchar **keyparam, const gchar **key_description)
+{
+    const struct idevid_params *idps;
+    uint32_t curr_handle = 0;
+    int ret;
+
+    idps = get_idevid_params(self, keyalgo, keyalgo_param);
+    if (!idps)
+        return 1;
+
+    switch (keyalgo) {
+    case KEYALGO_RSA:
+        ret = swtpm_tpm2_createprimary_rsa(self, TPM2_RH_ENDORSEMENT, idps->pk.keyflags,
+                                           &idps->pk, idps->pk.off, &curr_handle,
+                                           NULL, 0, keyparam, key_description);
+        break;
+    case KEYALGO_ECC:
+        ret = swtpm_tpm2_createprimary_ecc(self, TPM2_RH_ENDORSEMENT, idps->pk.keyflags,
+                                           &idps->pk, idps->pk.off, &curr_handle,
+                                           NULL, 0, keyparam, key_description);
+        break;
+    case KEYALGO_NONE:
+    default:
+        return 1;
+    }
+
+    if (ret != 0)
+        return 1;
+
+    ret = swtpm_tpm2_evictcontrol(self, curr_handle, TPM2_IDEVID_HANDLE);
+    if (ret == 0)
+        logit(self->logfile,
+              "Successfully created %s IDevID primary key with handle 0x%x.\n",
+              idps->keytype, TPM2_IDEVID_HANDLE);
+
+    return swtpm_tpm2_flushcontext(self, curr_handle);
+}
+
 
 /* Create an ECC EK key that may be allowed to sign and/or decrypt */
 static int swtpm_tpm2_createprimary_ek_ecc(struct swtpm *self, const struct ek_params *ekps,
@@ -1616,6 +2102,7 @@ static int swtpm_tpm2_create_ek(struct swtpm *self, enum keyalgo keyalgo, unsign
                                               ektemplate, &ektemplate_len, ekparam,
                                               key_description);
         break;
+    case KEYALGO_NONE:
     default:
         ret = 1;
     }
@@ -1851,14 +2338,50 @@ static char *swtpm_tpm2_get_active_profile(struct swtpm *self)
     return result;
 }
 
+static int swtpm_tpm2_write_iak_cert_nvram(struct swtpm *self, gboolean lock_nvram,
+                                           const unsigned char *data, size_t data_len)
+{
+    uint32_t nvindexattrs = TPMA_NV_PLATFORMCREATE |
+            TPMA_NV_AUTHREAD |
+            TPMA_NV_OWNERREAD |
+            TPMA_NV_PPREAD |
+            TPMA_NV_PPWRITE |
+            TPMA_NV_NO_DA |
+            TPMA_NV_WRITEDEFINE;
+    uint32_t nvindex = TPM2_NV_INDEX_IAK_CERT;
+
+    return swtpm_tpm2_write_cert_nvram(self, nvindex, nvindexattrs, data, data_len,
+                                       lock_nvram, "", "IAK certificate");
+}
+
+static int swtpm_tpm2_write_idevid_cert_nvram(struct swtpm *self, gboolean lock_nvram,
+                                              const unsigned char *data, size_t data_len)
+{
+    uint32_t nvindexattrs = TPMA_NV_PLATFORMCREATE |
+            TPMA_NV_AUTHREAD |
+            TPMA_NV_OWNERREAD |
+            TPMA_NV_PPREAD |
+            TPMA_NV_PPWRITE |
+            TPMA_NV_NO_DA |
+            TPMA_NV_WRITEDEFINE;
+    uint32_t nvindex = TPM2_NV_INDEX_IDEVID_CERT;
+
+    return swtpm_tpm2_write_cert_nvram(self, nvindex, nvindexattrs, data, data_len,
+                                       lock_nvram, "", "IDevID certificate");
+}
+
 static const struct swtpm2_ops swtpm_tpm2_ops = {
     .shutdown = swtpm_tpm2_shutdown,
     .create_spk = swtpm_tpm2_create_spk,
     .create_ek = swtpm_tpm2_create_ek,
+    .create_iak = swtpm_tpm2_create_iak,
+    .create_idevid = swtpm_tpm2_create_idevid,
     .get_all_pcr_banks = swtpm_tpm2_get_all_pcr_banks,
     .set_active_pcr_banks = swtpm_tpm2_set_active_pcr_banks,
     .write_ek_cert_nvram = swtpm_tpm2_write_ek_cert_nvram,
     .write_platform_cert_nvram = swtpm_tpm2_write_platform_cert_nvram,
+    .write_iak_cert_nvram = swtpm_tpm2_write_iak_cert_nvram,
+    .write_idevid_cert_nvram = swtpm_tpm2_write_idevid_cert_nvram,
     .get_active_profile = swtpm_tpm2_get_active_profile,
 };
 

--- a/src/swtpm_setup/swtpm.h
+++ b/src/swtpm_setup/swtpm.h
@@ -53,6 +53,10 @@ enum keyalgo {
 #define TPM2_ECC_NIST_P384 0x0004
 #define TPM2_ECC_NIST_P521 0x0005
 
+/* for get_capability */
+#define TPM2_CAP_TPM_PROPERTIES  6
+#define TPM2_PT_MANUFACTURER     0x105
+
 /* TPM 2 specific ops */
 struct swtpm2_ops {
     int (*shutdown)(struct swtpm *);
@@ -77,6 +81,7 @@ struct swtpm2_ops {
                                 const unsigned char *data, size_t data_len);
     int (*write_idevid_cert_nvram)(struct swtpm *self, gboolean lock_nvram,
                                    const unsigned char *data, size_t data_len);
+    int (*get_capability)(struct swtpm *self, uint32_t cap, uint32_t prop, uint32_t *res);
 };
 
 /* common structure for swtpm object */

--- a/src/swtpm_setup/swtpm.h
+++ b/src/swtpm_setup/swtpm.h
@@ -43,6 +43,7 @@ struct swtpm12_ops {
 };
 
 enum keyalgo {
+    KEYALGO_NONE = 0,
     KEYALGO_RSA = 1,
     KEYALGO_ECC = 2,
 };
@@ -59,6 +60,10 @@ struct swtpm2_ops {
     int (*create_ek)(struct swtpm *self, enum keyalgo keyalgo, unsigned int keyalgo_param,
                      gboolean allowsigning, gboolean decryption, gboolean lock_nvram,
                      gchar **ekparam, const gchar **key_description);
+    int (*create_iak)(struct swtpm *self, enum keyalgo keyalgo, unsigned int keyalgo_param,
+                      gchar **keyparam, const gchar **key_description);
+    int (*create_idevid)(struct swtpm *self, enum keyalgo keyalgo, unsigned int keyalgo_param,
+                         gchar **keyparam, const gchar **key_description);
     int (*get_all_pcr_banks)(struct swtpm *self, gchar ***all_pcr_banks);
     int (*set_active_pcr_banks)(struct swtpm *self, gchar **pcr_banks_l, gchar **all_pcr_banks,
                                 gchar ***active);
@@ -68,6 +73,10 @@ struct swtpm2_ops {
     int (*write_platform_cert_nvram)(struct swtpm *self, gboolean lock_nvram,
                                      const unsigned char *data, size_t data_len);
     char *(*get_active_profile)(struct swtpm *self);
+    int (*write_iak_cert_nvram)(struct swtpm *self, gboolean lock_nvram,
+                                const unsigned char *data, size_t data_len);
+    int (*write_idevid_cert_nvram)(struct swtpm *self, gboolean lock_nvram,
+                                   const unsigned char *data, size_t data_len);
 };
 
 /* common structure for swtpm object */

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -63,6 +63,8 @@
 #define SETUP_WRITE_EK_CERT_FILES_F (1 << 15)
 #define SETUP_RECONFIGURE_F         (1 << 16)
 #define SETUP_RSA_KEYSIZE_BY_USER_F (1 << 17)
+#define SETUP_IAK_F                 (1 << 18)
+#define SETUP_IDEVID_F              (1 << 19)
 
 /* default configuration file */
 #define SWTPM_SETUP_CONF "swtpm_setup.conf"
@@ -82,6 +84,8 @@ static const struct flag_to_certfile {
 } flags_to_certfiles[] = {
     {.flag = SETUP_EK_CERT_F      , .filename = "ek.cert",       .type = "ek" },
     {.flag = SETUP_PLATFORM_CERT_F, .filename = "platform.cert", .type = "platform" },
+    {.flag = SETUP_IAK_F,           .filename = "iak.cert",      .type = "iak" },
+    {.flag = SETUP_IDEVID_F,        .filename = "idevid.cert",   .type = "idevid" },
     {.flag = 0,                     .filename = NULL,            .type = NULL},
 };
 
@@ -198,7 +202,8 @@ error:
 /* Call an external tool to create the certificates */
 static int call_create_certs(unsigned long flags, unsigned int cert_flags,
                              const gchar *configfile, const gchar *certsdir,
-                             const gchar *ekparam, const gchar *vmid, struct swtpm *swtpm)
+                             const gchar *key_params, const gchar *vmid,
+                             const gchar *tpm_serial_num, struct swtpm *swtpm)
 {
     gchar **config_file_lines = NULL; /* must free */
     g_autofree gchar *create_certs_tool = NULL;
@@ -207,6 +212,7 @@ static int call_create_certs(unsigned long flags, unsigned int cert_flags,
     g_autofree const gchar **cmd = NULL;
     gchar **params = NULL; /* must free */
     g_autofree gchar *prgname = NULL;
+    const char *key_opt = "--key";
     gboolean success;
     gint exit_status;
     size_t idx, j;
@@ -242,10 +248,15 @@ static int call_create_certs(unsigned long flags, unsigned int cert_flags,
                                     NULL
                                 }, TRUE);
         }
+
+        /* use the old --ek option when the ek is passed */
+        if (cert_flags & (SETUP_EK_CERT_F | SETUP_PLATFORM_CERT_F))
+            key_opt = "--ek";
+
         cmd = concat_arrays((const gchar*[]) {
                                 create_certs_tool_path,
                                 "--type", "_",  /* '_' must be at index '2' ! */
-                                "--ek", ekparam,
+                                key_opt, key_params,
                                 "--dir", certsdir,
                                 NULL
                             }, NULL, FALSE);
@@ -265,6 +276,8 @@ static int call_create_certs(unsigned long flags, unsigned int cert_flags,
             cmd = concat_arrays(cmd, (const gchar*[]){"--configfile", create_certs_tool_config, NULL}, TRUE);
         if (create_certs_tool_options != NULL)
             cmd = concat_arrays(cmd, (const gchar*[]){"--optsfile", create_certs_tool_options, NULL}, TRUE);
+        if (tpm_serial_num) /* required for IAK & IDevID */
+            cmd = concat_arrays(cmd, (const gchar*[]){"--tpm-serial-num", tpm_serial_num, NULL}, TRUE);
 
         s = g_strrstr(create_certs_tool, G_DIR_SEPARATOR_S);
         if (s)
@@ -398,6 +411,7 @@ static int tpm2_persist_certificate(unsigned long flags, const gchar *certsdir,
     g_autofree gchar *filecontent = NULL;
     g_autofree gchar *certfile = NULL;
     gsize filecontent_len;
+    gboolean preserve;
     int ret;
 
     ret = read_certificate_file(certsdir, ftc->filename,
@@ -405,7 +419,15 @@ static int tpm2_persist_certificate(unsigned long flags, const gchar *certsdir,
     if (ret != 0)
         goto error_unlink;
 
-    if (ftc->flag == SETUP_EK_CERT_F) {
+    if (ftc->flag == SETUP_IAK_F) {
+        ret = swtpm2->ops->write_iak_cert_nvram(&swtpm2->swtpm,
+                                     !!(flags & SETUP_LOCK_NVRAM_F),
+                                     (const unsigned char*)filecontent, filecontent_len);
+    } else if (ftc->flag == SETUP_IDEVID_F) {
+        ret = swtpm2->ops->write_idevid_cert_nvram(&swtpm2->swtpm,
+                                     !!(flags & SETUP_LOCK_NVRAM_F),
+                                     (const unsigned char *)filecontent, filecontent_len);
+    } else if (ftc->flag == SETUP_EK_CERT_F) {
         ret = swtpm2->ops->write_ek_cert_nvram(&swtpm2->swtpm,
                                      keyalgo, keyalgo_param,
                                      !!(flags & SETUP_LOCK_NVRAM_F),
@@ -419,7 +441,9 @@ static int tpm2_persist_certificate(unsigned long flags, const gchar *certsdir,
     if (ret != 0)
         goto error_unlink;
 
-    return certfile_move_or_delete(flags, !!(ftc->flag & SETUP_EK_CERT_F),
+    preserve = !!(ftc->flag & (SETUP_EK_CERT_F | SETUP_IAK_F | SETUP_IDEVID_F));
+
+    return certfile_move_or_delete(flags, preserve,
                                    certfile, user_certsdir,
                                    key_type, key_description);
 
@@ -434,8 +458,8 @@ static int tpm2_create_ek_and_cert(unsigned long flags, const gchar *config_file
                                    enum keyalgo keyalgo, unsigned int keyalgo_param,
                                    struct swtpm2 *swtpm2, const gchar *user_certsdir)
 {
+    g_autofree gchar *key_params = NULL;
     const char *key_description = "";
-    g_autofree gchar *ekparam = NULL;
     unsigned long cert_flags;
     const gchar *key_type;
     size_t idx;
@@ -446,7 +470,7 @@ static int tpm2_create_ek_and_cert(unsigned long flags, const gchar *config_file
                                      !!(flags & SETUP_ALLOW_SIGNING_F),
                                      !!(flags & SETUP_DECRYPTION_F),
                                      !!(flags & SETUP_LOCK_NVRAM_F),
-                                     &ekparam, &key_description);
+                                     &key_params, &key_description);
         if (ret != 0)
             return 1;
     }
@@ -454,8 +478,8 @@ static int tpm2_create_ek_and_cert(unsigned long flags, const gchar *config_file
     /* Only look at ek and platform certs here */
     cert_flags = flags & (SETUP_EK_CERT_F | SETUP_PLATFORM_CERT_F);
     if (cert_flags) {
-        ret = call_create_certs(flags, cert_flags, config_file, certsdir, ekparam,
-                                vmid, &swtpm2->swtpm);
+        ret = call_create_certs(flags, cert_flags, config_file, certsdir, key_params,
+                                vmid, NULL, &swtpm2->swtpm);
         if (ret != 0)
             return 1;
 
@@ -497,6 +521,72 @@ static int tpm2_create_eks_and_certs(unsigned long flags, const gchar *config_fi
      flags &= ~SETUP_PLATFORM_CERT_F;
      return tpm2_create_ek_and_cert(flags, config_file, certsdir, vmid, ek2keyalgo,
                                     ek2keyalgo_param, swtpm2, user_certsdir);
+}
+
+/* Create the IAK and cert */
+static int tpm2_create_iak_idevid_and_certs(unsigned long flags, const gchar *config_file,
+                                            const gchar *certsdir, const char *vmid,
+                                            enum keyalgo iakkeyalgo, unsigned int iakkeyalgo_param,
+                                            enum keyalgo idevidkeyalgo, unsigned int idevidkeyalgo_param,
+                                            struct swtpm2 *swtpm2, const gchar *user_certsdir)
+{
+    g_autofree gchar *key_params = NULL;
+    const char *key_description;
+    const char *key_type = NULL;
+    unsigned long cert_flags = 0;
+    unsigned int keyalgo_param;
+    enum keyalgo keyalgo;
+    size_t idx;
+    int ret;
+
+    /* Only look at IAK and IDevID certs here */
+    if (iakkeyalgo != KEYALGO_NONE)
+        cert_flags |= SETUP_IAK_F;
+    if (idevidkeyalgo != KEYALGO_NONE)
+        cert_flags |= SETUP_IDEVID_F;
+
+    if (!cert_flags)
+        return 0;
+
+    for (idx = 0; flags_to_certfiles[idx].filename; idx++) {
+        if (cert_flags & flags_to_certfiles[idx].flag) {
+
+            SWTPM_G_FREE(key_params);
+
+            if (flags_to_certfiles[idx].flag == SETUP_IAK_F) {
+                key_type = "iak";
+                keyalgo = iakkeyalgo;
+                keyalgo_param = iakkeyalgo_param;
+                ret = swtpm2->ops->create_iak(&swtpm2->swtpm,
+                                              keyalgo, keyalgo_param,
+                                              &key_params, &key_description);
+            } else if (flags_to_certfiles[idx].flag == SETUP_IDEVID_F) {
+                key_type = "idevid";
+                keyalgo = idevidkeyalgo;
+                keyalgo_param = idevidkeyalgo_param;
+                ret = swtpm2->ops->create_idevid(&swtpm2->swtpm,
+                                                 keyalgo, keyalgo_param,
+                                                 &key_params, &key_description);
+            } else {
+                continue;
+            }
+            if (ret != 0)
+                return 1;
+
+            ret = call_create_certs(flags, flags_to_certfiles[idx].flag, config_file,
+                                    certsdir, key_params, vmid, "test", &swtpm2->swtpm);
+            if (ret != 0)
+                return 1;
+
+            ret = tpm2_persist_certificate(flags, certsdir, &flags_to_certfiles[idx],
+                                           keyalgo, keyalgo_param, swtpm2,
+                                           user_certsdir, key_type, key_description);
+            if (ret)
+                return 1;
+        }
+    }
+
+    return 0;
 }
 
 /* Get the default PCR banks from the config file and if nothing can
@@ -630,6 +720,8 @@ static int init_tpm2(unsigned long flags, gchar **swtpm_prg_l, const gchar *conf
                      const gchar *swtpm_keyopt, int *fds_to_pass, size_t n_fds_to_pass,
                      enum keyalgo ek1keyalgo, unsigned int ek1keyalgo_param,
                      enum keyalgo ek2keyalgo, unsigned int ek2keyalgo_param,
+                     enum keyalgo iakkeyalgo, unsigned int iakkeyalgo_param,
+                     enum keyalgo idevidkeyalgo, unsigned int idevidkeyalgo_param,
                      const gchar *certsdir, const gchar *user_certsdir,
                      const gchar *json_profile,
                      int json_profile_fd, const gchar *profile_remove_disabled_param)
@@ -675,6 +767,13 @@ static int init_tpm2(unsigned long flags, gchar **swtpm_prg_l, const gchar *conf
                                         ek1keyalgo, ek1keyalgo_param,
                                         ek2keyalgo, ek2keyalgo_param,
                                         swtpm2, user_certsdir);
+        if (ret != 0)
+            goto destroy;
+
+        ret = tpm2_create_iak_idevid_and_certs(flags, config_file, certsdir, vmid,
+                                               iakkeyalgo, iakkeyalgo_param,
+                                               idevidkeyalgo, idevidkeyalgo_param,
+                                               swtpm2, user_certsdir);
         if (ret != 0)
             goto destroy;
     }
@@ -769,7 +868,7 @@ static int tpm12_create_certs(unsigned long flags, const gchar *config_file,
     cert_flags = flags & (SETUP_EK_CERT_F | SETUP_PLATFORM_CERT_F);
 
     ret = call_create_certs(flags, cert_flags, config_file, certsdir, ekparam,
-                            vmid, &swtpm12->swtpm);
+                            vmid, NULL, &swtpm12->swtpm);
     if (ret != 0)
         return 1;
 
@@ -989,11 +1088,21 @@ static void usage(const char *prgname, const char *default_config_file)
         "--ecc            : This option allows to create a TPM 2's ECC key as storage\n"
         "                   primary key; a TPM 2 always gets an RSA and an ECC EK key.\n"
         "\n"
-        "--ek1keyalgo     : Choice of the 1st EK's key algorithm; default is %s\n"
+        "--ek1keyalgo <alg>\n"
+        "                 : Choice of the 1st EK's key algorithm; default is %s\n"
         "                   choices: rsa2048, rsa3072, rsa4096, ecc_nist_p384\n"
         "\n"
-        "--ek2keyalgo     : Choice of the 2nd EK's key algorithm; default is %s\n"
+        "--ek2keyalgo <alg>\n"
+        "                 : Choice of the 2nd EK's key algorithm; default is %s\n"
         "                   choices: same as for --ek1keyalgo\n"
+        "\n"
+        "--iakkeyalgo <alg>\n"
+        "                 : Choice of the IAK algorithm; default is 'none'\n"
+        "                   choices: rsa2048, rsa3072, rsa4096, ecc_nist_p384\n"
+        "\n"
+        "--idevidkeyalgo <alg>\n"
+        "                 : Choice of the IDevID key algorithm; default is 'none'\n"
+        "                   choices: same as for --iakkeyalgo\n"
         "\n"
         "--take-ownership : Take ownership; this option implies --createek\n"
         "  --ownerpass  <password>\n"
@@ -1352,6 +1461,7 @@ static int print_capabilities(const char **swtpm_prg_l, gboolean swtpm_has_tpm12
            "%s"
            ", \"cmdarg-profile\", \"cmdarg-profile-remove-disabled\""
            ", \"cmdarg-ek1keyalgo\", \"cmdarg-ek2keyalgo\""
+           ", \"cmdarg-iakkeyalgo\", \"cmdarg-idevidkeyalgo\""
            " ], "
            "\"profiles\": [%s], "
            "\"version\": \"" VERSION "\" "
@@ -1486,6 +1596,8 @@ int main(int argc, char *argv[])
         {"create-spk", no_argument, NULL, 'C'},
         {"ek1keyalgo", required_argument, NULL, '4'},
         {"ek2keyalgo", required_argument, NULL, '5'},
+        {"iakkeyalgo", required_argument, NULL, '6'},
+        {"idevidkeyalgo", required_argument, NULL, '7'},
         {"take-ownership", no_argument, NULL, 'o'},
         {"ownerpass", required_argument, NULL, 'O'},
         {"owner-well-known", no_argument, NULL, 'w'},
@@ -1522,6 +1634,7 @@ int main(int argc, char *argv[])
         {"profile-file-fd", required_argument, NULL, 'G'},
         {"profile-remove-disabled", required_argument, NULL, 'j'},
         {"print-profiles", no_argument, NULL, 'M'},
+        {"no-iak", no_argument, NULL, 'n'},
         {"help", no_argument, NULL, 'h'},
         {NULL, 0, NULL, 0}
     };
@@ -1557,6 +1670,8 @@ int main(int argc, char *argv[])
     g_autofree gchar *profile_remove_disabled_param = NULL;
     g_autofree gchar *ek1keyalgo_str = NULL;
     g_autofree gchar *ek2keyalgo_str = NULL;
+    g_autofree gchar *iakkeyalgo_str = NULL;
+    g_autofree gchar *idevidkeyalgo_str = NULL;
     int json_profile_fd = -1;
     gchar *tmp;
     gchar **swtpm_prg_l = NULL;
@@ -1571,14 +1686,19 @@ int main(int argc, char *argv[])
     int fds_to_pass[2] = { -1, -1 };
     unsigned n_fds_to_pass = 0;
     char tmpbuffer[200];
+    gboolean no_iak = FALSE;
     time_t now;
     struct tm *tm;
     int ret = 1;
     g_autoptr(GError) error = NULL;
     enum keyalgo ek1keyalgo = KEYALGO_RSA;
     enum keyalgo ek2keyalgo = KEYALGO_ECC;
+    enum keyalgo iakkeyalgo = KEYALGO_NONE;
+    enum keyalgo idevidkeyalgo = KEYALGO_NONE;
     unsigned int ek1keyalgo_param = 0;
     unsigned int ek2keyalgo_param = 0;
+    unsigned int iakkeyalgo_param = 0;
+    unsigned int idevidkeyalgo_param = 0;
 
     setvbuf(stdout, 0, _IONBF, 0);
 
@@ -1627,6 +1747,14 @@ int main(int argc, char *argv[])
         case '5': /* --ek2keyalgo */
             g_free(ek2keyalgo_str);
             ek2keyalgo_str = g_strdup(optarg);
+            break;
+        case '6': /* --iakkeyalgo */
+            g_free(iakkeyalgo_str);
+            iakkeyalgo_str = g_strdup(optarg);
+            break;
+        case '7': /* --idevidkeyalgo */
+            g_free(idevidkeyalgo_str);
+            idevidkeyalgo_str = g_strdup(optarg);
             break;
         case 'c': /* --createek */
             flags |= SETUP_CREATE_EK_F;
@@ -1787,6 +1915,9 @@ int main(int argc, char *argv[])
             break;
         case 'M': /* --print-profiles */
             printprofiles = TRUE;
+            break;
+        case 'n': /* --no-iak */
+            no_iak = TRUE;
             break;
         case '?':
         case 'h': /* --help */
@@ -2083,6 +2214,17 @@ int main(int argc, char *argv[])
                 !is_rsa_keysize_supported(flags, ek2keyalgo_param, swtpm_prg_l))
                 goto error;
         }
+
+        if (!iakkeyalgo_str)
+            iakkeyalgo_str = get_config_value(config_file_lines, "iakkeyalgo");
+        if (iakkeyalgo_str &&
+            !parse_keyalgo(iakkeyalgo_str, &iakkeyalgo, &iakkeyalgo_param, &flags))
+            goto error;
+        if (!idevidkeyalgo_str)
+            idevidkeyalgo_str = get_config_value(config_file_lines, "idevidkeyalgo");
+        if (idevidkeyalgo_str &&
+            !parse_keyalgo(idevidkeyalgo_str, &idevidkeyalgo, &idevidkeyalgo_param, &flags))
+            goto error;
     }
 
     if (flags & SETUP_RECONFIGURE_F) {
@@ -2112,6 +2254,8 @@ int main(int argc, char *argv[])
                    error->message);
             goto error;
         }
+        if (!no_iak)
+            flags |= SETUP_IAK_F | SETUP_IDEVID_F;
     }
 
     if ((flags & SETUP_TPM2_F) == 0) {
@@ -2127,6 +2271,8 @@ int main(int argc, char *argv[])
                        swtpm_keyopt, fds_to_pass, n_fds_to_pass,
                        ek1keyalgo, ek1keyalgo_param,
                        ek2keyalgo, ek2keyalgo_param,
+                       iakkeyalgo, iakkeyalgo_param,
+                       idevidkeyalgo, idevidkeyalgo_param,
                        certsdir, user_certsdir, json_profile, json_profile_fd,
                        profile_remove_disabled_param);
     }

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -31,6 +31,10 @@
 #include <glib-object.h>
 #include <json-glib/json-glib.h>
 
+#include <openssl/pem.h>
+#include <openssl/sha.h>
+#include <openssl/x509v3.h>
+
 #include <libtpms/tpm_nvfilename.h>
 
 #include "profile.h"
@@ -38,8 +42,6 @@
 #include "swtpm_conf.h"
 #include "swtpm_utils.h"
 #include "swtpm_setup_utils.h"
-
-#include <openssl/sha.h>
 
 /* default values for passwords */
 #define DEFAULT_OWNER_PASSWORD "ooo"
@@ -76,6 +78,15 @@ gchar *gl_LOGFILE = NULL;
 
 #define DEFAULT_EK1KEYALGO "rsa2048"
 #define DEFAULT_EK2KEYALGO "ecc_nist_p384"
+
+/* data extracted from EK certificate; */
+struct ek_certificate_data {
+    bool needed;  /* data are only needed if IAK and/or IDevID are created */
+    unsigned char id[32];
+    size_t id_len;
+    unsigned char serial[20];
+    size_t serial_len;
+};
 
 static const struct flag_to_certfile {
     unsigned long flag;
@@ -397,6 +408,60 @@ static int read_certificate_file(const gchar *certsdir, const gchar *filename,
     return read_file(*certfile, filecontent, filecontent_len);
 }
 
+static int tpm2_extract_certificate_data(const gchar *certdata, size_t certdata_len,
+                                         struct ek_certificate_data *ecd)
+{
+    const ASN1_OCTET_STRING *os;
+    const ASN1_INTEGER *serial;
+    X509 *cert = NULL;
+    BIGNUM *bn = NULL;
+    BIO *bio = NULL;
+    int ret = 1;
+
+    if (!ecd->needed)
+        return 0;
+
+    cert = d2i_X509(NULL, (const unsigned char **)&certdata, certdata_len);
+    if (!cert) {
+        fprintf(stderr, "Could not convert byte array to certificate.\n");
+        goto cleanup;
+    }
+
+    os = X509_get0_authority_key_id(cert);
+    if (os == NULL) {
+        fprintf(stderr, "The certificate does not have an AKID.\n");
+        goto cleanup;
+    }
+
+    ecd->id_len = min((size_t)ASN1_STRING_length(os), sizeof(ecd->id));
+    memcpy(ecd->id, ASN1_STRING_get0_data(os), ecd->id_len);
+
+    serial = X509_get0_serialNumber(cert);
+    if (!serial) {
+        fprintf(stderr, "Could not get serial number from certificate.\n");
+        goto cleanup;
+    }
+    bn = ASN1_INTEGER_to_BN(serial, NULL);
+    if (!bn) {
+        fprintf(stderr, "Out of memory.\n");
+        goto cleanup;
+    }
+    if ((size_t)BN_num_bytes(bn) > sizeof(ecd->serial)) {
+        fprintf(stderr, "The serial number is too large for the buffer.\n");
+        goto cleanup;
+    }
+    ecd->serial_len = BN_bn2bin(bn, ecd->serial);
+
+    ret = 0;
+
+cleanup:
+    BN_free(bn);
+    X509_free(cert);
+    BIO_free(bio);
+
+    return ret;
+}
+
 /*
  * Read the certificate from the file where swtpm_cert left it.
  * Write the file into the TPM's NVRAM and, if the user wants it,
@@ -406,7 +471,8 @@ static int tpm2_persist_certificate(unsigned long flags, const gchar *certsdir,
                                     const struct flag_to_certfile *ftc,
                                     enum keyalgo keyalgo, unsigned int keyalgo_param,
                                     struct swtpm2 *swtpm2, const gchar *user_certsdir,
-                                    const gchar *key_type, const gchar *key_description)
+                                    const gchar *key_type, const gchar *key_description,
+                                    struct ek_certificate_data *ecd)
 {
     g_autofree gchar *filecontent = NULL;
     g_autofree gchar *certfile = NULL;
@@ -418,6 +484,12 @@ static int tpm2_persist_certificate(unsigned long flags, const gchar *certsdir,
                                 &filecontent, &filecontent_len, &certfile);
     if (ret != 0)
         goto error_unlink;
+
+    if (ecd) {
+        ret = tpm2_extract_certificate_data(filecontent, filecontent_len, ecd);
+        if (ret != 0)
+            goto error_unlink;
+    }
 
     if (ftc->flag == SETUP_IAK_F) {
         ret = swtpm2->ops->write_iak_cert_nvram(&swtpm2->swtpm,
@@ -456,9 +528,11 @@ error_unlink:
 static int tpm2_create_ek_and_cert(unsigned long flags, const gchar *config_file,
                                    const gchar *certsdir, const gchar *vmid,
                                    enum keyalgo keyalgo, unsigned int keyalgo_param,
-                                   struct swtpm2 *swtpm2, const gchar *user_certsdir)
+                                   struct swtpm2 *swtpm2, const gchar *user_certsdir,
+                                   struct ek_certificate_data *ecd)
 {
     g_autofree gchar *key_params = NULL;
+    struct ek_certificate_data *ecd_dup;
     const char *key_description = "";
     unsigned long cert_flags;
     const gchar *key_type;
@@ -485,11 +559,19 @@ static int tpm2_create_ek_and_cert(unsigned long flags, const gchar *config_file
 
         for (idx = 0; flags_to_certfiles[idx].filename; idx++) {
             if (cert_flags & flags_to_certfiles[idx].flag) {
-                key_type = flags_to_certfiles[idx].flag & SETUP_EK_CERT_F ? "ek" : "";
+
+                ecd_dup = NULL;
+                if (flags_to_certfiles[idx].flag & SETUP_EK_CERT_F) {
+                    key_type = "ek";
+                    ecd_dup = ecd;
+                } else {
+                    key_type = "";
+                }
 
                 ret = tpm2_persist_certificate(flags, certsdir, &flags_to_certfiles[idx],
                                                keyalgo, keyalgo_param, swtpm2,
-                                               user_certsdir, key_type, key_description);
+                                               user_certsdir, key_type, key_description,
+                                               ecd_dup);
                 if (ret)
                     return 1;
             }
@@ -504,12 +586,13 @@ static int tpm2_create_eks_and_certs(unsigned long flags, const gchar *config_fi
                                      const gchar *certsdir, const gchar *vmid,
                                      enum keyalgo ek1keyalgo, unsigned int ek1keyalgo_param,
                                      enum keyalgo ek2keyalgo, unsigned int ek2keyalgo_param,
-                                     struct swtpm2 *swtpm2, const gchar *user_certsdir)
+                                     struct swtpm2 *swtpm2, const gchar *user_certsdir,
+                                     struct ek_certificate_data *ecd)
 {
      int ret;
 
      ret = tpm2_create_ek_and_cert(flags, config_file, certsdir, vmid, ek1keyalgo,
-                                   ek1keyalgo_param, swtpm2, user_certsdir);
+                                   ek1keyalgo_param, swtpm2, user_certsdir, ecd);
      if (ret != 0)
          return 1;
 
@@ -520,7 +603,33 @@ static int tpm2_create_eks_and_certs(unsigned long flags, const gchar *config_fi
      /* platform cert only with EK1 */
      flags &= ~SETUP_PLATFORM_CERT_F;
      return tpm2_create_ek_and_cert(flags, config_file, certsdir, vmid, ek2keyalgo,
-                                    ek2keyalgo_param, swtpm2, user_certsdir);
+                                    ek2keyalgo_param, swtpm2, user_certsdir, NULL);
+}
+
+static gchar *tpm2_create_tpm_serial_num(struct swtpm2 *swtpm2, const struct ek_certificate_data *ecd)
+{
+    struct swtpm *swtpm = &swtpm2->swtpm;
+    g_autofree gchar *cert_ser = NULL;
+    g_autofree gchar *ca_akid = NULL;
+    uint32_t res;
+    char code[sizeof(res) + 1];
+    size_t i;
+    int ret;
+
+    ret = swtpm2->ops->get_capability(swtpm, TPM2_CAP_TPM_PROPERTIES,
+                                      TPM2_PT_MANUFACTURER, &res);
+    if (ret != 0) {
+        logerr(gl_LOGFILE, "TPM_GetCapability failed\n");
+        return NULL;
+    }
+
+    ca_akid = print_as_hex(ecd->id, ecd->id_len);
+    cert_ser = print_as_hex(ecd->serial, ecd->serial_len);
+    for (i = 0; i < sizeof(res); i++)
+        code[i] = res >> (8 * (3 - i));
+    code[4] = 0;
+
+    return g_strdup_printf("%s:%s:%s", code, ca_akid, cert_ser);
 }
 
 /* Create the IAK and cert */
@@ -528,8 +637,10 @@ static int tpm2_create_iak_idevid_and_certs(unsigned long flags, const gchar *co
                                             const gchar *certsdir, const char *vmid,
                                             enum keyalgo iakkeyalgo, unsigned int iakkeyalgo_param,
                                             enum keyalgo idevidkeyalgo, unsigned int idevidkeyalgo_param,
-                                            struct swtpm2 *swtpm2, const gchar *user_certsdir)
+                                            struct swtpm2 *swtpm2, const gchar *user_certsdir,
+                                            const struct ek_certificate_data *ecd)
 {
+    g_autofree gchar *tpm_serial_num = NULL;
     g_autofree gchar *key_params = NULL;
     const char *key_description;
     const char *key_type = NULL;
@@ -547,6 +658,8 @@ static int tpm2_create_iak_idevid_and_certs(unsigned long flags, const gchar *co
 
     if (!cert_flags)
         return 0;
+
+    tpm_serial_num = tpm2_create_tpm_serial_num(swtpm2, ecd);
 
     for (idx = 0; flags_to_certfiles[idx].filename; idx++) {
         if (cert_flags & flags_to_certfiles[idx].flag) {
@@ -574,13 +687,14 @@ static int tpm2_create_iak_idevid_and_certs(unsigned long flags, const gchar *co
                 return 1;
 
             ret = call_create_certs(flags, flags_to_certfiles[idx].flag, config_file,
-                                    certsdir, key_params, vmid, "test", &swtpm2->swtpm);
+                                    certsdir, key_params, vmid, tpm_serial_num,
+                                    &swtpm2->swtpm);
             if (ret != 0)
                 return 1;
 
             ret = tpm2_persist_certificate(flags, certsdir, &flags_to_certfiles[idx],
                                            keyalgo, keyalgo_param, swtpm2,
-                                           user_certsdir, key_type, key_description);
+                                           user_certsdir, key_type, key_description, NULL);
             if (ret)
                 return 1;
         }
@@ -726,6 +840,9 @@ static int init_tpm2(unsigned long flags, gchar **swtpm_prg_l, const gchar *conf
                      const gchar *json_profile,
                      int json_profile_fd, const gchar *profile_remove_disabled_param)
 {
+    struct ek_certificate_data ecd = {
+        .needed = iakkeyalgo != KEYALGO_NONE || idevidkeyalgo != KEYALGO_NONE,
+    };
     unsigned int keyalgo_param;
     struct swtpm2 *swtpm2;
     enum keyalgo keyalgo;
@@ -766,14 +883,14 @@ static int init_tpm2(unsigned long flags, gchar **swtpm_prg_l, const gchar *conf
         ret = tpm2_create_eks_and_certs(flags, config_file, certsdir, vmid,
                                         ek1keyalgo, ek1keyalgo_param,
                                         ek2keyalgo, ek2keyalgo_param,
-                                        swtpm2, user_certsdir);
+                                        swtpm2, user_certsdir, &ecd);
         if (ret != 0)
             goto destroy;
 
         ret = tpm2_create_iak_idevid_and_certs(flags, config_file, certsdir, vmid,
                                                iakkeyalgo, iakkeyalgo_param,
                                                idevidkeyalgo, idevidkeyalgo_param,
-                                               swtpm2, user_certsdir);
+                                               swtpm2, user_certsdir, &ecd);
         if (ret != 0)
             goto destroy;
     }
@@ -2225,6 +2342,12 @@ int main(int argc, char *argv[])
         if (idevidkeyalgo_str &&
             !parse_keyalgo(idevidkeyalgo_str, &idevidkeyalgo, &idevidkeyalgo_param, &flags))
             goto error;
+
+        if ((iakkeyalgo != KEYALGO_NONE || idevidkeyalgo != KEYALGO_NONE) &&
+            (flags & SETUP_CREATE_EK_F)== 0 ) {
+            fprintf(stderr, "When creaing IAK and/or IDevID keys, then an EK certificate must be created as well.\n");
+            goto error;
+        }
     }
 
     if (flags & SETUP_RECONFIGURE_F) {

--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -55,7 +55,7 @@ exp='\{ "type": "swtpm_setup", '\
 '"cmdarg-reconfigure-pcr-banks"'\
 '(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")?(, "tpm2-rsa-keysize-4096")?, '\
 '"cmdarg-profile", "cmdarg-profile-remove-disabled", "cmdarg-ek1keyalgo", '\
-'"cmdarg-ek2keyalgo" \], '\
+'"cmdarg-ek2keyalgo", "cmdarg-iakkeyalgo", "cmdarg-idevidkeyalgo" \], '\
 '"profiles": \[ [^]]*\], '\
 '"version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then

--- a/tests/_test_tpm2_print_capabilities
+++ b/tests/_test_tpm2_print_capabilities
@@ -58,7 +58,7 @@ exp='\{ "type": "swtpm_setup", '\
 '"tpm12-not-need-root", "cmdarg-write-ek-cert-files", "cmdarg-create-config-files", '\
 '"cmdarg-reconfigure-pcr-banks"(, "tpm2-rsa-keysize-2048")?(, "tpm2-rsa-keysize-3072")?'\
 '(, "tpm2-rsa-keysize-4096")?, "cmdarg-profile", "cmdarg-profile-remove-disabled", '\
-'"cmdarg-ek1keyalgo", "cmdarg-ek2keyalgo" \], '\
+'"cmdarg-ek1keyalgo", "cmdarg-ek2keyalgo", "cmdarg-iakkeyalgo", "cmdarg-idevidkeyalgo" \], '\
 '"profiles": \[ [^]]*\], '\
 '"version": "[^"]*" \}'
 if ! [[ ${msg} =~ ${exp} ]]; then

--- a/tests/create_certs.sh
+++ b/tests/create_certs.sh
@@ -37,6 +37,12 @@ main() {
 	platform)
 		echo -n "platform" > ${dir}/platform.cert
 		;;
+	iak)
+		echo -n "iak" > ${dir}/iak.cert
+		;;
+	idevid)
+		echo -n "idevid" > ${dir}/idevid.cert
+		;;
 	esac
 }
 

--- a/tests/create_certs.sh
+++ b/tests/create_certs.sh
@@ -2,8 +2,29 @@
 
 #echo $@
 
+ek_cert=\
+MIID9TCCAl2gAwIBAgICBL4wDQYJKoZIhvcNAQELBQAwGDEWMBQGA1UEAxMNc3d0cG0tbG9jYWxj\
+YTAgFw0yMzA4MjIwMTM2MDdaGA85OTk5MTIzMTIzNTk1OVowEjEQMA4GA1UEAxMHdW5rbm93bjCC\
+ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJSKqmO3O1KnFQFXENX+z8kcL0eIFW8xVhPW\
+eCJrChwRil36KaxJHPf5aqzWkMuZnCHI2U5susPq7BAeCCPXaOb3pwbs3tgEC5eGAEApv6Y+5Yep\
+ia8chBGI58q3CuKL/HcToNnzT1MwwTtq4dCzav9BcmR/tkh9fSUvjOwZyPIDktgvMXAkLFzqhAx3\
+8TKSqdhjWgbUAr8fGsAUGm1bvepphEpycjCfftdC6/GnGEbHsDWjBS944k3sHWD7Aik/VV9wEHLT\
+EIN8r3rKdj5nzqUrGRFqSupN5e25YRhKxS1SB9wFOiOYoevsPR7Bh3/5MdZd33zhnTbrA9f0RDxu\
+qjUCAwEAAaOBzDCByTAQBgNVHSUECTAHBgVngQUIATBSBgNVHREBAf8ESDBGpEQwQjEWMBQGBWeB\
+BQIBDAtpZDowMDAwMTAxNDEQMA4GBWeBBQICDAVzd3RwbTEWMBQGBWeBBQIDDAtpZDoyMDE5MTAy\
+MzAMBgNVHRMBAf8EAjAAMCIGA1UdCQQbMBkwFwYFZ4EFAhAxDjAMDAMyLjACAQACAgCkMB8GA1Ud\
+IwQYMBaAFMFMlKkwREqQv5MU2eVVkxUZIOP0MA4GA1UdDwEB/wQEAwIFIDANBgkqhkiG9w0BAQsF\
+AAOCAYEAihjxS4PmR5xO7jAYsF5hqeMvEh5+wH+OWjkj9oH+a8N6oFlxUJeQgLLFgK+Jyq4zt0kz\
+tdAaFX0XrWfPH/s1AQdwtUzqOHdSHWcBmfPV+MlMCtz1HjfC5GGKmCHPgwDRLiowwzsWyKFRPKlu\
+UtmtP0ukRTbzGa/j3GpBSnIn7l2yTrnXZ6XXeZ/gvHghzyp02aGJ2Ei873X57zOuFmz1z++WwXRN\
+ipRoAjga57NAz/f1RceJuF+zA8aAX7GY2dcvDCVpU1yoBsWt9gXtZ/4ZO400fbwnxz3zVLJEXgpR\
+jd+XbUUxsGMWqWZ3qEApbrkWjS77TXkDmOqK8Nh92mZvLSMHBJa/mzWFJBPpu+MCSPbO9kAhfB5W\
+F2ynlGuQfeBue4ju5PmcID3xs2FbCItWyj8bJhuA2QQDYmUrSnqQJ9zNLj7ibbq7hDWsaeko65/E\
+HYBXBvksWO4cdoR7F9pcuyhsJDMU7jyGAo0RKuRkUrGnN2Aja4GKSXTilXTCeq/5
+
+
 main() {
-	local typ ek dir vmid
+	local typ ek dir vmid tpm2=0
 
 	while [ $# -ne 0 ]; do
 		#echo $1
@@ -25,6 +46,7 @@ main() {
 			vmid="$1"
 			;;
 		--tpm2)
+			tpm2=1
 			;;
 		esac
 		shift
@@ -32,7 +54,12 @@ main() {
 
 	case "$typ" in
 	ek)
-		echo -n "ek" > ${dir}/ek.cert
+		# ek cert must be parseable for a TPM 2
+		if [ "${tpm2}" -ne 0 ]; then
+			base64 -d <<< "${ek_cert}" > ${dir}/ek.cert
+		else
+			echo -n "ek" > ${dir}/ek.cert
+		fi
 		;;
 	platform)
 		echo -n "platform" > ${dir}/platform.cert

--- a/tests/test_tpm2_parameters
+++ b/tests/test_tpm2_parameters
@@ -40,7 +40,9 @@ PARAMETERS=(
 	"--profile-name null       --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --ek1keyalgo ecc_nist_p384 --ek2keyalgo ecc_nist_p384"
 	"--profile-name null       --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --ek1keyalgo ecc_nist_p521 --ek2keyalgo secp256r1"
 	"--profile-name null       --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --ek1keyalgo ecc_nist_p256 --ek2keyalgo secp256r1"
-	"--profile-name null       --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --ek1keyalgo rsa2048       --ek2keyalgo rsa3072       --ecc"
+	"--profile-name null       --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --ek1keyalgo rsa2048       --ek2keyalgo secp521r1 --ecc"
+	"--profile-name null       --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --ek1keyalgo ecc_nist_p256 --ek2keyalgo secp256r1 --iakkeyalgo ecc_nist_p256 --idevidkeyalgo rsa2048"
+	"--profile-name null       --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --ek1keyalgo rsa2048       --ek2keyalgo rsa3072   --iakkeyalgo rsa3072       --idevidkeyalgo secp521r1 --ecc"
 	"--profile-name default-v1 --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --ek1keyalgo rsa2048       --ek2keyalgo ecc_nist_p384"
 )
 
@@ -57,6 +59,7 @@ PARAMETERS_3072=(
 	"--createek --allow-signing --decryption --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --vmid test --display --keyfile ${TESTDIR}/data/keyfile256bit.txt --cipher aes-256-cbc --rsa-keysize 3072"
 	"--createek --allow-signing --decryption --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --vmid test --display --pwdfile ${TESTDIR}/data/pwdfile.txt --cipher aes-256-cbc --rsa-keysize 3072"
 	"--createek --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --vmid test --lock-nvram --rsa-keysize 3072"
+	"--profile-name null       --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --ek1keyalgo rsa2048 --ek2keyalgo rsa3072 --iakkeyalgo rsa3072 --idevidkeyalgo secp521r1 --ecc"
 	"--profile-name default-v1 --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --ek1keyalgo rsa2048 --ek2keyalgo rsa3072"
 )
 
@@ -68,7 +71,9 @@ PARAMETERS_4096=(
 	"--createek --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --vmid test --display --pwdfile ${TESTDIR}/data/pwdfile.txt --rsa-keysize 4096 --profile-name default-v2"
 	"--createek --allow-signing --decryption --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --vmid test --display --pwdfile ${TESTDIR}/data/pwdfile.txt --cipher aes-256-cbc --rsa-keysize 4096 --profile-name default-v2"
 	"--createek --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --vmid test --lock-nvram --rsa-keysize 4096 --profile-name default-v2"
+	"--profile-name default-v2 --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --ek1keyalgo rsa2048 --ek2keyalgo rsa3072 --iakkeyalgo rsa3072 --idevidkeyalgo secp521r1 --ecc"
 	"--profile-name default-v2 --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --ek1keyalgo rsa2048 --ek2keyalgo rsa4096"
+	"--profile-name default-v2 --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --ek1keyalgo rsa4096 --ek2keyalgo rsa4096 --iakkeyalgo rsa4096 --idevidkeyalgo secp384r1 --ecc"
 )
 
 # Open read-only file descriptors referenced in test cases
@@ -109,12 +114,13 @@ for (( i=0; i<${#PARAMETERS[*]}; i++)); do
 	rm -rf "${TPMDIR:?}"/*
 	echo -n "Test $i: "
 	params=${PARAMETERS[$i]}
-	if ! $TPMAUTHORING \
+	if ! msg=$($TPMAUTHORING \
 		--tpm-state "$TPMDIR" \
 		--tpm "$SWTPM_EXE socket ${SWTPM_TEST_SECCOMP_OPT}" \
-		${params:+${params}} &>/dev/null;
+		${params:+${params}} 2>&1);
 	then
 		echo "ERROR: Test with parameters '${params}' failed."
+		echo "${msg}"
 		exit 1
 	elif [ ! -f "$TPMDIR/tpm2-00.permall" ]; then
 		echo "ERROR: Test with parameters '${params}' did not

--- a/tests/test_tpm2_swtpm_cert
+++ b/tests/test_tpm2_swtpm_cert
@@ -136,6 +136,7 @@ if ! ${SWTPM_CERT} \
 	--pubkey "${TESTDIR}/data/pubek.pem" \
 	--out-cert "${cert}" \
 	--days 3650 \
+	--subject "serialNumber=${serial}" \
 	--pem \
 	--tpm-serial-num "${serial}" \
 	--tpm-manufacturer IBM --tpm-model swtpm-libtpms --tpm-version 2; then
@@ -177,6 +178,7 @@ if ! ${SWTPM_CERT} \
 	--pubkey "${TESTDIR}/data/pubek.pem" \
 	--out-cert "${cert}" \
 	--days 3650 \
+	--subject "serialNumber=${serial}" \
 	--pem \
 	--tpm-serial-num "${serial}" \
 	--tpm-manufacturer IBM --tpm-model swtpm-libtpms --tpm-version 2; then

--- a/tests/test_tpm2_swtpm_setup_create_cert
+++ b/tests/test_tpm2_swtpm_setup_create_cert
@@ -17,6 +17,8 @@ CERTSERIAL=${workdir}/certserial
 USER_CERTSDIR=${workdir}/mycerts
 mkdir -p "${USER_CERTSDIR}"
 
+vmid="test"
+
 PATH=${TOPBUILD}/src/swtpm_bios:$PATH
 
 trap "cleanup" SIGTERM EXIT
@@ -222,6 +224,7 @@ for pwdfile in "" "${PWDFILE}"; do
 		--overwrite \
 		--iakkeyalgo secp384r1 \
 		--idevidkeyalgo secp384r1 \
+		--vmid "${vmid}" \
 		--write-ek-cert-files "${workdir}" \
 		${pwdfile:+--pwdfile "${pwdfile}"}; then
 		echo "Error: Could not run $SWTPM_SETUP."
@@ -259,6 +262,33 @@ for pwdfile in "" "${PWDFILE}"; do
 			echo "Error: EK file '${certfile}' is not an ECC 384 bit key."
 			openssl x509 -inform der -in "${certfile}" -noout -text
 			exit 1
+		fi
+		# IAK and IDevID need serialNumber to match <company>:<ek cert akid>:<ek cert serial num>
+		if [[ ${certfile} =~ (iak|idevid) ]]; then
+			cert_vmid=$(openssl x509 -inform der --in "${certfile}" -noout -text \
+				| sed -n 's/.*Subject:.*serialNumber[[:space:]]*=[[:space:]]*//p')
+			if [ "${cert_vmid}" != "${vmid}" ]; then
+				echo "Error: The subject serialNumber in the cert is wrong"
+				echo "expected: ${vmid}"
+				echo "actual  : ${cert_vmid}"
+				exit 1
+			fi
+			# The serial number in the SAN is not display 'nicely'...
+			serial=$(openssl x509 -inform der --in "${certfile}" -noout -text \
+			          | grep "Subject Alternative Name:" -A1 \
+			          | tail -n1 \
+				  | sed -n "s/.*\(IBM[[:print:]]*\)/\1/p")
+			if [ -z "$serial" ] || \
+			   [ "${serial}" != \
+			     "$(echo "${serial}" | \
+			        sed -n 's/\([[:print:]^:]*\):\([[:xdigit:]^:]*\):\([[:xdigit:]^:]*\)/\1:\2:\3/p')" ];
+			then
+				echo "Error: serial Number does not seem to be properly formatted"
+				echo "  serial: ${serial}"
+				openssl x509 -inform der --in "${certfile}" -noout -text \
+				    | grep "Subject Alternative Name:" -A1
+				exit 1
+			fi
 		fi
 	done
 

--- a/tests/test_tpm2_swtpm_setup_create_cert
+++ b/tests/test_tpm2_swtpm_setup_create_cert
@@ -220,6 +220,8 @@ for pwdfile in "" "${PWDFILE}"; do
 		--logfile "${workdir}/logfile" \
 		--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}" \
 		--overwrite \
+		--iakkeyalgo secp384r1 \
+		--idevidkeyalgo secp384r1 \
 		--write-ek-cert-files "${workdir}" \
 		${pwdfile:+--pwdfile "${pwdfile}"}; then
 		echo "Error: Could not run $SWTPM_SETUP."
@@ -243,18 +245,22 @@ for pwdfile in "" "${PWDFILE}"; do
 		exit 1
 	fi
 
-	certfile="${workdir}/ek-secp384r1.crt"
-	if [ ! -f "${certfile}" ]; then
-		echo "Error: EK file '${certfile}' was not written."
-		ls -l "${workdir}"
-		exit 1
-	fi
+	for certfile in \
+		"${workdir}/ek-secp384r1.crt" \
+		"${workdir}/iak-secp384r1.crt" \
+		"${workdir}/idevid-secp384r1.crt"; do
+		if [ ! -f "${certfile}" ]; then
+			echo "Error: Certificate file '${certfile}' was not written."
+			ls -l "${workdir}"
+			exit 1
+		fi
 
-	if ! openssl x509 -inform der -in "${certfile}" -noout -text | grep -q "384 bit"; then
-		echo "Error: EK file '${certfile}' is not an ECC 384 bit key."
-		openssl x509 -inform der -in "${certfile}" -noout -text
-		exit 1
-	fi
+		if ! openssl x509 -inform der -in "${certfile}" -noout -text | grep -q "384 bit"; then
+			echo "Error: EK file '${certfile}' is not an ECC 384 bit key."
+			openssl x509 -inform der -in "${certfile}" -noout -text
+			exit 1
+		fi
+	done
 
 	swtpm_setup_reconfigure "${workdir}" "${pwdfile}"
 done


### PR DESCRIPTION
This is a rebase of the code in PR #823.

This PR extends the tools swtpm_cert, swtpm_localca, and swtpm_setup to create IAK and IDevID keys and certificates.

### ToDo:
- [X] swtpm_setup: Check NVRAM area flags
- [X] swtpm_setup: NVRAM indices currently used are wrong. Which ones to use?  We need to wait for an update of the specs that show the NVRAM indices for the certs.
- [X] swtpm_setup: Create serialNumber for subject from `<TCG Manuf Code>:<EK Authority Key Id>:<Ek Cert Serial Number>`
- [X] swtpm_cert: Is the ASN.1 in the certs ok? Properly nested?
- [X] man pages
- [X] test cases
