### PR TITLE
[2] Enable swtpm_cert to create certificates for ML-KEM and ML-DSA keys

### DIFF
--- a/man/man8/swtpm_cert.pod
+++ b/man/man8/swtpm_cert.pod
@@ -49,6 +49,18 @@ If this option is not given, secp256r1 is assumed.
 
 The exponent of the public key. By default 0x10001 is assumed.
 
+=item B<--public <hex digits>>
+
+The public key provided as hex digits. This option can be used for ML-KEM
+or ML-DSA keys. This option requires the B<--keyalgo> option to describe the
+algorithm of the key.
+
+=item B<--keyalgo <algorithm of key>>
+
+This option describes the key algorithm provided with the B<--public> option.
+This may be either one of ml-kem-512, ml-kem-768, ml-kem-1024, ml-dsa-44,
+ml-dsa-65, or ml-dsa-87.
+
 =item B<--signkey <filename>>
 
 The key used for signing the certificate. The file must be in PEM format.
@@ -152,7 +164,9 @@ The output may contain the following:
       "features": [
         "cmdarg-signkey-pwd",
         "cmdarg-tpm-serial-num",
-        "supports-iak-idevid"
+        "supports-iak-idevid",
+        "cmdarg-public",
+        "cmdarg-keyalgo"
       ],
       "version": "0.11.0"
     }
@@ -174,6 +188,16 @@ The I<--tpm-serial-num> option is supported.
 =item B<supports-iak-idevid> (since v0.11)
 
 Creation of IAK and IDevID certificates is supported.
+
+=item B<cmdarg-public>
+
+The I<--public> option is supported and ML-KEM and ML-DSA keys can
+be certified.
+
+=item B<cmdarg-keyalgo>
+
+The I<--keyalgo> option is supported and ML-KEM and ML-DSA keys can
+be certified.
 
 =back
 

--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -497,6 +497,27 @@ Display the help screen
 
 =back
 
+=head1 CA Keys
+
+It is recommended to use RSA or EC keys, such as RSA-3072/4096,
+secp256/384/521r1, or Ed25519/448 keys, for signing EK and platform
+certificates B<if> users may choose to create swtpm instances with the NULL
+or default-v1 profiles and therefore have only 2kb NVRAM spaces available
+for storing certificates.
+
+swtpm_cert can sign EK and platform certificates with an ML-DSA key.
+However, it is only recommended to setup a CA with ML-DSA keys if swtpm
+will only be used with the default-v2 or a later profile since the certificates
+created with an ML-DSA signing key are substantially larger than what
+previous versions of swtpm profiles allowed to store in NVRAM spaces.
+Older profiles (specifically those supporting StateFormatLevel less than
+'12') only allowed to store up to 2kb in an NVRAM space. This has been
+increased to 10kb, which allows to sign a certificate for an ML-DSA
+(signing) EK with a CA that uses an ML-DSA signing key.
+
+Note that for TPM 1.2 certificates a signing scheme must be used that can sign
+a SHA1.
+
 =head1 EXAMPLE USAGE
 
 To simulate manufacturing of a TPM, one would typically run the following command:

--- a/src/swtpm_cert/ek-cert.c
+++ b/src/swtpm_cert/ek-cert.c
@@ -203,6 +203,8 @@ static void usage(const char *prg)
         "--ecc-y <hex string>      : ECC key y component\n"
         "--ecc-curveid <id>        : ECC curve id; secp256r1, secp384r1, secp521r1\n"
         "                            default: secp256r1\n"
+        "--public <hex string>     : Public key component for ML-KEM keys\n"
+        "--keyalgo <name>          : ml-kem-512, ml-kem-768, or ml-kem-1024\n"
         "--serial <serial number>  : The certificate serial number\n"
         "--days <number>           : Number of days the cert is valid;\n"
         "                            -1 for no expiration\n"
@@ -404,6 +406,38 @@ create_ecc_from_x_and_y(unsigned char *ecc_x, unsigned int ecc_x_len,
         EVP_PKEY_fromdata(ctx, &pubkey, EVP_PKEY_PUBLIC_KEY, params) != 1,
         "Could not create %s key\n", curve);
 
