### PR TITLE
ci: Move testing into containers

### DIFF
--- a/.github/actions/test-swtpm/action.yml
+++ b/.github/actions/test-swtpm/action.yml
@@ -4,11 +4,13 @@ runs:
     - name: Build and test
       shell: bash
       run: |
+        if ! type -P sudo; then apt-get -y update && apt-get -y install sudo; fi
         sudo apt-get -y update
         sudo apt-get -y install automake autoconf libtool libssl-dev sed make gawk \
           sed bash dh-exec python3-pip libfuse-dev libglib2.0-dev libjson-glib-dev \
           libgmp-dev libtasn1-dev socat findutils gnutls-bin softhsm2 \
-          libseccomp-dev openssl pkcs11-provider ${PACKAGES}
+          libseccomp-dev openssl pkcs11-provider ${PACKAGES} \
+          git net-tools
         if [ "${SWTPM_TEST_IBMTSS2:-0}" -ne 0 ]; then
           git clone https://github.com/kgoldman/ibmtss.git
           pushd ibmtss

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   test-distcheck:
     runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:26.04
     env:
       PREFIX:   "/usr"
       CONFIG:   "--with-openssl --prefix=/usr"
@@ -21,6 +23,8 @@ jobs:
 
   test-coveralls:
     runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:26.04
     env:
       PREFIX:                    "/usr"
       CONFIG:                    "--with-openssl --prefix=/usr --enable-test-coverage"
@@ -47,12 +51,14 @@ jobs:
           sudo chown -R ${uidgid} ./
           git clone https://github.com/eddyxu/cpp-coveralls
           pushd cpp-coveralls
-           pip install -e .
+           sudo pip install -e . --break-system-packages
           popd
           cpp-coveralls -e libtpms --gcov-options '\-lp'
 
   test-asan-ubsan:
     runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:26.04
     env:
       CFLAGS:         "-fsanitize=address,undefined -g -fno-omit-frame-pointer -fno-sanitize-recover"
       LIBTPMS_CFLAGS: "-fsanitize=address,undefined -g -fno-omit-frame-pointer -fno-sanitize-recover"
@@ -72,6 +78,8 @@ jobs:
 
   test-asan-ubsan-non-openssl:
     runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:26.04
     env:
       CFLAGS:         "-fsanitize=address,undefined -g -fno-omit-frame-pointer -fno-sanitize-recover"
       LIBTPMS_CFLAGS: "-fsanitize=address,undefined -g -fno-omit-frame-pointer -fno-sanitize-recover"

--- a/tests/common
+++ b/tests/common
@@ -94,6 +94,16 @@ function wait_process_gone()
     kill_quiet -0 "${pid}" || return 1
     sleep 0.1
   done
+
+  # Last attempt for (ubuntu:26.04) containers:
+  #   defunct process are considered terminated
+  if type -P ps &>/dev/null; then
+    if ps "${pid}" | grep -q defunct; then
+      echo "WARN: Process with PID ${pid} is <defunct>!"
+      return 1
+    fi
+  fi
+
   return 0
 }
 

--- a/tests/test_tpm2_swtpm_localca_pkcs11.test
+++ b/tests/test_tpm2_swtpm_localca_pkcs11.test
@@ -77,6 +77,7 @@ fi
 
 pubkey="${workdir}/swtpm-localca-interm-pubkey.pem"
 
+# Some versions of pkcs11 provider + OpenSSL may get stuck here (Ubuntu 26.04 host)
 msg=$(timeout 5 openssl pkey \
            -provider pkcs11 \
            -in "${pkcs11uri}" -pubout -out "${pubkey}" 2>&1)
@@ -88,6 +89,11 @@ if [ "$rc" -ne 0 ]; then
         fi
 	echo "Could not get public key for pkcs11 uri key ($pkcs11uri}."
 	echo "${msg}"
+	if grep -q "Did you forget to load them?" <<< "${msg}"; then
+		# Error in ubuntu:26.04
+		echo "WARN: Something seems wrong with pkcs11 config."
+		exit 77
+	fi
 	exit 1
 fi
 


### PR DESCRIPTION
Since a ubuntu-26.04 host runner may not appear very soon, move the tests into containers.
