### PR TITLE
Remove last usage of certtool and remove dependency on gnutls packages

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -200,26 +200,6 @@ AS_CASE([$host_os],
 AM_CONDITIONAL([WITH_CHARDEV],[test "$with_chardev" = "yes"])
 AC_MSG_RESULT($with_chardev)
 
-AC_ARG_WITH([gnutls],
-            AS_HELP_STRING([--with-gnutls],[build with gnutls library]),
-            [],
-            [with_gnutls=check]
-)
-
-dnl certtool changed how it takes private key passwords
-dnl 3.3.29 is too old (RHEL 7); we need at least gnutls 3.4.0
-
-AS_IF([test "x$with_gnutls" != "xno"],[
-    AC_PATH_PROG([GNUTLS_CERTTOOL], certtool)
-    AS_IF([test "x$GNUTLS_CERTTOOL" = "x" && test "x$with_gnutls" = "xyes"],
-        [AC_MSG_ERROR("Could not find certtool. Is gnutls-utils/gnutls-bin installed?")],
-        [test "x$GNUTLS_CERTTOOL" = "x"],
-        [with_gnutls=no]
-    )
-    AS_IF([test "x$with_gnutls" != "xno"],[with_gnutls="yes"])
-])
-AM_CONDITIONAL([WITH_GNUTLS], [test "x$with_gnutls" = "xyes"])
-
 DEFAULT_PCR_BANKS="sha256"
 AC_ARG_ENABLE([default-pcr-banks],
               AS_HELP_STRING(

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,6 @@ Build-Depends: debhelper (>= 10),
                dh-apparmor,
                dh-sequence-installsysusers,
                gawk,
-               gnutls-bin,
                libfuse-dev,
                libglib2.0-dev,
                libgmp-dev,
@@ -63,7 +62,6 @@ Description: Tools for the TPM emulator
       tool basically simulates TPM manufacturing where certificates are
       written into the NVRAM of the TPM
   - swtpm_cert: Creation of certificates for the TPM (x509)
-Depends: gnutls-bin,
-         swtpm (= ${binary:Version}),
+Depends: swtpm (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}

--- a/man/man8/swtpm-create-tpmca.pod
+++ b/man/man8/swtpm-create-tpmca.pod
@@ -41,9 +41,6 @@ Overwrite the contents of the output directory.
 
 The new signing key will get this password.
 
-Note: Due to a bug in GnuTLS certtool it may be necessary to use the
-same password for the signing key as for the SRK.
-
 =item B<--outfile filename>
 
 The name of a file where to write the swtpm-localca.conf configuration

--- a/run_tests
+++ b/run_tests
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ $(uname -p) != "x86_64" ]; then
+if [ $(uname -m) != "x86_64" ]; then
  echo "This test only runs on x86_64 host"
  exit 1
 fi
@@ -16,7 +16,7 @@ WITHOUT_CUSE="--without-cuse"
 # doesn't behave as it does with 64bit. test_hashing2 gets stuck.
 
 
-CFLAGS='-m64' ./configure --with-openssl --with-gnutls --prefix=/usr --libdir=/lib64 ${WITHOUT_CUSE} && \
+CFLAGS='-m64' ./configure --with-openssl --prefix=/usr --libdir=/lib64 ${WITHOUT_CUSE} && \
  make clean && \
  make -j$(nproc) &&
  sudo make -j$(nproc) install &&
@@ -29,7 +29,7 @@ if [ -z "${WITHOUT_CUSE}" ]; then
 fi
 
 PKG_CONFIG_PATH=/usr/lib/pkgconfig \
- CFLAGS='-m32' ./configure --with-openssl --with-gnutls --prefix=/usr --libdir=/lib ${WITHOUT_CUSE} && \
+ CFLAGS='-m32' ./configure --with-openssl --prefix=/usr --libdir=/lib ${WITHOUT_CUSE} && \
  make clean && \
  make -j$(nproc) &&
  sudo make -j$(nproc) install &&
@@ -42,7 +42,7 @@ if [ -z "${WITHOUT_CUSE}" ]; then
  exit 1
 fi
 
-CFLAGS='-m64' ./configure --with-openssl --with-gnutls --prefix=/usr --libdir=/lib64 ${WITHOUT_CUSE} && \
+CFLAGS='-m64' ./configure --with-openssl --prefix=/usr --libdir=/lib64 ${WITHOUT_CUSE} && \
  make clean && \
  make -j$(nproc) &&
  SWTPM_EXE=/tmp/swtpm32 make -j$(nproc) check ||

--- a/samples/swtpm-create-tpmca
+++ b/samples/swtpm-create-tpmca
@@ -34,6 +34,29 @@ function get_filesize()
 	fi
 }
 
+# Get the OpenSSL provider path for the given module searching a few well-known
+# paths.
+function get_provider_path()
+{
+	local module="$1"
+
+	local p
+
+	for p in \
+		"/usr/lib64/ossl-modules" \
+		"/usr/lib/ossl-modules" \
+		"/usr/lib/$(uname -m)-linux-gnu/ossl-modules";
+	do
+		if [ -r "${p}/${module}" ]; then
+			echo "${p}"
+			return 0
+		fi
+	done
+
+	logerr "Could not find OpenSSL provider path for ${module} module."
+	return 1
+}
+
 # Create a config value by escaping the proper characters
 #
 # @param 1: The string to escape
@@ -55,42 +78,37 @@ create_localca_cert() {
 	local tpmkey=${dir}/swtpm-localca-tpmca-privkey.pem
 	local tpmpubkey=${dir}/swtpm-localca-tpmca-pubkey.pem
 	local tpmca=${dir}/swtpm-localca-tpmca-cert.pem
-	local template=${dir}/template
+	local pinfile=${dir}/pin
+	local passfile=${dir}/password
 	local tpmkeyurl
-	local msg output
+	local msg output providerpath
+
+	export SWTPM_ROOTCA_PASSWORD
 
 	if ! [ -r "${cakey}" ] || ! [ -r "${cacert}" ]; then
-		if ! msg=$("${CERTTOOL}" \
-			--generate-privkey \
-			${SWTPM_ROOTCA_PASSWORD:+--password "${SWTPM_ROOTCA_PASSWORD}"} \
-			--outfile "${cakey}" \
-			2>&1);
-		then
-			logerr "Could not create root-CA key ${cakey}."
-			logerr "${msg}"
-			return 1
-		fi
-		chmod 640 "${cakey}"
-
-		{
-			echo "cn=swtpm-localca-rootca"
-			echo "ca"
-			echo "cert_signing_key"
-			echo "expiration_days = 3650"
-		} > "${template}"
-
-		if ! msg=$(GNUTLS_PIN="${SWTPM_ROOTCA_PASSWORD}" ${CERTTOOL} \
-			--generate-self-signed \
-			--template "${template}" \
-			--outfile "${cacert}" \
-			--load-privkey "${cakey}" \
+		# shellcheck disable=2086
+		if ! msg=$(openssl \
+			req \
+			-x509 \
+			-keyout "${cakey}" \
+			-newkey rsa:3072 \
+			${SWTPM_ROOTCA_PASSWORD:+-passout "env:SWTPM_ROOTCA_PASSWORD"} \
+			${SWTPM_ROOTCA_PASSWORD:--noenc} \
+			-out "${cacert}" \
+			-days 36500 \
+			-sha256 \
+			-subj "/CN=swtpm-localca-rootca" \
+			-addext "basicConstraints=critical,CA:TRUE" \
+			-addext "keyUsage=critical,keyCertSign" \
 			2>&1);
 		then
 			logerr "Could not create root CA."
 			logerr "${msg}"
-			rm -f "${cakey}" "${template}"
+			rm -f "${cakey}" "${passfile}"
 			return 1
 		fi
+		chmod 640 "${cakey}"
+		rm -f "${passfile}"
 	else
 		logit "Reusing existing root CA"
 	fi
@@ -189,31 +207,38 @@ create_localca_cert() {
 		return 1
 	fi
 
-	{
-		echo "cn=swtpm-localca"
-		echo "ca"
-		echo "cert_signing_key"
-		echo "expiration_days = 3650"
-	} > "${template}"
+	if ! providerpath=$(get_provider_path "pkcs11.so"); then
+		return 1
+	fi
 
-	if ! msg=$(${CERTTOOL} \
-		--generate-certificate \
-		--template "${template}" \
-		--outfile "${tpmca}" \
-		--load-ca-privkey "${cakey}" \
-		--load-ca-certificate "${cacert}" \
-		--load-privkey "${tpmkeyurl}" \
-		--load-pubkey "${tpmpubkey}" \
+	# Write any PIN into a PIN file
+	echo "${SWTPM_PKCS11_PIN}" > "${pinfile}"
+	if ! msg=$(openssl \
+		req \
+		-provider-path "${providerpath}" \
+		-provider pkcs11 \
+		-x509 \
+		-key "${tpmkeyurl//%00/}${SWTPM_PKCS11_PIN:+?pin-source=${pinfile}}" \
+		-out "${tpmca}" \
+		-days 36500 \
+		-sha256 \
+		-CA "${cacert}" \
+		-CAkey "${cakey}" \
+		${SWTPM_ROOTCA_PASSWORD:+-passin "env:SWTPM_ROOTCA_PASSWORD"} \
+		-subj "/CN=swtpm-localca" \
+		-addext "basicConstraints=critical,CA:TRUE" \
+		-addext "keyUsage=critical,keyCertSign" \
 		2>&1);
 	then
 		logerr "Could not create TPM CA"
 		logerr "${msg}"
-		rm -f "${template}"
+		rm -f "${pinfile}"
 		return 1
 	fi
+	rm -f "${pinfile}"
 
 	output="statedir = ${dir}
-signingkey = $(escape_pkcs11_url "${tpmkeyurl}" | sed 's/%00//g')
+signingkey = $(escape_pkcs11_url "${tpmkeyurl//%00/}")
 issuercert = ${tpmca}
 certserial = ${dir}/certserial"
 
@@ -241,8 +266,6 @@ certserial = ${dir}/certserial"
 			chown "${owner}:${group}" "${outfile}"
 		fi
 	fi
-
-	rm -f "${template}"
 
 	return 0
 } #create_localca_cert
@@ -290,8 +313,6 @@ main() {
 	local flags=0
 	local dir outfile owner group msg pid
 	local algorithm="rsa2048"
-
-	CERTTOOL=certtool
 
 	while [ $# -ne 0 ]; do
 		case "$1" in

--- a/swtpm.spec
+++ b/swtpm.spec
@@ -1,5 +1,4 @@
 # spec file for RHEL/CentOS and Fedora
-%bcond_without gnutls
 
 # Macros needed by SELinux
 %global selinuxtype targeted
@@ -26,12 +25,8 @@ BuildRequires:  openssl
 BuildRequires:  pkcs11-provider
 BuildRequires:  socat
 BuildRequires:  softhsm
-%if %{with gnutls}
-BuildRequires:  gnutls >= 3.4.0
-BuildRequires:  gnutls-utils
 BuildRequires:  libtasn1-devel
 BuildRequires:  libtasn1
-%endif
 BuildRequires:  selinux-policy-devel
 BuildRequires:  gcc
 BuildRequires:  libseccomp-devel
@@ -64,7 +59,7 @@ Include files for the TPM emulator's CUSE interface.
 Summary:        Tools for the TPM emulator
 License:        BSD-3-Clause
 Requires:       swtpm = %{version}-%{release}
-Requires:       bash gnutls-utils
+Requires:       bash
 
 %description    tools
 Tools for the TPM emulator from the swtpm package
@@ -104,9 +99,6 @@ Installed swtpm tests
 
 NOCONFIGURE=1 ./autogen.sh
 %configure \
-%if %{with gnutls}
-        --with-gnutls \
-%endif
         --without-cuse
 
 %make_build
@@ -169,9 +161,7 @@ fi
 %files tools
 %doc README
 %{_bindir}/swtpm_bios
-%if %{with gnutls}
 %{_bindir}/swtpm_cert
-%endif
 %{_bindir}/swtpm_setup
 %{_bindir}/swtpm_ioctl
 %{_bindir}/swtpm_localca

--- a/swtpm.spec.in
+++ b/swtpm.spec.in
@@ -1,5 +1,4 @@
 # spec file for RHEL/CentOS and Fedora
-%bcond_without gnutls
 
 # Macros needed by SELinux
 %global selinuxtype targeted
@@ -26,12 +25,8 @@ BuildRequires:  openssl
 BuildRequires:  pkcs11-provider
 BuildRequires:  socat
 BuildRequires:  softhsm
-%if %{with gnutls}
-BuildRequires:  gnutls >= 3.4.0
-BuildRequires:  gnutls-utils
 BuildRequires:  libtasn1-devel
 BuildRequires:  libtasn1
-%endif
 BuildRequires:  selinux-policy-devel
 BuildRequires:  gcc
 BuildRequires:  libseccomp-devel
@@ -64,7 +59,7 @@ Include files for the TPM emulator's CUSE interface.
 Summary:        Tools for the TPM emulator
 License:        BSD-3-Clause
 Requires:       swtpm = %{version}-%{release}
-Requires:       bash gnutls-utils
+Requires:       bash
 
 %description    tools
 Tools for the TPM emulator from the swtpm package
@@ -104,9 +99,6 @@ Installed swtpm tests
 
 NOCONFIGURE=1 ./autogen.sh
 %configure \
-%if %{with gnutls}
-        --with-gnutls \
-%endif
         --without-cuse
 
 %make_build
@@ -169,9 +161,7 @@ fi
 %files tools
 %doc README
 %{_bindir}/swtpm_bios
-%if %{with gnutls}
 %{_bindir}/swtpm_cert
-%endif
 %{_bindir}/swtpm_setup
 %{_bindir}/swtpm_ioctl
 %{_bindir}/swtpm_localca

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,9 +15,8 @@ if ENABLE_TESTS
 
 TESTS = \
 	test_vtpm_proxy \
-	test_tpm2_vtpm_proxy
-
-TESTS += \
+	test_tpm2_vtpm_proxy \
+	\
 	test_commandline \
 	test_ctrlchannel \
 	test_ctrlchannel2 \
@@ -37,6 +36,8 @@ TESTS += \
 	test_setbuffersize \
 	test_volatilestate \
 	test_swtpm_bios \
+	test_swtpm_cert \
+	test_swtpm_setup_create_cert \
 	test_tpm_probe \
 	test_tpm12 \
 	test_wrongorder \
@@ -45,9 +46,8 @@ TESTS += \
 	test_print_states \
 	test_swtpm_setup_overwrite \
 	test_swtpm_setup_file_backend \
-	test_swtpm_setup_misc
-
-TESTS += \
+	test_swtpm_setup_misc \
+	\
 	test_tpm2_avoid_da_lockout \
 	test_tpm2_chroot_socket \
 	test_tpm2_chroot_chardev \
@@ -64,11 +64,13 @@ TESTS += \
 	test_tpm2_hashing2 \
 	test_tpm2_hashing3 \
 	test_tpm2_migration_key \
+	test_tpm2_parameters \
 	test_tpm2_partial_reads \
 	test_tpm2_pcap \
 	test_tpm2_print_capabilities \
 	test_tpm2_print_states \
 	test_tpm2_resume_volatile \
+	test_tpm2_samples_create_tpmca.test \
 	test_tpm2_savestate \
 	test_tpm2_save_load_encrypted_state \
 	test_tpm2_save_load_state \
@@ -79,6 +81,11 @@ TESTS += \
 	test_tpm2_save_load_state_da_timeout \
 	test_tpm2_save_load_state_locking \
 	test_tpm2_setbuffersize \
+	test_tpm2_swtpm_cert \
+	test_tpm2_swtpm_cert_ecc \
+	test_tpm2_swtpm_localca \
+	test_tpm2_swtpm_localca_pkcs11.test \
+	test_tpm2_swtpm_setup_create_cert \
 	test_tpm2_volatilestate \
 	test_tpm2_wrongorder \
 	test_tpm2_probe \
@@ -93,19 +100,6 @@ TESTS += \
 	test_tpm2_swtpm_setup_profile_name \
 	test_tpm2_libtpms_versions_profiles
 
-if WITH_GNUTLS
-TESTS += \
-	test_swtpm_cert \
-	test_swtpm_setup_create_cert \
-	test_tpm2_parameters \
-	test_tpm2_samples_create_tpmca.test
-	test_tpm2_swtpm_cert \
-	test_tpm2_swtpm_cert_ecc \
-	test_tpm2_swtpm_localca \
-	test_tpm2_swtpm_localca_pkcs11.test \
-	test_tpm2_swtpm_setup_create_cert
-
-endif # WITH_GNUTLS
 endif # ENABLE_TESTS
 
 TEST_UTILS = \

--- a/tests/test_tpm2_samples_create_tpmca.test
+++ b/tests/test_tpm2_samples_create_tpmca.test
@@ -25,6 +25,11 @@ if ! tpm2_ptool | grep -q ",config,"; then
 	exit 77
 fi
 
+if [ -z "$(type -P p11tool)" ]; then
+	echo "This test requires p11tool from gnutls-utils/gnutls-bin to be installed"
+	exit 77
+fi
+
 if [ -z "$(type -P tpm2-abrmd)" ]; then
 	echo "Could not find tpm2-abrmd in PATH"
 	exit 77


### PR DESCRIPTION
Switch from certtool usage to openssl CLI tool usage in swtpm-create-tpmca and clean up the dependency on gnutls-utils/gnutls-bin. Keep it for CI so that the pkcs11 test could run there (currently not) but remove it from the build system as a hard dependency and where possible from the rpm and debian packages.