+cleanup:
+    OSSL_PARAM_BLD_free(bld);
+    OSSL_PARAM_free(params);
+    EVP_PKEY_CTX_free(ctx);
+
+    return pubkey;
+}
+
+static EVP_PKEY *create_pubkey(unsigned char *public_bin, size_t public_len,
+                               const char *keyalgo)
+{
+    EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_from_name(NULL, keyalgo, NULL);
+    OSSL_PARAM_BLD *bld = OSSL_PARAM_BLD_new();
+    EVP_PKEY *pubkey = NULL;
+    OSSL_PARAM *params = NULL;
+
+    CHECK_OSSL_NULLPTR(ctx, "Could not create pkey context for %s key.\n",
+                       keyalgo);
+    CHECK_OSSL_NULLPTR1(bld, "Out of memory.\n");
+
+    CHECK_OSSL_RETURN1(
+        !OSSL_PARAM_BLD_push_octet_string(bld, OSSL_PKEY_PARAM_PUB_KEY,
+                                          public_bin, public_len),
+        "Could not push octet string.\n");
+
+    if ((params = OSSL_PARAM_BLD_to_param(bld)) == NULL ||
+        EVP_PKEY_fromdata_init(ctx) != 1 ||
+        EVP_PKEY_fromdata(ctx, &pubkey,
+                          EVP_PKEY_PUBLIC_KEY, params) != 1) {
+        fprintf(stderr, "Could not create %s public key.\n", keyalgo);
+        ERR_print_errors_fp(stderr);
+    }
 cleanup:
     OSSL_PARAM_BLD_free(bld);
     OSSL_PARAM_free(params);
@@ -1070,6 +1104,8 @@ static void capabilities_print_json(void)
              "\"cmdarg-signkey-pwd\""
              ", \"cmdarg-tpm-serial-num\""
              ", \"supports-iak-idevid\""
+             ", \"cmdarg-public\""
+             ", \"cmdarg-keyalgo\""
             " ], "
             "\"version\": \"" VERSION "\" "
             "}\n");
@@ -1117,6 +1153,8 @@ int main(int argc, char *argv[])
     unsigned char *ecc_y_bin = NULL;
     int ecc_y_len = 0;
     const char *ecc_curveid = NULL;
+    unsigned char *public_bin = NULL;
+    int public_len;
     datum_t datum = { NULL, 0 }, out = { NULL, 0 };
     mpz_t serial;
     time_t now;
@@ -1148,6 +1186,7 @@ int main(int argc, char *argv[])
     char *endptr;
     const char *keychoice = NULL;
     int critical = 0;
