### PR TITLE
selinux: Add SELinux policy for virtqemud_t swtpm_t setsched process …

### DIFF
--- a/src/selinux/swtpm_libvirt.te
+++ b/src/selinux/swtpm_libvirt.te
@@ -40,7 +40,8 @@ allow virtqemud_t svirt_tcg_t:file { open read };
 allow virtqemud_t svirt_tcg_t:process { noatsecure rlimitinh setsched siginh signal signull transition };
 allow virtqemud_t svirt_tcg_t:unix_stream_socket { bind connectto create listen };
 allow virtqemud_t svirt_tcg_devpts_t:chr_file { ioctl open read write };
-allow virtqemud_t swtpm_t:process { noatsecure rlimitinh siginh signull };
+allow virtqemud_t swtpm_t:process { noatsecure rlimitinh siginh signull setsched };
+allow virtqemud_t swtpm_t:unix_stream_socket { bind connectto create listen };
 allow virtqemud_t urandom_device_t:chr_file setattr;
 
 # Some rules are due to swtpm-localca ( https://bugzilla.redhat.com/show_bug.cgi?id=2278905#c34 )


### PR DESCRIPTION
…and unix socket interactions.

Allows virtqemud_t to:
- Signal and control swtpm_t processes (noatsecure, rlimitinh, siginh, signull, setsched)
- Create and listen on Unix stream sockets with swtpm_t processes

This enables libvirt to properly control swtpm instances, including sending signals and managing process scheduling attributes, when the system is using cockpit-machines interface to manage and start VMs.

Fixes: https://github.com/stefanberger/swtpm/issues/1131