### PR TITLE
Add support for creating secp256r1 and secp521r1 EKs and a test case

### DIFF
--- a/man/man5/swtpm_setup.conf.pod
+++ b/man/man5/swtpm_setup.conf.pod
@@ -121,7 +121,8 @@ by users of the system.
 =item B<ek1keyalgo> (since v0.11)
 
 This keyword allows to choose the key algorithm of the 1st endorsement key.
-Supported values are: ecc_nist_p384 or secp384r1, rsa2048, rsa3072, rsa4096
+Supported values are: ecc_nist_p256 or secp256r1, ecc_nist_p384 or secp384r1,
+rsa2048, rsa3072, rsa4096
 
 Note that rsa4096 requires the default-v2 or a later profile.
 

--- a/man/man5/swtpm_setup.conf.pod
+++ b/man/man5/swtpm_setup.conf.pod
@@ -122,7 +122,7 @@ by users of the system.
 
 This keyword allows to choose the key algorithm of the 1st endorsement key.
 Supported values are: ecc_nist_p256 or secp256r1, ecc_nist_p384 or secp384r1,
-rsa2048, rsa3072, rsa4096
+ecc_nist_p521 or secp521r1, rsa2048, rsa3072, rsa4096
 
 Note that rsa4096 requires the default-v2 or a later profile.
 

--- a/man/man5/swtpm_setup.conf.pod
+++ b/man/man5/swtpm_setup.conf.pod
@@ -121,7 +121,7 @@ by users of the system.
 =item B<ek1keyalgo> (since v0.11)
 
 This keyword allows to choose the key algorithm of the 1st endorsement key.
-Supported values are: ecc_nist_p384, rsa2048, rsa3072, rsa4096
+Supported values are: ecc_nist_p384 or secp384r1, rsa2048, rsa3072, rsa4096
 
 Note that rsa4096 requires the default-v2 or a later profile.
 

--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -89,7 +89,8 @@ Choose the key algorithm for the 1st endorsement key. This key algorithm
 must be supported by the chosen profile since it will lead to a key
 generation error otherwise. The default is rsa2048.
 
-Valid values are: ecc_nist_p384 or secp384r1, rsa2048, rsa3072, rsa4096.
+Valid values are: ecc_nist_p256 or secp256r1, ecc_nist_p384 or secp384r1,
+rsa2048, rsa3072, rsa4096.
 
 Note that rsa4096 requires the default-v2 or a later profile.
 

--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -89,7 +89,7 @@ Choose the key algorithm for the 1st endorsement key. This key algorithm
 must be supported by the chosen profile since it will lead to a key
 generation error otherwise. The default is rsa2048.
 
-Valid values are: ecc_nist_p384, rsa2048, rsa3072, rsa4096.
+Valid values are: ecc_nist_p384 or secp384r1, rsa2048, rsa3072, rsa4096.
 
 Note that rsa4096 requires the default-v2 or a later profile.
 

--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -90,7 +90,7 @@ must be supported by the chosen profile since it will lead to a key
 generation error otherwise. The default is rsa2048.
 
 Valid values are: ecc_nist_p256 or secp256r1, ecc_nist_p384 or secp384r1,