+    const char *keyalgo = NULL;
     static struct option long_options[] = {
         {"pubkey", required_argument, NULL, 'p'},
         {"modulus", required_argument, NULL, 'm'},
@@ -1155,6 +1194,8 @@ int main(int argc, char *argv[])
         {"ecc-y", required_argument, NULL, 'y'},
         {"ecc-curveid", required_argument, NULL, 'z'},
         {"exponent", required_argument, NULL, 'e'},
+        {"public", required_argument, NULL, 'q'},
+        {"keyalgo", required_argument, NULL, 'R'},
         {"signkey", required_argument, NULL, 's'},
         {"signkey-password", required_argument, NULL, 'S'},
         {"signkey-pwd", required_argument, NULL, 'T'},
@@ -1191,7 +1232,7 @@ int main(int argc, char *argv[])
 
 #ifdef __NetBSD__
     while ((opt = getopt_long(argc, argv,
-                    "p:m:x:y:z:e:s:S:T:i:o:u:d:r:1:2:3:4:5:6:7:8:9:MaXADcvh",
+                    "p:q:m:x:y:z:e:s:R:S:T:i:o:u:d:r:1:2:3:4:5:6:7:8:9:MaXADcvh",
                     long_options, &option_index)) != -1) {
 #else
     while ((opt = getopt_long_only(argc, argv, "", long_options,
@@ -1245,6 +1286,28 @@ int main(int argc, char *argv[])
             }
             if ((unsigned long int)exponent > UINT_MAX) {
                 fprintf(stderr, "Exponent must fit into 32bits.\n");
+                goto cleanup;
+            }
+            break;
+        case 'q': /* --public */
+            free(public_bin);
+            if (!(public_bin = hex_str_to_bin(optarg, &public_len)))
+                goto cleanup;
+            if (keychoice != NULL &&
+                !check_keychoice(&keychoice, "ML-KEM"))
+                goto cleanup;
+            break;
+        case 'R': /* --keyalgo */
+            if (strcmp(optarg, "ml-kem-512") == 0 ||
+                strcmp(optarg, "ml-kem-768") == 0 ||
+                strcmp(optarg, "ml-kem-1024") == 0) {
+                if (keychoice &&
+                    !check_keychoice(&keychoice, "ML-KEM"))
+                    goto cleanup;
+                keychoice = "ML-KEM";
+                keyalgo = optarg;
+            } else {
+                fprintf(stderr, "Unsupported key type '%s'.\n", optarg);
                 goto cleanup;
             }
             break;
@@ -1410,8 +1473,27 @@ int main(int argc, char *argv[])
         goto cleanup;
     }
 
+    if (public_bin && keyalgo == NULL) {
+        fprintf(stderr,
+                "--public requires --keyalgo to specify the key algorithm.\n");
+        goto cleanup;
+    }
+
     if (keychoice == NULL) {
         fprintf(stderr, "No parameters for a public key were given.\n");
+        goto cleanup;
+    }
+
+    if (public_bin &&
+        (pubkey_filename || modulus_bin || ecc_x_bin || ecc_y_bin)) {
+        fprintf(stderr,
+                "--public cannot be combined with --pubkey, --modulus, or --ecc-x/--ecc-y.\n");
+        goto cleanup;
+    }
+
+    if (!strcmp(keychoice, "ML-KEM") && !public_bin) {
+        fprintf(stderr, "Missing --public option for key type %s.\n",
+                keychoice);
         goto cleanup;
     }
 
@@ -1499,6 +1581,15 @@ int main(int argc, char *argv[])
             ecc_y_bin = NULL;
 
             is_ecc = true;
+        } else if (public_bin) {
+            if (strncmp(keyalgo, "ml-kem-", 7) == 0) {
+                pubkey = create_pubkey(public_bin, public_len, keyalgo);
+            } else {
+                fprintf(stderr, "Internal error: Unhandled keyalgo '%s'.\n",
+                        keyalgo);
+            }
+            free(public_bin);
+            public_bin = NULL;
         }
 
         if (pubkey == NULL)
@@ -1955,6 +2046,7 @@ cleanup:
     free(modulus_bin);
     free(ecc_x_bin);
     free(ecc_y_bin);
+    free(public_bin);
     asn_free();
 
     return ret;

--- a/src/swtpm_cert/ek-cert.c
+++ b/src/swtpm_cert/ek-cert.c
@@ -203,8 +203,9 @@ static void usage(const char *prg)
         "--ecc-y <hex string>      : ECC key y component\n"
         "--ecc-curveid <id>        : ECC curve id; secp256r1, secp384r1, secp521r1\n"
         "                            default: secp256r1\n"
-        "--public <hex string>     : Public key component for ML-KEM keys\n"
-        "--keyalgo <name>          : ml-kem-512, ml-kem-768, or ml-kem-1024\n"
+        "--public <hex string>     : Public key component for ML-KEM or ML-DSA keys\n"
+        "--keyalgo <name>          : ml-kem-512, ml-kem-768, ml-kem-1024,\n"
+        "                            ml-dsa-44, ml-dsa-65, or ml-dsa-87\n"
         "--serial <serial number>  : The certificate serial number\n"
         "--days <number>           : Number of days the cert is valid;\n"
         "                            -1 for no expiration\n"
@@ -1294,8 +1295,13 @@ int main(int argc, char *argv[])
             if (!(public_bin = hex_str_to_bin(optarg, &public_len)))
                 goto cleanup;
             if (keychoice != NULL &&
-                !check_keychoice(&keychoice, "ML-KEM"))
+                strcmp(keychoice, "ML-KEM") &&
+                strcmp(keychoice, "ML-DSA")) {
+                fprintf(stderr, "Already found options for keytype '%s'; "
+                                "cannot switch to ML-KEM or ML-DSA.\n",
+                        keychoice);
                 goto cleanup;
+            }
             break;
         case 'R': /* --keyalgo */
             if (strcmp(optarg, "ml-kem-512") == 0 ||
@@ -1305,6 +1311,14 @@ int main(int argc, char *argv[])
                     !check_keychoice(&keychoice, "ML-KEM"))
                     goto cleanup;
                 keychoice = "ML-KEM";
+                keyalgo = optarg;
+            } else if (strcmp(optarg, "ml-dsa-44") == 0 ||
+                       strcmp(optarg, "ml-dsa-65") == 0 ||
+                       strcmp(optarg, "ml-dsa-87") == 0) {
+                if (keychoice &&
+                    !check_keychoice(&keychoice, "ML-DSA"))
+                    goto cleanup;
+                keychoice = "ML-DSA";
                 keyalgo = optarg;
             } else {
                 fprintf(stderr, "Unsupported key type '%s'.\n", optarg);
@@ -1491,7 +1505,8 @@ int main(int argc, char *argv[])
         goto cleanup;
     }
 
