### PR TITLE
Fix policy loading with 3.11 SElinux toolchain (bsc#1271417)

### DIFF
--- a/src/selinux/swtpm.te
+++ b/src/selinux/swtpm.te
@@ -14,7 +14,6 @@ require {
 	type virtqemud_t;
 	type virtqemud_tmp_t;
 	class file map;
-	tunable virt_use_nfs;
 }
 
 attribute_role swtpm_roles;


### PR DESCRIPTION
This is not needed and causes issues with policy loading due to this fix in the 3.11 SELinux toolchain:
https://github.com/SELinuxProject/selinux/commit/81fae2f376f6c4f9928ce29264e534b841e975f5

The virt_use_nfs is created with "gen_tunable":
https://github.com/fedora-selinux/selinux-policy/blob/c905bb439845daff1ff442650b3225ad84ee724a/policy/modules/contrib/virt.te#L69

"tunable_policy" is a bool in fedora and openSUSE: https://github.com/fedora-selinux/selinux-policy/blob/c905bb439845daff1ff442650b3225ad84ee724a/policy/support/loadable_module.spt#L129

Adding "tunable virt_use_nfs;" makes it a tunable, not a bool.


Test run failure see: https://bugzilla.suse.com/show_bug.cgi?id=1271417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SELinux policy handling to remove a redundant tunable declaration while keeping existing virtualization and NFS behavior intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->