### PR TITLE
tests+samples: Check for --help support to determine stat tool flavor

### DIFF
--- a/samples/swtpm-create-tpmca
+++ b/samples/swtpm-create-tpmca
@@ -26,7 +26,7 @@ logerr()
 # @1: filename
 function get_filesize()
 {
-	if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-) ]]; then
+	if stat --help &>/dev/null; then
 		stat -c%s "$1"
 	else
 		# OpenBSD

--- a/tests/common
+++ b/tests/common
@@ -735,7 +735,7 @@ function run_swtpm_bios()
 # @1: filename
 function get_filesize()
 {
-	if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-|GNU) ]]; then
+	if stat --help &>/dev/null; then
 		stat -c%s "$1"
 	else
 		# OpenBSD
@@ -748,7 +748,7 @@ function get_filesize()
 # @1: filename
 function get_filemode()
 {
-	if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-) ]]; then
+	if stat --help &>/dev/null; then
 		stat -c%a "$1"
 	else
 		# BSDs
@@ -761,7 +761,7 @@ function get_filemode()
 # @1: filename
 function get_fileowner()
 {
-	if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-|GNU) ]]; then
+	if stat --help &>/dev/null; then
 		stat -c"%u %g" "$1"
 	else
 		# BSDs
@@ -774,7 +774,7 @@ function get_fileowner()
 # @1: filename
 function get_fileowner_names()
 {
-	if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-|GNU) ]]; then
+	if stat --help &>/dev/null; then
 		stat -c"%U %G" "$1"
 	else
 		# BSDs

--- a/tests/fileinstall
+++ b/tests/fileinstall
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-) ]]; then
+if install --help &>/dev/null; then
 	install -D "$1" "$2"
 else
 	mkdir -p "$(dirname "$2")"

--- a/tests/sed-inplace
+++ b/tests/sed-inplace
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [[ "$(uname -s)" =~ (Linux|CYGWIN_NT-|GNU) ]]; then
+if sed --help &>/dev/null; then
 	sed -i "$1" "$2"
 else
 	sed -i '' "$1" "$2"


### PR DESCRIPTION
Using the kernel name was not a good choice for determining which flavor (BSD vs. GNU) of stat was being used since one could install either one of them at least on MacOS. Instead, check whether --help is supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime detection of system tools to make filesystem operations and in-place editing more reliable across environments.

* **Tests**
  * Updated test helpers and scripts to probe tool behavior at runtime, improving cross-platform robustness of filesystem-related tests and reducing reliance on OS heuristics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stefanberger/swtpm/pull/1128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->