### PR TITLE
Replace usage of plain stat in scripts with get_filesize and fix typo

### DIFF
--- a/tests/test_swtpm_cert
+++ b/tests/test_swtpm_cert
@@ -24,7 +24,7 @@ function check_cert_size()
 
 	local size
 
-	size=$(stat -c%s "${cert}" 2>/dev/null)
+	size=$(get_filesize "${cert}")
 	if [ "$size" -ne "$exp" ]; then
 		echo "Warning: Certificate file has unexpected size."
 		echo "         Expected: $exp;  found: $size"

--- a/tests/test_tpm2_swtpm_cert
+++ b/tests/test_tpm2_swtpm_cert
@@ -227,7 +227,7 @@ if ! ${SWTPM_CERT} \
 	echo "Error: ${SWTPM_CERT} failed with max. serial number."
 	exit 1
 fi
-tmp=$(openssl x509 --in "${cert}" -noout -text |
+tmp=$(openssl x509 -in "${cert}" -noout -text |
       grep -A1 "Serial Number:" |
       tail -n1 |
       sed -n 's/[[:space:]]*\([[:xdigit:]:]*\)/\1/p')

--- a/tests/test_tpm2_swtpm_cert
+++ b/tests/test_tpm2_swtpm_cert
@@ -24,7 +24,7 @@ function check_cert_size()
 
 	local size
 
-	size=$(stat -c%s "${cert}" 2>/dev/null)
+	size=$(get_filesize "${cert}")
 	if [ "$size" -ne "$exp" ]; then
 		echo "Warning: Certificate file has unexpected size."
 		echo "         Expected: $exp;  found: $size"

--- a/tests/test_tpm2_swtpm_cert_ecc
+++ b/tests/test_tpm2_swtpm_cert_ecc
@@ -24,7 +24,7 @@ function check_cert_size()
 
 	local size
 
-	size=$(stat -c%s "${cert}" 2>/dev/null)
+	size=$(get_filesize "${cert}")
 	if [ "$size" -ne "$exp" ]; then
 		echo "Warning: Certificate file has unexpected size."
 		echo "         Expected: $exp;  found: $size"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored certificate size validation checks across multiple test scenarios to use a standardized helper method for consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stefanberger/swtpm/pull/1129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->