-rsa2048, rsa3072, rsa4096.
+ecc_nist_p521 or secp521r1, rsa2048, rsa3072, rsa4096.
 
 Note that rsa4096 requires the default-v2 or a later profile.
 

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -453,12 +453,15 @@ static const struct swtpm_cops swtpm_cops = {
 // Specification Version 2.1; Revision 13; 10 December 2018
 #define TPM2_NV_INDEX_PLATFORMCERT           0x01c08000
 
+#define TPM2_NV_INDEX_ECC_SECP256R1_EKCERT        0x01c0000a
+#define TPM2_NV_INDEX_ECC_SECP256R1_EKTEMPLATE    0x01c0000b
 #define TPM2_NV_INDEX_ECC_SECP384R1_HI_EKCERT     0x01c00016
 #define TPM2_NV_INDEX_ECC_SECP384R1_HI_EKTEMPLATE 0x01c00017
 
 #define TPM2_EK_RSA_HANDLE           0x81010001
 #define TPM2_EK_RSA3072_HANDLE       0x8101001c
 #define TPM2_EK_RSA4096_HANDLE       0x8101001e
+#define TPM2_EK_ECC_SECP256R1_HANDLE 0x8101000a
 #define TPM2_EK_ECC_SECP384R1_HANDLE 0x81010016
 #define TPM2_SPK_HANDLE              0x81000001
 
@@ -493,6 +496,7 @@ static const unsigned char NONCE_EMPTY[2] = {AS2BE(0)};
 static const unsigned char NONCE_RSA2048[2+0x100] = {AS2BE(0x100), 0, };
 static const unsigned char NONCE_RSA3072[2+0x180] = {AS2BE(0x180), 0, };
 static const unsigned char NONCE_RSA4096[2+0x200] = {AS2BE(0x200), 0, };
+static const unsigned char NONCE_ECC_256[2+0x20] = {AS2BE(0x20), 0, };
 static const unsigned char NONCE_ECC_384[2+0x30] = {AS2BE(0x30), 0, };
 
 static const unsigned char PolicyA_SHA256[32] = {
@@ -547,6 +551,24 @@ static const struct ek_params {
     uint32_t nvindex_template;
 } ek_params[] = {
     {
+        .pk = {
+            .keyalgo = KEYALGO_ECC,
+            .keyalgo_param = TPM2_ECC_NIST_P256,
+            .keydescription = "secp256r1",
+            .nonce = NONCE_ECC_256,
+            .nonce_len = sizeof(NONCE_ECC_256),
+            .hashalg = TPM2_ALG_SHA256,
+            .authpolicy = PolicyA_SHA256,
+            .authpolicy_len = sizeof(PolicyA_SHA256),
+            .symkey_len = 128,
+            .duration = TPM2_DURATION_LONG,
+            .keysize = 32,
+        },
+        .ek_handle = TPM2_EK_ECC_SECP256R1_HANDLE,
+        .keytype = "secp256r1",
+        .nvindex_ekcert = TPM2_NV_INDEX_ECC_SECP256R1_EKCERT,
+        .nvindex_template = TPM2_NV_INDEX_ECC_SECP256R1_EKTEMPLATE,
+    }, {
         .pk = {
             .keyalgo = KEYALGO_ECC,
             .keyalgo_param = TPM2_ECC_NIST_P384,
@@ -621,6 +643,45 @@ static const struct ek_params {
     }
 };
 
+static const unsigned char null_authpolicy[] = {};
+
+static const struct spk_params {
+    struct pk_params pk;
+} spk_params[] = {
+    {
+        .pk = {
+            .keyalgo = KEYALGO_ECC,
+            .keyalgo_param = TPM2_ECC_NIST_P256,
+            .nonce = NONCE_ECC_256,
+            .nonce_len = sizeof(NONCE_ECC_256),
+            .hashalg = TPM2_ALG_SHA256,
+            .authpolicy = null_authpolicy,
+            .authpolicy_len = 0,
+            .keysize = 32,
+            .symkey_len = 128,
+            .duration = TPM2_DURATION_LONG,
+        }
+   }, {
+        .pk = {
+            .keyalgo = KEYALGO_ECC,
+            .keyalgo_param = TPM2_ECC_NIST_P384,
+            /* per "TCG TPM v2.0 Provisioning Guidance v1.0" page 37
+             * -> "Ek Credential Profile 2.0" rev.14 section 2.1.5.2:
+             * template for NIST P256 uses 2 identical 32-byte all-zero nonces
+             * -> Use two 48-byte all-zero nonces for NIST P384.
+             */
+            .nonce = NONCE_ECC_384,
+            .nonce_len = sizeof(NONCE_ECC_384),
+            .hashalg = TPM2_ALG_SHA384,
+            .authpolicy = null_authpolicy,
+            .authpolicy_len = 0,
+            .keysize = 48,
+            .symkey_len = 256,
+            .duration = TPM2_DURATION_LONG,
+        },
+    }
+};
+
 static const struct ek_params *get_ek_params(struct swtpm *self,
                                              enum keyalgo keyalgo,
                                              unsigned int keyalgo_param)
@@ -637,6 +698,24 @@ static const struct ek_params *get_ek_params(struct swtpm *self,
            keyalgo, keyalgo_param);
     return NULL;
 }
+
+static const struct spk_params *get_spk_params(struct swtpm *self,
+                                               enum keyalgo keyalgo,
+                                               unsigned int keyalgo_param)
+{
+    size_t i;
+
+    for (i = 0; i < ARRAY_LEN(spk_params); i++) {
+        if (spk_params[i].pk.keyalgo == keyalgo &&
+            spk_params[i].pk.keyalgo_param == keyalgo_param) {
+            return &spk_params[i];
+        }
+    }
+    logerr(self->logfile, "Internal error: Unsupported SRK keyalgo and keyalgo_param: %u/%u\n",
+           keyalgo, keyalgo_param);
+    return NULL;
+}
+
 
 /* function prototypes */
 static int swtpm_tpm2_createprimary_rsa(struct swtpm *self, uint32_t primaryhandle, unsigned int keyflags,
@@ -1223,39 +1302,28 @@ err_too_short:
     return 1;
 }
 
-static int swtpm_tpm2_createprimary_spk_ecc_nist_p384(struct swtpm *self,
-                                                      uint32_t *curr_handle)
+static int swtpm_tpm2_createprimary_spk_ecc(struct swtpm *self,
+                                            unsigned int keyalgo_param,
+                                            uint32_t *curr_handle)
 {
+    uint16_t curveid = (uint16_t)keyalgo_param;
+    const unsigned char schemedata[] = {
+        AS2BE(TPM2_ALG_NULL), AS2BE(curveid), AS2BE(TPM2_ALG_NULL)
+    };
+    size_t schemedata_len = sizeof(schemedata);
     // keyflags: fixedTPM, fixedParent, sensitiveDataOrigin, userWithAuth
     //           noDA, restricted, decrypt
     unsigned int keyflags = 0x00030472;
-    const unsigned char authpolicy[0] = { };
-    size_t authpolicy_len = sizeof(authpolicy);
-    const unsigned char schemedata[] = {
-        AS2BE(TPM2_ALG_NULL), AS2BE(TPM2_ECC_NIST_P384), AS2BE(TPM2_ALG_NULL)
-    };
-    struct pk_params pk_params = {
-        .authpolicy = authpolicy,
-        .authpolicy_len = authpolicy_len,
-        .nonce = NONCE_ECC_384,
-        .nonce_len = sizeof(NONCE_ECC_384),
-        .hashalg = TPM2_ALG_SHA384,
-        .keysize = 48,
-        .symkey_len = 256,
-        .duration = TPM2_DURATION_LONG,
-    };
-    size_t schemedata_len = sizeof(schemedata);
+    const struct spk_params *spks;
     size_t off = 42;
 
-    /* per "TCG TPM v2.0 Provisioning Guidance v1.0" page 37
-     * -> "Ek Credential Profile 2.0" rev.14 section 2.1.5.2:
-     * template for NIST P256 uses 2 identical 32-byte all-zero nonces
-     * -> Use two 48-byte all-zero nonces for NIST P384.
-     */
+    spks = get_spk_params(self, KEYALGO_ECC, keyalgo_param);
+    if (!spks)
+        return 1;
 
     return swtpm_tpm2_createprimary_ecc(self, TPM2_RH_OWNER, keyflags,
                                         schemedata, schemedata_len,
-                                        &pk_params, off, curr_handle,
+                                        &spks->pk, off, curr_handle,
                                         NULL, 0, NULL, NULL);
 }
 
@@ -1312,7 +1380,7 @@ static int swtpm_tpm2_create_spk(struct swtpm *self, enum keyalgo keyalgo,
 
     switch (keyalgo) {
     case KEYALGO_ECC:
-        ret = swtpm_tpm2_createprimary_spk_ecc_nist_p384(self, &curr_handle);
+        ret = swtpm_tpm2_createprimary_spk_ecc(self, keyalgo_param, &curr_handle);
         break;
     case KEYALGO_RSA:
         ret = swtpm_tpm2_createprimary_spk_rsa(self, keyalgo_param, &curr_handle);
@@ -1339,46 +1407,55 @@ static int swtpm_tpm2_create_spk(struct swtpm *self, enum keyalgo keyalgo,
 }
 
 /* Create an ECC EK key that may be allowed to sign and/or decrypt */
-static int swtpm_tpm2_createprimary_ek_ecc_nist_p384(struct swtpm *self, gboolean allowsigning,
-                                                     gboolean decryption, uint32_t *curr_handle,
-                                                     unsigned char *ektemplate, size_t *ektemplate_len,
-                                                     gchar **ekparam, const char **key_description)
+static int swtpm_tpm2_createprimary_ek_ecc(struct swtpm *self, const struct ek_params *ekps,
+                                           gboolean allowsigning, gboolean decryption,
+                                           uint32_t *curr_handle,
+                                           unsigned char *ektemplate, size_t *ektemplate_len,
+                                           gchar **ekparam, const char **key_description)
 {
     const unsigned char schemedata[] = {
-        AS2BE(TPM2_ALG_NULL), AS2BE(TPM2_ECC_NIST_P384), AS2BE(TPM2_ALG_NULL)
+        AS2BE(TPM2_ALG_NULL), AS2BE(ekps->pk.keyalgo_param), AS2BE(TPM2_ALG_NULL)
     };
     size_t schemedata_len = sizeof(schemedata);
-    const struct ek_params *ekps;
     struct pk_params pkps;
     unsigned int keyflags;
     size_t off;
     int ret;
 
-    ekps = get_ek_params(self, KEYALGO_ECC, TPM2_ECC_NIST_P384);
-    if (!ekps)
-        return 1;
     pkps = ekps->pk;
+
+    switch (pkps.keyalgo_param) {
+    case TPM2_ECC_NIST_P256:
+        off = 0x4a;
+        keyflags = 0;
+        break;
+    case TPM2_ECC_NIST_P384:
+        off = 0x5a;
+        keyflags = 0x40; // userWithAuth (high range)
+        break;
+    default:
+        return 1;
+    }
 
     if (allowsigning && decryption) {
         // keyflags: fixedTPM, fixedParent, sensitiveDatOrigin,
         // userWithAuth, adminWithPolicy, sign, decrypt; restricted CANNOT be set
-        keyflags = 0x000600f2;
+        keyflags |= 0x000600b2;
         // symmetric: TPM_ALG_NULL
         pkps.symkey_len = 0;
-        off = 86;
+        off -= 4;
     } else if (allowsigning) {
         // keyflags: fixedTPM, fixedParent, sensitiveDatOrigin,
         // userWithAuth, adminWithPolicy, sign; restricted CANNOT be set
-        keyflags = 0x000400f2;
+        keyflags |= 0x000400b2;
         // symmetric: TPM_ALG_NULL
         pkps.symkey_len = 0;
-        off = 86;
+        off -= 4;
     } else {
         // keyflags: fixedTPM, fixedParent, sensitiveDatOrigin,
         // userWithAuth, adminWithPolicy, restricted, decrypt
-        keyflags = 0x000300f2;
+        keyflags |= 0x000300b2;
         // symmetric: TPM_ALG_AES, 256bit, TPM_ALG_CFB
-        off = 90;
     }
 
     ret = swtpm_tpm2_createprimary_ecc(self, TPM2_RH_ENDORSEMENT, keyflags,
@@ -1409,9 +1486,11 @@ static int swtpm_tpm2_create_ek(struct swtpm *self, enum keyalgo keyalgo, unsign
 
     switch (keyalgo) {
     case KEYALGO_ECC:
-        ret = swtpm_tpm2_createprimary_ek_ecc_nist_p384(self, allowsigning, decryption, &curr_handle,
-                                                        ektemplate, &ektemplate_len, ekparam,
-                                                        key_description);
+        ret = swtpm_tpm2_createprimary_ek_ecc(self, ekps,
+                                              allowsigning, decryption,
+                                              &curr_handle,
+                                              ektemplate, &ektemplate_len,
+                                              ekparam, key_description);
         break;
     case KEYALGO_RSA:
         ret = swtpm_tpm2_createprimary_ek_rsa(self, keyalgo_param, allowsigning,

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -457,12 +457,15 @@ static const struct swtpm_cops swtpm_cops = {
 #define TPM2_NV_INDEX_ECC_SECP256R1_EKTEMPLATE    0x01c0000b
 #define TPM2_NV_INDEX_ECC_SECP384R1_HI_EKCERT     0x01c00016
 #define TPM2_NV_INDEX_ECC_SECP384R1_HI_EKTEMPLATE 0x01c00017
+#define TPM2_NV_INDEX_ECC_SECP521R1_HI_EKCERT     0x01c00018
+#define TPM2_NV_INDEX_ECC_SECP521R1_HI_EKTEMPLATE 0x01c00019
 
 #define TPM2_EK_RSA_HANDLE           0x81010001
 #define TPM2_EK_RSA3072_HANDLE       0x8101001c
 #define TPM2_EK_RSA4096_HANDLE       0x8101001e
 #define TPM2_EK_ECC_SECP256R1_HANDLE 0x8101000a
 #define TPM2_EK_ECC_SECP384R1_HANDLE 0x81010016
+#define TPM2_EK_ECC_SECP521R1_HANDLE 0x81010018
 #define TPM2_SPK_HANDLE              0x81000001
 
 #define TPM2_DURATION_SHORT      ( 2000 /* ms */ * ARCH_PROCESSING_DELAY_FACTOR)
@@ -498,6 +501,7 @@ static const unsigned char NONCE_RSA3072[2+0x180] = {AS2BE(0x180), 0, };
 static const unsigned char NONCE_RSA4096[2+0x200] = {AS2BE(0x200), 0, };
 static const unsigned char NONCE_ECC_256[2+0x20] = {AS2BE(0x20), 0, };
 static const unsigned char NONCE_ECC_384[2+0x30] = {AS2BE(0x30), 0, };
+static const unsigned char NONCE_ECC_521[2+0x42] = {AS2BE(0x42), 0, };
 
 static const unsigned char PolicyA_SHA256[32] = {
     0x83, 0x71, 0x97, 0x67, 0x44, 0x84, 0xb3, 0xf8, 0x1a, 0x90, 0xcc, 0x8d,
@@ -512,6 +516,17 @@ static const unsigned char PolicyB_SHA384[48] = {
     0xCB, 0x1C, 0x0A, 0xD9, 0xBD, 0xE4, 0x19, 0xCA,
     0xCB, 0x47, 0xBA, 0x09, 0x69, 0x96, 0x46, 0x15,
     0x0F, 0x9F, 0xC0, 0x00, 0xF3, 0xF8, 0x0E, 0x12
+};
+
+static const unsigned char PolicyB_SHA512[64] = {
+    0xB8, 0x22, 0x1C, 0xA6, 0x9E, 0x85, 0x50, 0xA4,
+    0x91, 0x4D, 0xE3, 0xFA, 0xA6, 0xA1, 0x8C, 0x07,
+    0x2C, 0xC0, 0x12, 0x08, 0x07, 0x3A, 0x92, 0x8D,
+    0x5D, 0x66, 0xD5, 0x9E, 0xF7, 0x9E, 0x49, 0xA4,
+    0x29, 0xC4, 0x1A, 0x6B, 0x26, 0x95, 0x71, 0xD5,
+    0x7E, 0xDB, 0x25, 0xFB, 0xDB, 0x18, 0x38, 0x42,
+    0x56, 0x08, 0xB4, 0x13, 0xCD, 0x61, 0x6A, 0x5F,
+    0x6D, 0xB5, 0xB6, 0x07, 0x1A, 0xF9, 0x9B, 0xEA
 };
 
 static const struct bank_to_name {
@@ -586,6 +601,24 @@ static const struct ek_params {
         .keytype = "ECC",
         .nvindex_ekcert = TPM2_NV_INDEX_ECC_SECP384R1_HI_EKCERT,
         .nvindex_template = TPM2_NV_INDEX_ECC_SECP384R1_HI_EKTEMPLATE,
+    }, {
+        .pk = {
+            .keyalgo = KEYALGO_ECC,
+            .keyalgo_param = TPM2_ECC_NIST_P521,
+            .keydescription = "secp521r1",
+            .nonce = NONCE_EMPTY,
+            .nonce_len = sizeof(NONCE_EMPTY),
+            .hashalg = TPM2_ALG_SHA512,
+            .authpolicy = PolicyB_SHA512,
+            .authpolicy_len = sizeof(PolicyB_SHA512),
+            .symkey_len = 256,
+            .duration = TPM2_DURATION_LONG,
+            .keysize = 66,
+        },
+        .ek_handle = TPM2_EK_ECC_SECP521R1_HANDLE,
+        .keytype = "ECC",
+        .nvindex_ekcert = TPM2_NV_INDEX_ECC_SECP521R1_HI_EKCERT,
+        .nvindex_template = TPM2_NV_INDEX_ECC_SECP521R1_HI_EKTEMPLATE,
     }, {
         .pk = {
             .keyalgo = KEYALGO_RSA,
@@ -679,6 +712,19 @@ static const struct spk_params {
             .symkey_len = 256,
             .duration = TPM2_DURATION_LONG,
         },
+    }, {
+        .pk = {
+            .keyalgo = KEYALGO_ECC,
+            .keyalgo_param = TPM2_ECC_NIST_P521,
+            .nonce = NONCE_ECC_521,
+            .nonce_len = sizeof(NONCE_ECC_521),
+            .hashalg = TPM2_ALG_SHA512,
+            .authpolicy = null_authpolicy,
+            .authpolicy_len = 0,
+            .keysize = 66,
+            .symkey_len = 256,
+            .duration = TPM2_DURATION_LONG,
+       },
     }
 };
 
@@ -1431,6 +1477,10 @@ static int swtpm_tpm2_createprimary_ek_ecc(struct swtpm *self, const struct ek_p
         break;
     case TPM2_ECC_NIST_P384:
         off = 0x5a;
+        keyflags = 0x40; // userWithAuth (high range)
+        break;
+    case TPM2_ECC_NIST_P521:
+        off = 0x6a;
         keyflags = 0x40; // userWithAuth (high range)
         break;
     default:

--- a/src/swtpm_setup/swtpm.h
+++ b/src/swtpm_setup/swtpm.h
@@ -48,6 +48,7 @@ enum keyalgo {
 };
 
 /* for keyalgo_param: */
+#define TPM2_ECC_NIST_P256 0x0003
 #define TPM2_ECC_NIST_P384 0x0004
 
 /* TPM 2 specific ops */

--- a/src/swtpm_setup/swtpm.h
+++ b/src/swtpm_setup/swtpm.h
@@ -50,6 +50,7 @@ enum keyalgo {
 /* for keyalgo_param: */
 #define TPM2_ECC_NIST_P256 0x0003
 #define TPM2_ECC_NIST_P384 0x0004
+#define TPM2_ECC_NIST_P521 0x0005
 
 /* TPM 2 specific ops */
 struct swtpm2_ops {

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -95,6 +95,8 @@ static const struct {
     { .name = "rsa4096"      , .keyalgo = KEYALGO_RSA, .keyalgo_param = 4096 },
     { .name = "ecc_nist_p384", .keyalgo = KEYALGO_ECC, .keyalgo_param = TPM2_ECC_NIST_P384 },
     { .name = "secp384r1"    , .keyalgo = KEYALGO_ECC, .keyalgo_param = TPM2_ECC_NIST_P384 },
+    { .name = "ecc_nist_p256", .keyalgo = KEYALGO_ECC, .keyalgo_param = TPM2_ECC_NIST_P256 },
+    { .name = "secp256r1"    , .keyalgo = KEYALGO_ECC, .keyalgo_param = TPM2_ECC_NIST_P256 },
 };
 
 /* initialize the path of the config_file */

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -97,6 +97,8 @@ static const struct {
     { .name = "secp384r1"    , .keyalgo = KEYALGO_ECC, .keyalgo_param = TPM2_ECC_NIST_P384 },
     { .name = "ecc_nist_p256", .keyalgo = KEYALGO_ECC, .keyalgo_param = TPM2_ECC_NIST_P256 },
     { .name = "secp256r1"    , .keyalgo = KEYALGO_ECC, .keyalgo_param = TPM2_ECC_NIST_P256 },
+    { .name = "ecc_nist_p521", .keyalgo = KEYALGO_ECC, .keyalgo_param = TPM2_ECC_NIST_P521 },
+    { .name = "secp521r1"    , .keyalgo = KEYALGO_ECC, .keyalgo_param = TPM2_ECC_NIST_P521 },
 };
 
 /* initialize the path of the config_file */

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -94,6 +94,7 @@ static const struct {
     { .name = "rsa3072"      , .keyalgo = KEYALGO_RSA, .keyalgo_param = 3072 },
     { .name = "rsa4096"      , .keyalgo = KEYALGO_RSA, .keyalgo_param = 4096 },
     { .name = "ecc_nist_p384", .keyalgo = KEYALGO_ECC, .keyalgo_param = TPM2_ECC_NIST_P384 },
+    { .name = "secp384r1"    , .keyalgo = KEYALGO_ECC, .keyalgo_param = TPM2_ECC_NIST_P384 },
 };
 
 /* initialize the path of the config_file */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -87,6 +87,7 @@ TESTS += \
 	test_tpm2_swtpm_bios \
 	\
 	test_tpm2_ibmtss2 \
+	test_tpm2_swtpm_setup_check_certs \
 	test_tpm2_swtpm_setup_overwrite \
 	test_tpm2_swtpm_setup_profile \
 	test_tpm2_swtpm_setup_profile_name \

--- a/tests/test_tpm2_parameters
+++ b/tests/test_tpm2_parameters
@@ -38,6 +38,8 @@ PARAMETERS=(
 	"--ecc --createek --allow-signing --decryption --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --vmid test --display --pwdfile-fd 101 --cipher aes-256-cbc"
 	"--ecc --createek --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --vmid test --lock-nvram"
 	"--profile-name null       --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --ek1keyalgo ecc_nist_p384 --ek2keyalgo ecc_nist_p384"
+	"--profile-name null       --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --ek1keyalgo ecc_nist_p521 --ek2keyalgo secp256r1"
+	"--profile-name null       --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --ek1keyalgo ecc_nist_p256 --ek2keyalgo secp256r1"
 	"--profile-name null       --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --ek1keyalgo rsa2048       --ek2keyalgo rsa3072       --ecc"
 	"--profile-name default-v1 --create-spk --create-ek-cert --create-platform-cert --config ${TESTDIR}/swtpm_setup.conf --ek1keyalgo rsa2048       --ek2keyalgo ecc_nist_p384"
 )

--- a/tests/test_tpm2_swtpm_setup_check_certs
+++ b/tests/test_tpm2_swtpm_setup_check_certs
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+
+# For the license, see the LICENSE file in the root directory.
+
+TOPBUILD=${abs_top_builddir:-$(dirname "$0")/..}
+ROOT=${abs_top_builddir:-$(dirname "$0")/..}
+TESTDIR=${abs_top_testdir:-$(dirname "$0")}
+
+source "${TESTDIR}/common"
+skip_test_no_tpm20 "${SWTPM_EXE}"
+
+WORKDIR="$(mktemp -d)" || exit 1
+
+SWTPM_SERVER_PORT=65490
+SWTPM_CTRL_PORT=65491
+
+PID_FILE=${WORKDIR}/pid
+SIGNINGKEY=${WORKDIR}/signingkey.pem
+ISSUERCERT=${WORKDIR}/issuercert.pem
+CERTSERIAL=${WORKDIR}/certserial
+USER_CERTSDIR=${WORKDIR}/mycerts
+mkdir -p "${USER_CERTSDIR}"
+
+trap "cleanup" SIGTERM EXIT
+
+function cleanup()
+{
+	if [ -n "${SWTPM_PID}" ]; then
+		kill_quiet "${SWTPM_PID}"
+	fi
+	rm -rf "${WORKDIR}"
+}
+
+# We want swtpm_cert to use the local CA and see that the
+# local CA script automatically creates a signingkey and
+# self-signed certificate
+
+cat <<_EOF_ > "${WORKDIR}/swtpm-localca.conf"
+statedir=${WORKDIR}
+signingkey = ${SIGNINGKEY}
+issuercert = ${ISSUERCERT}
+certserial = ${CERTSERIAL}
+_EOF_
+
+cat <<_EOF_ > "${WORKDIR}/swtpm-localca.options"
+--tpm-manufacturer IBM
+--tpm-model swtpm-libtpms
+--tpm-version 2
+--platform-manufacturer "Fedora XYZ"
+--platform-version 2.1
+--platform-model "QEMU A.B"
+_EOF_
+
+export MY_SWTPM_LOCALCA="${SWTPM_LOCALCA}"
+
+cat <<_EOF_ > "${WORKDIR}/swtpm_setup.conf"
+create_certs_tool=\${MY_SWTPM_LOCALCA}
+create_certs_tool_config=${WORKDIR}/swtpm-localca.conf
+create_certs_tool_options=${WORKDIR}/swtpm-localca.options
+profile = {"Name": "default-v2"}
+_EOF_
+
+# We need to adapt the PATH so the correct swtpm_cert is picked
+export PATH=${TOPBUILD}/src/swtpm_cert:${PATH}
+
+function check_cert() {
+	local user_certsdir="$1"
+	local keyalgo="$2"
+	local pattern="$3"
+	local ekfile="$4"
+
+	local output data tmp pubkey1 pubkey2 line1 line2
+
+	case "${keyalgo}" in
+	rsa*)
+		output=$(openssl x509 -inform der -in "${user_certsdir}/ek-${keyalgo}.crt" \
+			-noout -pubkey | openssl pkey -pubin -inform pem -text_pub)
+		;;
+	ecc_nist_p256)
+		output=$(openssl x509 -inform der -in "${user_certsdir}/ek-secp256r1.crt" \
+			-noout -pubkey | openssl pkey -pubin -inform pem -text_pub)
+		;;
+	ecc_nist_p384)
+		output=$(openssl x509 -inform der -in "${user_certsdir}/ek-secp384r1.crt" \
+			-noout -pubkey | openssl pkey -pubin -inform pem -text_pub)
+		;;
+	ecc_nist_p521)
+		output=$(openssl x509 -inform der -in "${user_certsdir}/ek-secp521r1.crt" \
+			-noout -pubkey | openssl pkey -pubin -inform pem -text_pub)
+		;;
+	esac
+
+	if ! grep -q "${pattern}" <<< "${output}"; then
+		echo "Error: Could not find expected pattern '${pattern}' for created ${keyalgo} EK"
+		exit 1
+	fi
+
+	case "${keyalgo}" in
+	rsa*)
+		# get the modulus; it must be found in the file tpm2_createek wrote
+		line1=$(grep -n "Modulus:"<<<"${output}"  | cut -d":" -f1)
+		line2=$(grep -n "Exponent:"<<<"${output}" | cut -d":" -f1)
+		line1=$((line1 + 1))
+		line2=$((line2 - 1))
+		tmp=$(sed -n "${line1},${line2}p" <<< "${output}" | tr -d "\n: ")
+		pubkey1=${tmp:2}
+		;;
+	ecc_nist_p256)
+		# get the coordinates; skip leading 04 and split x and y coordinates
+		line1=$(grep -n "pub:"<<<"${output}"  | cut -d":" -f1)
+		line2=$(grep -n "ASN1 OID: "<<<"${output}" | cut -d":" -f1)
+		line1=$((line1 + 1))
+		line2=$((line2 - 1))
+		tmp=$(sed -n "${line1},${line2}p" <<< "${output}" | tr -d "\n: ")
+		pubkey1="${tmp:2:64}"
+		pubkey2="${tmp:66:64}"
+		;;
+	ecc_nist_p384)
+		# get the coordinates; skip leading 04 and split x and y coordinates
+		line1=$(grep -n "pub:"<<<"${output}"  | cut -d":" -f1)
+		line2=$(grep -n "ASN1 OID: "<<<"${output}" | cut -d":" -f1)
+		line1=$((line1 + 1))
+		line2=$((line2 - 1))
+		tmp=$(sed -n "${line1},${line2}p" <<< "${output}" | tr -d "\n: ")
+		pubkey1="${tmp:2:96}"
+		pubkey2="${tmp:98:96}"
+		;;
+	ecc_nist_p521)
+		# get the coordinates; skip leading 04 and split x and y coordinates
+		line1=$(grep -n "pub:"<<<"${output}"  | cut -d":" -f1)
+		line2=$(grep -n "ASN1 OID: "<<<"${output}" | cut -d":" -f1)
+		line1=$((line1 + 1))
+		line2=$((line2 - 1))
+		tmp=$(sed -n "${line1},${line2}p" <<< "${output}" | tr -d "\n: ")
+		pubkey1="${tmp:2:132}"
+		pubkey2="${tmp:134:132}"
+		;;
+	esac
+
+	if [ -n "${ekfile}" ] && [ -r "${ekfile}" ]; then
+		data=$(od -tx1 -A n < "${ekfile}" |tr -d "\n ")
+		if ! grep -q "${pubkey1}" <<< "${data}"; then
+			echo "Error: Could not find public ${keyalgo} key in file that tpm2_createek wrote."
+			echo "public key  : ${pubkey1}"
+			echo "file content: ${data}"
+			exit 1
+		fi
+		echo "INFO: tpm2_createek created same ${keyalgo} key (length: $((${#pubkey1}/2)))"
+		if [ -n "${pubkey2}" ]; then
+			if ! grep -q "${pubkey2}" <<< "${data}"; then
+				echo "Error: Could not find public ${keyalgo} key (y coordinate) in file that tpm2_createek wrote."
+				echo "y-coordinate: ${pubkey2}"
+				echo "file content: ${data}"
+				exit 1
+			fi
+			echo "INFO: tpm2_createek created same ${keyalgo} EK (y-coordinate) (length: $((${#pubkey1}/2)))"
+		fi
+	fi
+}
+
+function swtpm_setup_run() {
+	local workdir="$1"
+	local user_certsdir="$2"
+	local tpm2_createek="$3"
+	local ek1keyalgo="$4"
+	local ek1pattern="$5"
+	local ek2keyalgo="$6"
+	local ek2pattern="$7"
+
+	local ek1file ek2file
+
+	rm -f "${user_certsdir}/"*
+
+	echo "INFO: Testing with ${ek1keyalgo} and ${ek2keyalgo}"
+
+	if ! ${SWTPM_SETUP} \
+		--tpm2 \
+		--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}" \
+		--tpmstate "${workdir}" \
+		--create-ek-cert \
+		--create-platform-cert \
+		--config "${workdir}/swtpm_setup.conf" \
+		--logfile "${workdir}/logfile" \
+		--tpm "${SWTPM_EXE} socket ${SWTPM_TEST_SECCOMP_OPT}" \
+		--overwrite \
+		--ek1keyalgo "${ek1keyalgo}" \
+		--ek2keyalgo "${ek2keyalgo}" \
+		--write-ek-cert-files "${user_certsdir}";
+	then
+		echo "Error: Could not run $SWTPM_SETUP."
+		echo "Logfile output:"
+		cat "${workdir}/logfile"
+		exit 1
+	fi
+
+	if [ -n "${tpm2_createek}" ]; then
+		ek1file="${workdir}/ek1"
+		ek2file="${workdir}/ek2"
+		ek1ctx="${workdir}/ek1ctx"
+		ek2ctx="${workdir}/ek2ctx"
+
+		rm -f "${ek1file}" "${ek2file}" "${ek1ctx}" "${ek2ctx}"
+
+		run_swtpm socket+socket \
+			--tpm2 \
+			--tpmstate dir="${workdir}" \
+			--flags not-need-init,startup-clear \
+			--log "file=${workdir}/logfile" \
+			--pid "file=${PID_FILE}"
+		if wait_for_file "${PID_FILE}" 3; then
+			echo "Error: Socket TPM did not write pidfile."
+			exit 1
+		fi
+		if [[ ${ek1keyalgo} =~ ^(ecc_nist_p256|ecc_nist_p384|ecc_nist_p521|rsa2048|rsa3072|rsa4096)$ ]]; then
+			if ! tpm2_createek -T "swtpm:host=localhost,port=${SWTPM_SERVER_PORT}" \
+				-G "${ek1keyalgo}" -u "${ek1file}" -c "${ek1ctx}"; then
+				ek1file=""
+			fi
+		fi
+		if [[ ${ek2keyalgo} =~ ^(ecc_nist_p256|ecc_nist_p384|ecc_nist_p521|rsa2048|rsa3072|rsa4096)$ ]]; then
+			if ! tpm2_createek -T "swtpm:host=localhost,port=${SWTPM_SERVER_PORT}" \
+				-G "${ek2keyalgo}" -u "${ek2file}" -c "${ek2ctx}"; then
+				ek2file=""
+			fi
+		fi
+
+		kill -SIGTERM "${SWTPM_PID}"
+		if wait_process_gone "${SWTPM_PID}" 4; then
+			echo "Error: SWTPM did not terminate on SIGTERM."
+			exit 1
+		fi
+	fi
+
+	check_cert "${user_certsdir}" "${ek1keyalgo}" "${ek1pattern}" "${ek1file}"
+	check_cert "${user_certsdir}" "${ek2keyalgo}" "${ek2pattern}" "${ek2file}"
+}
+
+TPM2_CREATEEK=$(type -P tpm2_createek)
+if [ -n "${TPM2_CREATEEK}" ]; then
+	echo -e "INFO: Will use ${TPM2_CREATEEK} to compare created EKs.\n"
+fi
+
+swtpm_setup_run "${WORKDIR}" "${USER_CERTSDIR}" "${TPM2_CREATEEK}" \
+	"rsa2048" "Public-Key: (2048 bit)" \
+	"ecc_nist_p256" "Public-Key: (256 bit)"
+echo -e "Test 1: OK\n"
+
+swtpm_setup_run "${WORKDIR}" "${USER_CERTSDIR}" "${TPM2_CREATEEK}" \
+	"ecc_nist_p384" "Public-Key: (384 bit)" \
+	"ecc_nist_p521" "Public-Key: (521 bit)"
+echo -e "Test 2: OK\n"
+
+swtpm_setup_run "${WORKDIR}" "${USER_CERTSDIR}" "${TPM2_CREATEEK}" \
+	"rsa3072" "Public-Key: (3072 bit)" \
+	"rsa4096" "Public-Key: (4096 bit)"
+echo -e "Test 3: OK\n"
+
+exit 0


### PR DESCRIPTION
Introduce secp384r1 as an alias to ecc_nist_p384 and add support for creating secp256r1 and secp521r1 EKs. Add a test case using the Intel TSS2 tpm2_createek to create the EKs and compare the results of this tool against the EK public key found in certificates.