### PR TITLE
selinux: fix policy for virtqemud

### DIFF
--- a/src/selinux/swtpm_libvirt.te
+++ b/src/selinux/swtpm_libvirt.te
@@ -40,7 +40,8 @@ allow virtqemud_t svirt_tcg_t:file { open read };
 allow virtqemud_t svirt_tcg_t:process { noatsecure rlimitinh setsched siginh signal signull transition };
 allow virtqemud_t svirt_tcg_t:unix_stream_socket { bind connectto create listen };
 allow virtqemud_t svirt_tcg_devpts_t:chr_file { ioctl open read write };
-allow virtqemud_t swtpm_t:process { noatsecure rlimitinh siginh signull };
+allow virtqemud_t swtpm_t:process { noatsecure rlimitinh siginh signull setsched };
+allow virtqemud_t swtpm_t:unix_stream_socket { bind connectto create listen };
 allow virtqemud_t urandom_device_t:chr_file setattr;
 
 # Some rules are due to swtpm-localca ( https://bugzilla.redhat.com/show_bug.cgi?id=2278905#c34 )


### PR DESCRIPTION
This allows unix_stream_socket and setsched for swtpm_t
Adresses #1131 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SELinux policy to enhance compatibility between the virtualization service and the TPM emulator.
  * Adds scheduling permission for the virtualization service and enables UNIX stream socket operations (bind, connect, create, listen) to reduce permission-related failures in virtualized TPM workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stefanberger/swtpm/pull/1132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->