### PR TITLE
Query for the buffer size of the TPM 2 in libtpms v0.11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -144,7 +144,7 @@ AS_IF([test "$OPENSSL_CLITOOL" != "yes"],
 
 PKG_CHECK_MODULES([LIBTASN1],[libtasn1])
 
-PKG_CHECK_MODULES([LIBTPMS],[libtpms >= 0.10])
+PKG_CHECK_MODULES([LIBTPMS],[libtpms >= 0.11])
 
 
 AC_CHECK_LIB(c, clock_gettime, LIBRT_LIBS="", LIBRT_LIBS="-lrt")

--- a/src/swtpm/mainloop.c
+++ b/src/swtpm/mainloop.c
@@ -135,6 +135,9 @@ int mainLoop(struct mainLoopParams *mlp, int notify_fd, bool tpm_running)
     uint32_t            ack = htobe32(0);
     struct tpm2_resp_prefix respprefix;
     uint32_t            lastCommand;
+    enum TPMLIB_TPMProperty prop = (mlp->tpmversion == TPMLIB_TPM_VERSION_1_2)
+        ? TPMPROP_TPM_BUFFER_MAX
+        : TPMPROP_TPM2_BUFFER_MAX;
 
     /* poolfd[] indexes */
     enum {
@@ -147,7 +150,7 @@ int mainLoop(struct mainLoopParams *mlp, int notify_fd, bool tpm_running)
 
     TPM_DEBUG("mainLoop:\n");
 
-    max_command_length = tpmlib_get_tpm_property(TPMPROP_TPM_BUFFER_MAX) +
+    max_command_length = tpmlib_get_tpm_property(prop) +
                          sizeof(struct tpm2_send_command_prefix);
 
     command = malloc(max_command_length);


### PR DESCRIPTION
Introduce a hard dependency on libtpms v0.11, which will be needed for PQC support. Query the TPM 2's buffer size using the new TPMPROP_TPM2_BUFFER_MAX introduced in libtpms v.0.11. For now it's 4kb but will become 8kb once PQC enablement is there.