### PR TITLE
Sync permanent state blob upon GET_STATEBLOB cmd

### DIFF
--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -175,6 +175,9 @@ static int ctrlchannel_return_state(ptm_getstate *pgs, int fd,
     if (!blobname)
         res = TPM_FAIL;
 
+    if (res == 0 && blobtype == PTM_BLOB_TYPE_PERMANENT)
+        res = SWTPM_NVRAM_Store_Permanent();
+
     if (res == 0 && blobtype == PTM_BLOB_TYPE_VOLATILE)
         res = SWTPM_NVRAM_Store_Volatile();
 

--- a/src/swtpm/swtpm_nvstore.c
+++ b/src/swtpm/swtpm_nvstore.c
@@ -481,6 +481,37 @@ TPM_RESULT SWTPM_NVRAM_Store_Volatile(void)
     return rc;
 }
 
+/*
+ * Flush libtpms's in-memory PERMANENT state to disk so that the next
+ * SWTPM_NVRAM_GetStateBlob(PERMANENT) returns a blob consistent with what
+ * libtpms is actually running. Counterpart to SWTPM_NVRAM_Store_Volatile().
+ *
+ * Without this, GET_STATEBLOB(PERMANENT) on the migration-out path reads a
+ * file that may be missing, empty, or stale relative to libtpms RAM (the
+ * file is only written by _plat__NvCommit() on UT_NV-class commands), and
+ * an empty/short-read blob then poisons the destination's state restore.
+ */
+TPM_RESULT SWTPM_NVRAM_Store_Permanent(void)
+{
+    TPM_RESULT     rc = 0;
+    char           *name = TPM_PERMANENT_ALL_NAME;
+    uint32_t       tpm_number = 0;
+    unsigned char  *buffer = NULL;
+    uint32_t       buflen = 0;
+
+    TPM_DEBUG(" SWTPM_Store_Permanent: Name %s\n", name);
+    if (rc == 0) {
+        rc = TPMLIB_GetState(TPMLIB_STATE_PERMANENT, &buffer, &buflen);
+    }
+    if (rc == 0 && buflen > 0) {
+        rc = SWTPM_NVRAM_StoreData(buffer, buflen, tpm_number, name);
+    }
+
+    free(buffer);
+
+    return rc;
+}
+
 static TPM_RESULT
 SWTPM_NVRAM_KeyParamCheck(uint32_t keylen,
                           enum encryption_mode encmode)

--- a/src/swtpm/swtpm_nvstore.h
+++ b/src/swtpm/swtpm_nvstore.h
@@ -69,6 +69,7 @@ TPM_RESULT SWTPM_NVRAM_DeleteName(uint32_t tpm_number,
 				  const char *name,
                                   TPM_BOOL mustExist);
 TPM_RESULT SWTPM_NVRAM_Store_Volatile(void);
+TPM_RESULT SWTPM_NVRAM_Store_Permanent(void);
 
 TPM_RESULT SWTPM_NVRAM_Set_FileKey(const unsigned char *data,
                                    uint32_t length,


### PR DESCRIPTION
We've seen a live migration failure in production, with Win2k25 guest, with the following symptoms:

QEMU dest log:
```
qemu-kvm: tpm-emulator: Setting the stateblob (type 2) failed with a TPM error 0x800
qemu-kvm: error while loading state for instance 0x0 of device 'tpm-emulator'
qemu-kvm: load of migration failed: Input/output error
```

swtpm dest log:
```
main: Initializing TPM at Fri May  1 14:04:10 2026                              
mainLoop:                                                                       
SWTPM_NVRAM_Validate_Dir: Rooted state path /path/to/shared/storage             
SWTPM_NVRAM_Validate_Dir: Rooted state path /path/to/shared/storage             
SWTPM_NVRAM_LoadData: No such file /path/to/shared/storage/tpm2-00.permall                                                                                     
Data client disconnected 
```

The root cause is not perfectly clear, either orchestration layer left the blob out of sync, or some kind of storage error occured when the blob was initially written on the src node.  Either way, I suggest an additional sync for the permanent state blob as a potential workaround for such errors, similar to how it's done with volatile state.