### PR TITLE
Upgrade the IBMTSS2 test to v2.5.0 and for ci build it from the sources 

### DIFF
--- a/.github/actions/test-swtpm/action.yml
+++ b/.github/actions/test-swtpm/action.yml
@@ -8,7 +8,18 @@ runs:
         sudo apt-get -y install automake autoconf libtool libssl-dev sed make gawk \
           sed bash dh-exec python3-pip libfuse-dev libglib2.0-dev libjson-glib-dev \
           libgmp-dev libtasn1-dev socat findutils gnutls-bin softhsm2 \
-          libseccomp-dev tss2 openssl pkcs11-provider ${PACKAGES}
+          libseccomp-dev openssl pkcs11-provider ${PACKAGES}
+        if [ "${SWTPM_TEST_IBMTSS2:-0}" -ne 0 ]; then
+          git clone https://github.com/kgoldman/ibmtss.git
+          pushd ibmtss
+            git checkout tags/v2.5.0
+            autoreconf --force --install
+            ./configure --prefix=/usr --disable-tpm-1.2
+            make -j$(${NPROC:-nproc})
+            sudo make install
+          popd
+          rm -rf ibmtss
+        fi
         if [ ! -d libtpms ]; then
           git clone https://github.com/stefanberger/libtpms;
         fi

--- a/tests/test_tpm2_ibmtss2
+++ b/tests/test_tpm2_ibmtss2
@@ -57,7 +57,7 @@ function build_ibmtss2() {
 
 	pushd ibmtpm20tss-tss &>/dev/null || exit 1
 
-	if ! git checkout tags/v2.4.1; then
+	if ! git checkout tags/v2.5.0; then
 		echo "'Git checkout' failed."
 		exit 1
 	fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated IBM TSS2 library to v2.5.0.
  * CI workflows can now conditionally build and install IBM TSS2 from source when enabled.

* **Tests**
  * Test setup and helpers updated to target IBM TSS2 v2.5.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stefanberger/swtpm/pull/1130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->