### PR TITLE
debian/rpm: Add openssl as dependent package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -62,6 +62,7 @@ Description: Tools for the TPM emulator
       tool basically simulates TPM manufacturing where certificates are
       written into the NVRAM of the TPM
   - swtpm_cert: Creation of certificates for the TPM (x509)
-Depends: swtpm (= ${binary:Version}),
+Depends: openssl,
+         swtpm (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}

--- a/swtpm.spec
+++ b/swtpm.spec
@@ -59,7 +59,7 @@ Include files for the TPM emulator's CUSE interface.
 Summary:        Tools for the TPM emulator
 License:        BSD-3-Clause
 Requires:       swtpm = %{version}-%{release}
-Requires:       bash
+Requires:       bash openssl
 
 %description    tools
 Tools for the TPM emulator from the swtpm package
@@ -69,7 +69,7 @@ Summary:        Tools for creating a local CA based on a pkcs11 device
 License:        BSD-3-Clause
 Requires:       swtpm-tools = %{version}-%{release}
 Requires:       tpm2-pkcs11 tpm2-pkcs11-tools tpm2-tools tpm2-abrmd
-Requires:       gnutls-utils
+Requires:       gnutls-utils openssl
 
 %description    tools-pkcs11
 Tools for creating a local CA based on a pkcs11 device

--- a/swtpm.spec.in
+++ b/swtpm.spec.in
@@ -59,7 +59,7 @@ Include files for the TPM emulator's CUSE interface.
 Summary:        Tools for the TPM emulator
 License:        BSD-3-Clause
 Requires:       swtpm = %{version}-%{release}
-Requires:       bash
+Requires:       bash openssl
 
 %description    tools
 Tools for the TPM emulator from the swtpm package
@@ -69,7 +69,7 @@ Summary:        Tools for creating a local CA based on a pkcs11 device
 License:        BSD-3-Clause
 Requires:       swtpm-tools = %{version}-%{release}
 Requires:       tpm2-pkcs11 tpm2-pkcs11-tools tpm2-tools tpm2-abrmd
-Requires:       gnutls-utils
+Requires:       gnutls-utils openssl
 
 %description    tools-pkcs11
 Tools for creating a local CA based on a pkcs11 device


### PR DESCRIPTION
swtpm_localca and swtpm-create-tpmca now depend on openssl command line tool, so add it as a dependency for the swtpm-tools and swtpm-tools-pkcs11 packages.