-    if (!strcmp(keychoice, "ML-KEM") && !public_bin) {
+    if ((!strcmp(keychoice, "ML-KEM") || !strcmp(keychoice, "ML-DSA"))
+        && !public_bin) {
         fprintf(stderr, "Missing --public option for key type %s.\n",
                 keychoice);
         goto cleanup;
@@ -1582,7 +1597,8 @@ int main(int argc, char *argv[])
 
             is_ecc = true;
         } else if (public_bin) {
-            if (strncmp(keyalgo, "ml-kem-", 7) == 0) {
+            if (strncmp(keyalgo, "ml-kem-", 7) == 0 ||
+                strncmp(keyalgo, "ml-dsa-", 7) == 0) {
                 pubkey = create_pubkey(public_bin, public_len, keyalgo);
             } else {
                 fprintf(stderr, "Internal error: Unhandled keyalgo '%s'.\n",

--- a/src/swtpm_cert/ek-cert.c
+++ b/src/swtpm_cert/ek-cert.c
@@ -174,6 +174,15 @@ typedef struct TCG_PCCLIENT_STORED_FULL_CERT_HEADER {
         goto cleanup;				\
     }
 
+static bool uses_hashless_signing(const EVP_PKEY *key)
+{
+    return EVP_PKEY_is_a(key, "ml-dsa-44") ||
+           EVP_PKEY_is_a(key, "ml-dsa-65") ||
+           EVP_PKEY_is_a(key, "ml-dsa-87") ||
+           EVP_PKEY_is_a(key, "ED25519") ||
+           EVP_PKEY_is_a(key, "ED448");
+}
+
 static void versioninfo(void)
 {
     fprintf(stdout,
@@ -1074,7 +1083,9 @@ static const EVP_MD *get_hashalg_for_signing(EVP_PKEY *signingkey)
     int bits = EVP_PKEY_get_bits(signingkey);
     const EVP_MD *md;
 
-    if (EVP_PKEY_is_a(signingkey, "RSA")) {
+    if (uses_hashless_signing(signingkey)) {
+        md = NULL;
+    } else if (EVP_PKEY_is_a(signingkey, "RSA")) {
         switch (bits) {
         case 2048:
             md = EVP_sha256();
@@ -1142,7 +1153,7 @@ int main(int argc, char *argv[])
     const X509_NAME *issuer_name = NULL;
     X509V3_CTX x509v3_ctx;
     OSSL_PROVIDER *provider = NULL;
-    const EVP_MD *md = EVP_sha1();
+    const EVP_MD *md;
     const char *pubkey_filename = NULL;
     const char *sigkey_filename = NULL;
     const char *cert_filename = NULL;
@@ -1642,8 +1653,16 @@ int main(int argc, char *argv[])
 
     /* The signing hash algorithm depends on the key */
     if (flags & CERT_TYPE_TPM2_F) {
-        if (!(md = get_hashalg_for_signing(sigkey)))
+        md = get_hashalg_for_signing(sigkey);
+    }else {
+        /* TPM 1.2 had to be signed with SHA1 */
+        if (uses_hashless_signing(sigkey)) {
+            fprintf(stderr,
+                    "Cannot use hashless signing scheme for TPM 1.2 certs.\n");
             goto cleanup;
+        }
+        md = EVP_sha1();
+        setenv("OPENSSL_ENABLE_SHA1_SIGNATURES", "1", 1);
     }
 
     if (!(fp = fopen(issuercert_filename, "r"))) {
@@ -1976,11 +1995,8 @@ int main(int argc, char *argv[])
                        "Could not set public EK on CRT.\n");
 
     /* sign cert */
-    if (md == EVP_sha1())
-        setenv("OPENSSL_ENABLE_SHA1_SIGNATURES", "1", 1);
-    if (sigkey)
-        CHECK_OSSL_RETURN1(X509_sign(crt, sigkey, md) == 0,
-                           "Could not sign the certificate.\n");
+    CHECK_OSSL_RETURN1(X509_sign(crt, sigkey, md) == 0,
+                       "Could not sign the certificate.\n");
 
     /* write the certificate */
     bp = BIO_new(BIO_s_mem());

--- a/tests/_test_print_capabilities
+++ b/tests/_test_print_capabilities
@@ -77,7 +77,7 @@ if [ -x "$(type -P "$(echo "${SWTPM_CERT}" | cut -d" " -f1)" )" ]; then
 
 	exp='\{ "type": "swtpm_cert", "features": '\
 '\[ "cmdarg-signkey-pwd", "cmdarg-tpm-serial-num", '\
-'"supports-iak-idevid" \], '\
+'"supports-iak-idevid", "cmdarg-public", "cmdarg-keyalgo" \], '\
 '"version": "[^"]*" \}'
 	if ! [[ "${msg}" =~ ${exp} ]]; then
 		echo "Unexpected response from ${SWTPM_CERT} to --print-capabilities:"

--- a/tests/_test_tpm2_print_capabilities
+++ b/tests/_test_tpm2_print_capabilities
@@ -80,7 +80,7 @@ if [ -x "$(type -P "$(echo "${SWTPM_CERT}" | cut -d" " -f1)" )" ]; then
 
 	exp='\{ "type": "swtpm_cert", "features": '\
 '\[ "cmdarg-signkey-pwd", "cmdarg-tpm-serial-num", '\
-'"supports-iak-idevid" \], '\
+'"supports-iak-idevid", "cmdarg-public", "cmdarg-keyalgo" \], '\
 '"version": "[^"]*" \}'
 	if ! [[ "${msg}" =~ ${exp} ]]; then
 		echo "Unexpected response from ${SWTPM_CERT} to --print-capabilities:"

--- a/tests/_test_tpm2_swtpm_cert
+++ b/tests/_test_tpm2_swtpm_cert
@@ -168,6 +168,70 @@ check_cert "${cert}" "${PARAM_CERT_SIZES[$((TC++))]}" \
 echo -n > "${cert}"
 echo "Test ${TC}: OK (ecc)"
 
+
+if ! ${SWTPM_CERT} \
+	"${COMMON[@]}" \
+	--pubkey "${PARAM_MLKEM1024PUBKEY}";
+then
+	echo "Error: ${SWTPM_CERT} returned error code."
+	exit 1
+fi
+
+check_cert "${cert}" "${PARAM_CERT_SIZES[$((TC++))]}" \
+	"Serial Number: 1 (0x1)" \
+	"ML-KEM-1024 Public-Key:" \
+	"CA:FALSE" \
+	"Endorsement Key Certificate" \
+	"Key Encipherment" \
+	"DirName:/tcg-at-tpmManufacturer=IBM/tcg-at-tpmModel=swtpm-libtpms/tcg-at-tpmVersion=2"
+
+# truncate result file
+echo -n > "${cert}"
+echo "Test ${TC}: OK (ML-KEM-1024 key)"
+
+
+if ! ${SWTPM_CERT} \
+	"${COMMON[@]}" \
+	--public 16d75180b96183fc9ff96aa6b8d93793a0a645dc97589b62245955be3061719525ac90c3efb17308859038776d7eb88c8b55a8d9ebbeb8873f2b798d9888aff3f22358808b1c3c489d690d29ea9f6e1c1c301815686a0d39d1479f0979cfb07f7127c37c83c2f26a9c8c203d68c41ae6a690ce56bc4276082cec00c32a5b6515a41121a853d76e64e2a928aac333a4618af260ef7763b9f425d1737926e180ec50cbb87b334b085a638568455c2d14b8501056514e062365117a6603b007a70d1567290297b3998a7bc0cab0b43625a2fa94e58b88755cb3c5779aaff877ff11c1b380555bb05eae277f98808ebf590f6bc33c26353e8a55abdf838e7cb5ada53545dc3164e668494ef45441016f11b94c964b379c653f28111286f25987c0283189ba3dc34430f3c026b72870667dfe85038dec103ae08c511cc8dc292fd9091ac624575d78994ff54f3b20b985b62d76c6512c240c65024fba29a486b9c096ac9173c44583f94a1e6c5e1586ab35c3c93d667e5edb22393705eb9782666c76423954b818b346012851aa015af6cb9865ca45aa14e966a7882704d28049c66601615855acb604ced42bf743c1c1a37ead7bbd2284bf512086d6a6cde9f22e39a5abe321393b477f07ec76a5529cc81996c99777df184f41842f1722801d936becda48159c21e85bc5f39b6f17e537a18956eca7238e0336b196bc5a36b1c6e531b88b29a1b23ad9d0bfb6643c65092730e81410154faf1a429950aa3cf7a435a24d1ca00930bb354c207a5809958a505936224fcfcbb4f622ca5115113781b53f1225dda59b39bba4b82ca180f535ac3b7554a62187566a3a3c81dfc9cf7fd91648b36c0e19237dd2a067d86d627c366cacb716acaa3fd9c22bd0a1dd6256d42b2a460acb1a95ccf0070f62367096765d06dcb2f7959f0c7280874362c0f75473998240a91ac70528aec4b49ea974bf975f405180bd1393093555f015ca1dc81c8b22999466a674d440ee47bffd5193fae2c67ba6360e86c4d3a38c52a448f773b91094c25d56731ce83bdf515e6a345999186136f57a4bdb2d6c49aa185c81330e8ff4bdbd9321bb74c5e0c6c217c7b78a02783594a09dd7aeb9293b1e31fc \
+	--keyalgo ml-kem-512;
+then
+	echo "Error: ${SWTPM_CERT} returned error code."
+	exit 1
+fi
+
+check_cert "${cert}" "${PARAM_CERT_SIZES[$((TC++))]}" \
+	"Serial Number: 1 (0x1)" \
+	"ML-KEM-512 Public-Key:" \
+	"CA:FALSE" \
+	"Endorsement Key Certificate" \
+	"Key Encipherment" \
+	"DirName:/tcg-at-tpmManufacturer=IBM/tcg-at-tpmModel=swtpm-libtpms/tcg-at-tpmVersion=2"
+
+# truncate result file
+echo -n > "${cert}"
+echo "Test ${TC}: OK (ML-KEM-512 key)"
+
+
+if ! ${SWTPM_CERT} \
+	"${COMMON[@]}" \
+	--pubkey "${PARAM_MLDSA87PUBKEY}";
+then
+	echo "Error: ${SWTPM_CERT} returned error code."
+	exit 1
+fi
+
+check_cert "${cert}" "${PARAM_CERT_SIZES[$((TC++))]}" \
+	"Serial Number: 1 (0x1)" \
+	"ML-DSA-87 Public-Key:" \
+	"CA:FALSE" \
+	"Endorsement Key Certificate" \
+	"Key Encipherment" \
+	"DirName:/tcg-at-tpmManufacturer=IBM/tcg-at-tpmModel=swtpm-libtpms/tcg-at-tpmVersion=2"
+
+# truncate result file
+echo -n > "${cert}"
+echo "Test ${TC}: OK (ML-DSA-87 key)"
+
 ###################### Platform Certificate #####################
 
 if ! ${SWTPM_CERT} \
@@ -246,6 +310,29 @@ check_cert "${cert}" "${PARAM_CERT_SIZES[$((TC++))]}" \
 # truncate result file
 echo -n > "${cert}"
 echo "Test ${TC}: OK (IAK)"
+
+
+if ! ${SWTPM_CERT} \
+	"${COMMON[@]}" \
+	--type iak \
+	--pubkey "${PARAM_MLDSA87PUBKEY}" \
+	--subject "serialNumber=${serial}" \
+	--tpm-serial-num "${serial}";
+then
+	echo "Error: ${SWTPM_CERT} returned error code."
+	exit 1
+fi
+
+check_cert "${cert}" "${PARAM_CERT_SIZES[$((TC++))]}" \
+	"Serial Number: 1 (0x1)" \
+	"ML-DSA-87 Public-Key:" \
+	"..${serial}" \
+	"CA:FALSE" \
+	"Digital Signature"
+
+# truncate result file
+echo -n > "${cert}"
+echo "Test ${TC}: OK (ML-DSA-87 IAK)"
 
 ###################### IDevID Certificate #####################
 

--- a/tests/test_tpm2_swtpm_cert
+++ b/tests/test_tpm2_swtpm_cert
@@ -22,6 +22,8 @@ MLKEM1024PRIVKEY=${TMPDIR}/mlkem1024privkey.pem
 MLKEM1024PUBKEY=${TMPDIR}/mlkem1024pubkey.pem
 MLDSA87PRIVKEY=${TMPDIR}/mldsa87privkey.pem
 MLDSA87PUBKEY=${TMPDIR}/mldsa87pubkey.pem
+ED448PRIVKEY=${TMPDIR}/ed448privkey.pem
+ED448PUBKEY=${TMPDIR}/ed448pubkey.pem
 
 # secp521r1 key used for signing
 EC521PRIVKEY=${TMPDIR}/ec521privkey.pem
@@ -36,6 +38,9 @@ ISSUERCERT_RSA3072=${TMPDIR}/rsa3072-issuercert.pem
 # ML-DSA-87 key used for signing
 ISSUERCERT_MLDSA87=${TMPDIR}/mldsa87-issuercert.pem
 
+# ED448 key used for signing
+ISSUERCERT_ED448=${TMPDIR}/ed448-issuercert.pem
+
 if ! msg=$(openssl genrsa -out "${RSAPRIVKEY}" 2432 2>&1) ||
    ! msg=$(openssl rsa -in "${RSAPRIVKEY}" -pubout -out "${RSAPUBKEY}" 2>&1) ||
    ! msg=$(openssl ecparam -name prime256v1 -genkey -noout -out "${EC256PRIVKEY}" 2>&1) || \
@@ -44,6 +49,8 @@ if ! msg=$(openssl genrsa -out "${RSAPRIVKEY}" 2432 2>&1) ||
    ! msg=$(openssl pkey -in "${MLKEM1024PRIVKEY}" -pubout -out "${MLKEM1024PUBKEY}" 2>&1) || \
    ! msg=$(openssl genpkey -algorithm ml-dsa-87 -out "${MLDSA87PRIVKEY}" 2>&1) || \
    ! msg=$(openssl pkey -in "${MLDSA87PRIVKEY}" -pubout -out "${MLDSA87PUBKEY}" 2>&1) || \
+   ! msg=$(openssl genpkey -algorithm ed448 -out "${ED448PRIVKEY}" 2>&1) || \
+   ! msg=$(openssl pkey -in "${ED448PRIVKEY}" -pubout -out "${ED448PUBKEY}" 2>&1) || \
    ! msg=$(openssl req \
 	-x509 \
 	-new \
@@ -78,6 +85,14 @@ if ! msg=$(openssl genrsa -out "${RSAPRIVKEY}" 2432 2>&1) ||
 	-x509 \
 	-key "${MLDSA87PRIVKEY}" \
 	-out "${ISSUERCERT_MLDSA87}" \
+	-days 1000 \
+	-subj "/CN=swtpm-localca" \
+	-CA "${CACERT}" \
+	-CAkey "${CAKEY}" 2>&1) || \
+   ! msg=$(openssl req \
+	-x509 \
+	-key "${ED448PRIVKEY}" \
+	-out "${ISSUERCERT_ED448}" \
 	-days 1000 \
 	-subj "/CN=swtpm-localca" \
 	-CA "${CACERT}" \
@@ -125,6 +140,20 @@ PARAM_MLDSA87PUBKEY="${MLDSA87PUBKEY}" \
 PARAM_SIGNKEY="${MLDSA87PRIVKEY}" \
 PARAM_ISSUERCERT="${ISSUERCERT_MLDSA87}" \
 PARAM_CERT_SIZES="5285 5080 5331 5080 6579 5811 7603 5296 5045 5212 7484 5212 5351" \
+	./_test_tpm2_swtpm_cert
+ret=$?
+[ $ret -ne 0 ] && exit $ret
+
+
+printf "\nTesting with Ed448 certificate signing key\n"
+
+PARAM_RSAPUBKEY="${RSAPUBKEY}" \
+PARAM_ECPUBKEY="${EC256PUBKEY}" \
+PARAM_MLKEM1024PUBKEY="${MLKEM1024PUBKEY}" \
+PARAM_MLDSA87PUBKEY="${MLDSA87PUBKEY}" \
+PARAM_SIGNKEY="${ED448PRIVKEY}" \
+PARAM_ISSUERCERT="${ISSUERCERT_ED448}" \
+PARAM_CERT_SIZES="758 553 804 553 2052 1284 3076 769 518 685 2957 685 824" \
 	./_test_tpm2_swtpm_cert
 ret=$?
 [ $ret -ne 0 ] && exit $ret

--- a/tests/test_tpm2_swtpm_cert
+++ b/tests/test_tpm2_swtpm_cert
@@ -18,6 +18,10 @@ RSAPRIVKEY=${TMPDIR}/rsaprivkey.pem
 RSAPUBKEY=${TMPDIR}/rsapubkey.pem
 EC256PRIVKEY=${TMPDIR}/ec256privkey.pem
 EC256PUBKEY=${TMPDIR}/ec256pubkey.pem
+MLKEM1024PRIVKEY=${TMPDIR}/mlkem1024privkey.pem
+MLKEM1024PUBKEY=${TMPDIR}/mlkem1024pubkey.pem
+MLDSA87PRIVKEY=${TMPDIR}/mldsa87privkey.pem
+MLDSA87PUBKEY=${TMPDIR}/mldsa87pubkey.pem
 
 # secp521r1 key used for signing
 EC521PRIVKEY=${TMPDIR}/ec521privkey.pem
@@ -33,6 +37,10 @@ if ! msg=$(openssl genrsa -out "${RSAPRIVKEY}" 2432 2>&1) ||
    ! msg=$(openssl rsa -in "${RSAPRIVKEY}" -pubout -out "${RSAPUBKEY}" 2>&1) ||
    ! msg=$(openssl ecparam -name prime256v1 -genkey -noout -out "${EC256PRIVKEY}" 2>&1) || \
    ! msg=$(openssl ec -in "${EC256PRIVKEY}" -pubout -out "${EC256PUBKEY}" 2>&1) || \
+   ! msg=$(openssl genpkey -algorithm ml-kem-1024 -out "${MLKEM1024PRIVKEY}" 2>&1) || \
+   ! msg=$(openssl pkey -in "${MLKEM1024PRIVKEY}" -pubout -out "${MLKEM1024PUBKEY}" 2>&1) || \
+   ! msg=$(openssl genpkey -algorithm ml-dsa-87 -out "${MLDSA87PRIVKEY}" 2>&1) || \
+   ! msg=$(openssl pkey -in "${MLDSA87PRIVKEY}" -pubout -out "${MLDSA87PUBKEY}" 2>&1) || \
    ! msg=$(openssl req \
 	-x509 \
 	-new \
@@ -73,9 +81,11 @@ echo "Testing with RSA certificate signing key"
 
 PARAM_RSAPUBKEY="${RSAPUBKEY}" \
 PARAM_ECPUBKEY="${EC256PUBKEY}" \
+PARAM_MLKEM1024PUBKEY="${MLKEM1024PUBKEY}" \
+PARAM_MLDSA87PUBKEY="${MLDSA87PUBKEY}" \
 PARAM_SIGNKEY="${RSA3072PRIVKEY}" \
 PARAM_ISSUERCERT="${ISSUERCERT_RSA3072}" \
-PARAM_CERT_SIZES="1046 841 1092 841 1057 806 973 973 1112" \
+PARAM_CERT_SIZES="1046 841 1092 841 2340 1572 3364 1057 806 973 3245 973 1112" \
 	./_test_tpm2_swtpm_cert
 ret=$?
 [ $ret -ne 0 ] && exit $ret
@@ -85,9 +95,11 @@ printf "\nTesting with secp521r1 certificate signing key\n"
 
 PARAM_RSAPUBKEY="${RSAPUBKEY}" \
 PARAM_ECPUBKEY="${EC256PUBKEY}" \
+PARAM_MLKEM1024PUBKEY="${MLKEM1024PUBKEY}" \
+PARAM_MLDSA87PUBKEY="${MLDSA87PUBKEY}" \
 PARAM_SIGNKEY="${EC521PRIVKEY}" \
 PARAM_ISSUERCERT="${ISSUERCERT_EC521}" \
-PARAM_CERT_SIZES="792-794 588-589 838-840 587-589 804-805 552-554 720-721 720-721 859-860" \
+PARAM_CERT_SIZES="792-794 587-589 838-840 587-589 2086-2088 1318-1320 3110-3112 804-805 552-554 719-721 2991-2993 720-721 858-860" \
 	./_test_tpm2_swtpm_cert
 ret=$?
 [ $ret -ne 0 ] && exit $ret

--- a/tests/test_tpm2_swtpm_cert
+++ b/tests/test_tpm2_swtpm_cert
@@ -33,6 +33,9 @@ RSA3072PRIVKEY=${TMPDIR}/rsa3072privkey.pem
 RSA3072PUBKEY=${TMPDIR}/rsa3072pubkey.pem
 ISSUERCERT_RSA3072=${TMPDIR}/rsa3072-issuercert.pem
 
+# ML-DSA-87 key used for signing
+ISSUERCERT_MLDSA87=${TMPDIR}/mldsa87-issuercert.pem
+
 if ! msg=$(openssl genrsa -out "${RSAPRIVKEY}" 2432 2>&1) ||
    ! msg=$(openssl rsa -in "${RSAPRIVKEY}" -pubout -out "${RSAPUBKEY}" 2>&1) ||
    ! msg=$(openssl ecparam -name prime256v1 -genkey -noout -out "${EC256PRIVKEY}" 2>&1) || \
@@ -70,6 +73,14 @@ if ! msg=$(openssl genrsa -out "${RSAPRIVKEY}" 2432 2>&1) ||
 	-days 1000 \
 	-subj "/CN=swtpm-localca" \
 	-CA "${CACERT}" \
+	-CAkey "${CAKEY}" 2>&1) || \
+   ! msg=$(openssl req \
+	-x509 \
+	-key "${MLDSA87PRIVKEY}" \
+	-out "${ISSUERCERT_MLDSA87}" \
+	-days 1000 \
+	-subj "/CN=swtpm-localca" \
+	-CA "${CACERT}" \
 	-CAkey "${CAKEY}" 2>&1) \
 ; then
 	echo "Could not create the required keys"
@@ -103,5 +114,20 @@ PARAM_CERT_SIZES="792-794 587-589 838-840 587-589 2086-2088 1318-1320 3110-3112 
 	./_test_tpm2_swtpm_cert
 ret=$?
 [ $ret -ne 0 ] && exit $ret
+
+
+printf "\nTesting with ml-dsa-87 certificate signing key\n"
+
+PARAM_RSAPUBKEY="${RSAPUBKEY}" \
+PARAM_ECPUBKEY="${EC256PUBKEY}" \
+PARAM_MLKEM1024PUBKEY="${MLKEM1024PUBKEY}" \
+PARAM_MLDSA87PUBKEY="${MLDSA87PUBKEY}" \
+PARAM_SIGNKEY="${MLDSA87PRIVKEY}" \
+PARAM_ISSUERCERT="${ISSUERCERT_MLDSA87}" \
+PARAM_CERT_SIZES="5285 5080 5331 5080 6579 5811 7603 5296 5045 5212 7484 5212 5351" \
+	./_test_tpm2_swtpm_cert
+ret=$?
+[ $ret -ne 0 ] && exit $ret
+
 
 exit 0


### PR DESCRIPTION
See patch descriptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI options to certify ML-KEM and ML-DSA public keys, plus capability flags indicating support (requires specifying algorithm for raw public input).

* **Documentation**
  * Manpages updated with new options, example capability output, and CA key recommendations noting NVRAM size impacts for older TPM profiles.

* **Tests**
  * Test suite expanded to exercise ML-KEM/ML-DSA/Ed448 signing, certificate contents, DER size bounds, and updated capability reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->