### PR TITLE
Fix policy loading with 3.11 SElinux toolchain (bsc#1271417)

### DIFF
--- a/src/selinux/swtpm.te
+++ b/src/selinux/swtpm.te
@@ -14,7 +14,6 @@ require {
 	type virtqemud_t;
 	type virtqemud_tmp_t;
 	class file map;
-	tunable virt_use_nfs;
 }
 
 attribute_role swtpm_roles;

--- a/tests/test_tpm2_libtpms_versions_profiles
+++ b/tests/test_tpm2_libtpms_versions_profiles
@@ -41,7 +41,7 @@ LIBTPMS_URL=https://github.com/stefanberger/libtpms
 LIBTPMS_INITIAL_BRANCH=master
 
 SWTPM_URL=https://github.com/stefanberger/swtpm
-SWTPM_DEFAULT_BRANCH=master   # during development change to local branch
+SWTPM_DEFAULT_BRANCH=stable-0.10   # during development change to local branch
 
 cat <<_EOF_ > "${workdir}/swtpm-localca.options"
 --tpm-manufacturer IBM
@@ -595,6 +595,12 @@ function build_libtpms_and_swtpm()
 	for ((maj=0; maj<=major; maj++)) {
 		min=0
 		[ "${maj}" = 0 ] && min=9  # start with v0.9
+
+		# only build a few versions of libtpms
+		case "${maj}.${min}" in
+		0.9|0.10)	;;
+		*)		continue;;
+		esac
 
 		for ((;; min++)) {
 			git checkout "origin/stable-${maj}.${min}" &>/dev/null || break


### PR DESCRIPTION
This is not needed and causes issues with policy loading due to this fix in the 3.11 SELinux toolchain:
https://github.com/SELinuxProject/selinux/commit/81fae2f376f6c4f9928ce29264e534b841e975f5

The virt_use_nfs is created with "gen_tunable":
https://github.com/fedora-selinux/selinux-policy/blob/c905bb439845daff1ff442650b3225ad84ee724a/policy/modules/contrib/virt.te#L69

"tunable_policy" is a bool in fedora and openSUSE: https://github.com/fedora-selinux/selinux-policy/blob/c905bb439845daff1ff442650b3225ad84ee724a/policy/support/loadable_module.spt#L129

Adding "tunable virt_use_nfs;" makes it a tunable, not a bool.