### PR TITLE
Changes required to run on OpenBSD with LibreSSL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,7 +115,7 @@ AC_ARG_WITH([openssl],
             [])
 
 AS_CASE([$cryptolib],[openssl],
-    [PKG_CHECK_MODULES([LIBCRYPTO],[libcrypto >= 3.5])
+    [PKG_CHECK_MODULES([LIBCRYPTO],[libcrypto >= 0.0])
     AC_CHECK_HEADERS([openssl/obj_mac.h],[],
         AC_MSG_ERROR(Is openssl-devel/libssl-dev installed?))
     AC_MSG_RESULT([Building with openssl crypto library])
@@ -139,7 +139,7 @@ AS_IF([test "$OPENSSL_CLITOOL" != "yes"],
 
 PKG_CHECK_MODULES([LIBTASN1],[libtasn1])
 
-PKG_CHECK_MODULES([LIBTPMS],[libtpms >= 0.11])
+PKG_CHECK_MODULES([LIBTPMS],[libtpms >= 0.10])
 
 
 AC_CHECK_LIB(c, clock_gettime, LIBRT_LIBS="", LIBRT_LIBS="-lrt")

--- a/man/man3/Makefile.am
+++ b/man/man3/Makefile.am
@@ -11,10 +11,11 @@ man3_PODS = \
 man3_MANS = \
 	swtpm_ioctls.3
 
-%.3 : %.pod
+SUFFIXES: .pod .3
+.pod.3:
 	@pod2man -r "swtpm" \
 		-c "" \
-		-n $(basename $@) \
+		-n $(<:.pod=) \
 		--section=3 $< > $@
 
 EXTRA_DIST = $(man3_MANS) $(man3_PODS)

--- a/man/man5/Makefile.am
+++ b/man/man5/Makefile.am
@@ -15,10 +15,11 @@ man5_MANS = \
 	swtpm-localca.options.5 \
 	swtpm-localca.conf.5
 
-%.5 : %.pod
+SUFFIXES: .pod .5
+.pod.5:
 	@pod2man -r "swtpm" \
 		-c "" \
-		-n $(basename $@) \
+		-n $(<:.pod=) \
 		--section=5 $< > $@
 
 EXTRA_DIST = $(man5_MANS) $(man5_PODS)

--- a/man/man8/Makefile.am
+++ b/man/man8/Makefile.am
@@ -35,10 +35,11 @@ man8_MANS = \
 	$(man8_generated_MANS) \
 	$(man8_static_MANS)
 
-%.8 : %.pod
+SUFFIXES: .pod .8
+.pod.8:
 	@pod2man -r "swtpm" \
 		-c "" \
-		-n $(basename $@) \
+		-n $(<:.pod=) \
 		--section=8 $< > $@
 
 EXTRA_DIST = $(man8_static_MANS) $(man8_PODS)

--- a/samples/swtpm-create-tpmca
+++ b/samples/swtpm-create-tpmca
@@ -207,6 +207,47 @@ create_localca_cert() {
 		return 1
 	fi
 
+	if openssl version | grep -qi "LibreSSL"; then
+		csr="${workdir}/swtpm-localca-interm-csr.pem"
+		ext="${workdir}/swtpm-localca-interm-ext.conf"
+		template="${workdir}/swtpm-localca-interm-csr-template.txt"
+	
+		cat > "${template}" << EOF
+cn = "swtpm-tpmca"
+signing_key = "${tpmkeyurl}"
+EOF
+		msg=$(certtool --generate-request --template "${template}" \
+			--outfile "${csr}" 2>&1)
+		rc=$?
+		rm -f "${template}"
+		if [ "$rc" -ne 0 ]; then
+			logerr "ERROR: Could not create CSR"
+			logerr "${msg}"
+			retturn 1
+		fi
+	
+		cat > "${ext}" << EOF
+[v3_ca]
+keyUsage=critical,keyCertSign
+basicContsraints=critical,CA:TRUE
+EOF
+		if ! msg=$(openssl x509 \
+			-req -in "${csr}" -CA "${cacert}" -CAkey "${cakey}" \
+			-key "${pkcs11uri}" \
+			-CAcreateserial -CAserial "${dir}/certserial" \
+			-days 3650 \
+			-extfile "${ext}" \
+			-extensions "v3_ca" \
+			-out "${tpmca}" \
+			-out "${ISSUERCERT}" \
+			2>&1); then
+			logerr "Could not create TPM CA"
+			logerr "${msg}"
+			exit 1
+		fi
+		rm -f "${csr}" "${ext}" 
+	else # not LibreSSL
+
 	if ! providerpath=$(get_provider_path "pkcs11.so"); then
 		return 1
 	fi
@@ -236,6 +277,7 @@ create_localca_cert() {
 		return 1
 	fi
 	rm -f "${pinfile}"
+	fi # not LibreSSL
 
 	output="statedir = ${dir}
 signingkey = $(escape_pkcs11_url "${tpmkeyurl//%00/}")

--- a/src/swtpm/pcap.c
+++ b/src/swtpm/pcap.c
@@ -11,10 +11,10 @@
 #include <stdint.h>
 #include <time.h>
 #include <unistd.h>
+#include <arpa/inet.h>
 #include <netinet/ip.h>
 #include <netinet/tcp.h>
 #include <sys/uio.h>
-#include <arpa/inet.h>
 
 #include <glib.h>
 
@@ -74,6 +74,10 @@ struct packet {
     struct ip     iphdr; // Cygwin has 'struct ip' but not 'struct iphdr'
     struct tcphdr tcphdr;
 } __attribute__((packed));
+#define PACKET_ETHHDR_OFF	(sizeof(struct enhanced_packet_block_hdr))
+#define PACKET_IPHDR_OFF	(PACKET_ETHHDR_OFF + sizeof(struct ethhdr))
+#define PACKET_TCPHDR_OFF	(PACKET_IPHDR_OFF + sizeof(struct ip))
+#define PACKET_DATA_OFF		(PACKET_TCPHDR_OFF + sizeof(struct tcphdr))
 
 static __attribute__((noinline)) uint32_t calc_checksum(void *array, size_t array_len)
 {
@@ -93,21 +97,31 @@ static __attribute__((noinline)) uint32_t calc_checksum(void *array, size_t arra
      return check;
 }
 
-static void calc_ip_checksum(struct packet *packet)
+static void calc_ip_checksum(char *packet)
 {
+    struct ip iphdr;
+    struct ip *packet_iphdr = (struct ip *)&packet[PACKET_IPHDR_OFF];
     uint32_t check = 0;
 
-    packet->iphdr.ip_sum = 0;
+    memcpy(&iphdr, packet_iphdr, sizeof(iphdr));
+    iphdr.ip_sum = 0;
 
-    check = calc_checksum(&packet->iphdr, sizeof(packet->iphdr));
+    check = calc_checksum(&iphdr, sizeof(iphdr));
     check = (check & 0xffff) + (check >> 16);
+    check = htons(~check);
 
-    packet->iphdr.ip_sum = htons(~check);
+    memcpy(&packet_iphdr->ip_sum, &check, sizeof(check));
 }
 
-static void calc_tcp_checksum(struct packet *packet,
+static void calc_tcp_checksum(char *packet,
                               void *payload, size_t payload_len)
 {
+    struct ip iphdr;
+    struct tcphdr tcphdr;
+    struct ip *packet_iphdr = (struct ip *)&packet[PACKET_IPHDR_OFF];
+    struct tcphdr *packet_tcphdr = (struct tcphdr *)&packet[PACKET_TCPHDR_OFF];
+    memcpy(&iphdr, packet_iphdr, sizeof(iphdr));
+    memcpy(&tcphdr, packet_tcphdr, sizeof(tcphdr));
     struct {
         uint32_t saddr;
         uint32_t daddr;
@@ -115,26 +129,27 @@ static void calc_tcp_checksum(struct packet *packet,
         uint8_t  protocol;
         uint16_t tcpseglength;
     } pseudo = {
-        .saddr = packet->iphdr.ip_src.s_addr,
-        .daddr = packet->iphdr.ip_dst.s_addr,
+        .saddr = iphdr.ip_src.s_addr,
+        .daddr = iphdr.ip_dst.s_addr,
         .reserved = 0,
-        .protocol = packet->iphdr.ip_p,
+        .protocol = iphdr.ip_p,
         .tcpseglength = htons(sizeof(struct tcphdr) + payload_len),
     };
     uint32_t check;
 
-    packet->tcphdr.th_sum = 0;
+    tcphdr.th_sum = 0;
 
     check = calc_checksum(&pseudo, sizeof(pseudo)) +
-            calc_checksum(&packet->tcphdr, sizeof(packet->tcphdr)) +
+            calc_checksum(&tcphdr, sizeof(tcphdr)) +
             calc_checksum(payload, payload_len);
 
     check = (check & 0xffff) + (check >> 16);
-    packet->tcphdr.th_sum = htons(~check);
+    check = htons(~check);
+    memcpy(&packet_tcphdr->th_sum, &check, sizeof(check));
 }
 
 /* Calculate TCP and IP checksums on a packet */
-static void calc_checksums(struct packet *packet,
+static void calc_checksums(char *packet,
                            void *payload, size_t payload_len,
                            struct pcap_state *ps)
 {
@@ -179,10 +194,13 @@ static int pcap_file_header_write(int fd)
     return write_full(fd, &shb, sizeof(shb));
 }
 
-static int pcap_packet_fill(struct packet *packet, bool to_tpm,
+static int pcap_packet_fill(char *packet, bool to_tpm,
                             uint32_t tpm_packet_len, uint32_t orig_len,
                             struct pcap_state *ps)
 {
+    struct ethhdr *packet_ethhdr = (struct ethhdr *)&packet[PACKET_ETHHDR_OFF];
+    struct ip *packet_iphdr = (struct ip *)&packet[PACKET_IPHDR_OFF];
+    struct tcphdr *packet_tcphdr = (struct tcphdr *)&packet[PACKET_TCPHDR_OFF];
     struct timespec ts;
     size_t hdrs_len;
     uint64_t ms;
@@ -193,41 +211,43 @@ static int pcap_packet_fill(struct packet *packet, bool to_tpm,
     ms = ts.tv_sec * 1000 * 1000 + ts.tv_nsec / 1000;
     hdrs_len = sizeof(struct ethhdr) + sizeof(struct ip) + sizeof(struct tcphdr);
 
-    *packet = (struct packet){
-        .epb_hdr = {
-            .block_type = BLOCK_TYPE_EPB,
-            .ts_hi = ms >> 32,
-            .ts_lo = ms,
-            .capture_len = hdrs_len + tpm_packet_len,
-            .original_len = hdrs_len + orig_len,
-        },
-        .ethhdr = {
-            .eth_type = htons(ETHERTYPE_IP),
-        },
-        .iphdr = {
-            .ip_hl = sizeof(struct ip) >> 2,
-            .ip_v = 4,
-            .ip_tos = 0x10,
-            .ip_len = htons(sizeof(struct ip) +
-                            sizeof(struct tcphdr) +
-                            tpm_packet_len),
-            .ip_id = htons(0x069b),
-            .ip_off = htons(IP_DF),
-            .ip_ttl = 64,
-            .ip_p = 6, /* TCP */
-            .ip_sum = 0,
-            .ip_src.s_addr = htonl(0x7f000001),
-            .ip_dst.s_addr = htonl(0x7f000001),
-        },
-        .tcphdr =  {
-            .th_sport = to_tpm ? htons(ps->cport) : htons(ps->tpmport),
-            .th_dport = to_tpm ? htons(ps->tpmport) : htons(ps->cport),
-            .th_seq = to_tpm ? htonl(ps->cseq) : htonl(ps->sseq),
-            .th_ack = to_tpm ? htonl(ps->sseq) : htonl(ps->cseq),
-            .th_off = sizeof(struct tcphdr) >> 2,
-            .th_win = htons(0xffc4),
-        },
+    struct enhanced_packet_block_hdr epb_hdr = {
+        .block_type = BLOCK_TYPE_EPB,
+        .ts_hi = ms >> 32,
+        .ts_lo = ms,
+        .capture_len = hdrs_len + tpm_packet_len,
+        .original_len = hdrs_len + orig_len,
     };
+    struct ethhdr ethhdr = {
+        .eth_type = htons(ETHERTYPE_IP),
+    };
+    struct ip iphdr = {
+        .ip_hl = sizeof(struct ip) >> 2,
+        .ip_v = 4,
+        .ip_tos = 0x10,
+        .ip_len = htons(sizeof(struct ip) +
+                        sizeof(struct tcphdr) +
+                        tpm_packet_len),
+        .ip_id = htons(0x069b),
+        .ip_off = htons(IP_DF),
+        .ip_ttl = 64,
+        .ip_p = 6, /* TCP */
+        .ip_sum = 0,
+        .ip_src.s_addr = htonl(0x7f000001),
+        .ip_dst.s_addr = htonl(0x7f000001),
+    };
+    struct tcphdr tcphdr =  {
+        .th_sport = to_tpm ? htons(ps->cport) : htons(ps->tpmport),
+        .th_dport = to_tpm ? htons(ps->tpmport) : htons(ps->cport),
+        .th_seq = to_tpm ? htonl(ps->cseq) : htonl(ps->sseq),
+        .th_ack = to_tpm ? htonl(ps->sseq) : htonl(ps->cseq),
+        .th_off = sizeof(struct tcphdr) >> 2,
+        .th_win = htons(0xffc4),
+    };
+    memcpy(packet, &epb_hdr, sizeof(epb_hdr));
+    memcpy(packet_ethhdr, &ethhdr, sizeof(ethhdr));
+    memcpy(packet_iphdr, &iphdr, sizeof(iphdr));
+    memcpy(packet_tcphdr, &tcphdr, sizeof(tcphdr));
     return 0;
 }
 
@@ -235,10 +255,12 @@ static int pcap_packet_fill(struct packet *packet, bool to_tpm,
  * Write a packet to the file. Take care of unaligned packets to due unaligned
  * overall size (32bit alignment). Also write a block_total_len at the end.
  */
-static int pcap_write(int fd, struct packet *packet,
+static int pcap_write(int fd, char *packet,
                       void *tpm_packet, uint32_t tpm_packet_len)
 {
-    size_t packet_len = sizeof(*packet);
+    struct enhanced_packet_block_hdr *packet_epb_hdr =
+        (struct enhanced_packet_block_hdr *)packet;
+    size_t packet_len = PACKET_DATA_OFF;
     size_t filler_len = 4 - ((packet_len + tpm_packet_len) & 3);
     uint32_t block_total_len;
     uint8_t filler[3] = { 0, };
@@ -258,7 +280,8 @@ static int pcap_write(int fd, struct packet *packet,
     }
 
     block_total_len = packet_len + tpm_packet_len + filler_len + sizeof(uint32_t);
-    packet->epb_hdr.block_total_length = block_total_len;
+    memcpy(&packet_epb_hdr->block_total_length, &block_total_len,
+           sizeof(block_total_len));
 
     return writev_full(fd, iov, num_iov);
 }
@@ -278,33 +301,40 @@ static int pcap_file_write_idb(struct pcap_state *ps)
 /* Write a simulated TCP SYN/SYN+ACK/ACK or FIN/FIN+ACK/ACK exchange */
 static int pcap_file_tcp_flags(struct pcap_state *ps, uint8_t flag)
 {
-    struct packet packet;
+    char buf[PACKET_TCPHDR_OFF];
+    struct ip iphdr;
+    struct tcphdr tcphdr;
+    char *packet = buf;
+    struct ip *packet_iphdr = (struct ip *)&packet[PACKET_IPHDR_OFF];
+    struct tcphdr *packet_tcphdr = (struct tcphdr *)&packet[PACKET_TCPHDR_OFF];
+    memcpy(&iphdr, packet_iphdr, sizeof(iphdr));
+    memcpy(&tcphdr, packet_tcphdr, sizeof(tcphdr));
 
-    pcap_packet_fill(&packet, true, 0, 0, ps);
-    packet.tcphdr.th_flags = flag;
+    pcap_packet_fill(packet, true, 0, 0, ps);
+    packet_tcphdr->th_flags = flag;
     if (flag == TH_SYN)
-        packet.tcphdr.th_ack = 0;
-    calc_checksums(&packet, NULL, 0, ps);
+        memset(&packet_tcphdr->th_ack, 0, sizeof(packet_tcphdr->th_ack));
+    calc_checksums(packet, NULL, 0, ps);
 
-    if (pcap_write(ps->fd, &packet, NULL, 0) < 0)
+    if (pcap_write(ps->fd, packet, NULL, 0) < 0)
         return -1;
 
     ps->cseq++;
 
-    pcap_packet_fill(&packet, false, 0, 0, ps);
-    packet.tcphdr.th_flags = flag | TH_ACK;
-    calc_checksums(&packet, NULL, 0, ps);
+    pcap_packet_fill(packet, false, 0, 0, ps);
+    packet_tcphdr->th_flags = flag | TH_ACK;
+    calc_checksums(packet, NULL, 0, ps);
 
-    if (pcap_write(ps->fd, &packet, NULL, 0) < 0)
+    if (pcap_write(ps->fd, packet, NULL, 0) < 0)
         return -1;
 
     ps->sseq++;
 
-    pcap_packet_fill(&packet, true, 0, 0, ps);
-    packet.tcphdr.th_flags = TH_ACK;
-    calc_checksums(&packet, NULL, 0, ps);
+    pcap_packet_fill(packet, true, 0, 0, ps);
+    packet_tcphdr->th_flags = TH_ACK;
+    calc_checksums(packet, NULL, 0, ps);
 
-    if (pcap_write(ps->fd, &packet, NULL, 0) < 0)
+    if (pcap_write(ps->fd, packet, NULL, 0) < 0)
         return -1;
 
     return 0;
@@ -361,19 +391,20 @@ int pcap_packet_record_write(struct pcap_state *ps,
                              void *tpm_packet, uint32_t tpm_packet_len,
                              bool to_tpm)
 {
-    struct packet packet;
+    char buf[PACKET_TCPHDR_OFF];
+    char *packet = buf;
     int ret;
 
     if (ps->fd < 0)
         return 0;
 
-    if (pcap_packet_fill(&packet, to_tpm,
+    if (pcap_packet_fill(packet, to_tpm,
                          tpm_packet_len, tpm_packet_len, ps) < 0)
         return -1;
 
-    calc_checksums(&packet, tpm_packet, tpm_packet_len, ps);
+    calc_checksums(packet, tpm_packet, tpm_packet_len, ps);
 
-    ret = pcap_write(ps->fd, &packet, tpm_packet, tpm_packet_len);
+    ret = pcap_write(ps->fd, packet, tpm_packet, tpm_packet_len);
     if (ret < 0)
         return ret;
 

--- a/src/swtpm/swtpm_nvstore.c
+++ b/src/swtpm/swtpm_nvstore.c
@@ -75,12 +75,8 @@
 # include <openssl/hmac.h>
 #endif
 
-#if defined(__OpenBSD__)
- # define OPENSSL_OLD_API
-#else
- #if OPENSSL_VERSION_NUMBER < 0x10100000
-  #define OPENSSL_OLD_API
- #endif
+#if OPENSSL_VERSION_NUMBER < 0x10100000
+ #define OPENSSL_OLD_API
 #endif
 
 #include "swtpm.h"

--- a/src/swtpm_cert/ek-cert.c
+++ b/src/swtpm_cert/ek-cert.c
@@ -61,13 +61,21 @@
 #include <openssl/bio.h>
 #include <openssl/evp.h>
 #include <openssl/pem.h>
-#include <openssl/core_names.h>
-#include <openssl/param_build.h>
+#ifndef LIBRESSL_VERSION_NUMBER
+# include <openssl/core_names.h>
+# include <openssl/param_build.h>
+#endif
 #include <openssl/x509v3.h>
 #include <openssl/err.h>
-#include <openssl/provider.h>
+#ifndef LIBRESSL_VERSION_NUMBER
+# include <openssl/provider.h>
+#else
+# include <openssl/engine.h>
+#endif
 #include <openssl/ui.h>
-#include <openssl/store.h>
+#ifndef LIBRESSL_VERSION_NUMBER
+# include <openssl/store.h>
+#endif
 
 #include <gmp.h>
 
@@ -176,11 +184,15 @@ typedef struct TCG_PCCLIENT_STORED_FULL_CERT_HEADER {
 
 static bool uses_hashless_signing(const EVP_PKEY *key)
 {
+#ifndef LIBRESSL_VERSION_NUMBER
     return EVP_PKEY_is_a(key, "ml-dsa-44") ||
            EVP_PKEY_is_a(key, "ml-dsa-65") ||
            EVP_PKEY_is_a(key, "ml-dsa-87") ||
            EVP_PKEY_is_a(key, "ED25519") ||
            EVP_PKEY_is_a(key, "ED448");
+#else
+    return EVP_PKEY_base_id(key) == EVP_PKEY_ED25519;
+#endif
 }
 
 static void versioninfo(void)
@@ -321,6 +333,7 @@ static unsigned char *hex_str_to_bin(const char *hexstr, int *modulus_len)
     return result;
 }
 
+#ifndef LIBRESSL_VERSION_NUMBER
 static EVP_PKEY *
 create_rsa_from_modulus(unsigned char *modulus, unsigned int modulus_len,
                         uint32_t exponent)
@@ -362,7 +375,41 @@ cleanup:
 
     return pubkey;
 }
+#else
+static EVP_PKEY *
+create_rsa_from_modulus(unsigned char *modulus, unsigned int modulus_len,
+                        uint32_t exponent)
+{
+    RSA *rsa = RSA_new();
+    EVP_PKEY *pubkey = EVP_PKEY_new();
+    BIGNUM *n = BN_bin2bn(modulus, modulus_len, NULL);
+    BIGNUM *e = BN_new();
 
+    if (!rsa || !pubkey || !e || !n) {
+        fprintf(stderr, "Out of memory.\n");
+        goto cleanup;
+    }
+
+    CHECK_OSSL_RETURN1(!BN_set_word(e, exponent),
+                       "Could not set exponent.\n");
+    CHECK_OSSL_RETURN1(!RSA_set0_key(rsa, n, e, NULL),
+                       "Could not push BN.\n");
+    n = NULL;
+    e = NULL;
+    CHECK_OSSL_RETURN1(!EVP_PKEY_assign_RSA(pubkey, rsa),
+                       "Could not create RSA public key.\n");
+    return pubkey;
+
+cleanup:
+    EVP_PKEY_free(pubkey);
+    RSA_free(rsa);
+    BN_free(e);
+    BN_free(n);
+    return NULL;
+}
+#endif
+
+#ifndef LIBRESSL_VERSION_NUMBER
 static EVP_PKEY *
 create_ecc_from_x_and_y(unsigned char *ecc_x, unsigned int ecc_x_len,
                         unsigned char *ecc_y, unsigned int ecc_y_len,
@@ -423,7 +470,81 @@ cleanup:
 
     return pubkey;
 }
+#else
+static EVP_PKEY *
+create_ecc_from_x_and_y(unsigned char *ecc_x, unsigned int ecc_x_len,
+                        unsigned char *ecc_y, unsigned int ecc_y_len,
+                        const char *ecc_curveid)
+{
+    EVP_PKEY *pubkey = NULL;
+    EC_KEY *ec_key = NULL;
+    EC_GROUP *group = NULL;
+    EC_POINT *point = NULL;
+    BIGNUM *x = NULL;
+    BIGNUM *y = NULL;
+    size_t exp_len;
+    int nid;
 
+    if (ecc_curveid == NULL || !strcmp(ecc_curveid, "secp256r1")) {
+        nid = NID_X9_62_prime256v1;
+        exp_len = BITS_TO_BYTES(256);
+    } else if (!strcmp(ecc_curveid, "secp384r1")) {
+        nid = NID_secp384r1;
+        exp_len = BITS_TO_BYTES(384);
+    } else if (!strcmp(ecc_curveid, "secp521r1")) {
+        nid = NID_secp521r1;
+        exp_len = BITS_TO_BYTES(521);
+    } else {
+        fprintf(stderr, "Unsupported ECC curve id: %s\n", ecc_curveid);
+        goto cleanup;
+    }
+
+    if (ecc_x_len > exp_len || ecc_y_len > exp_len) {
+        fprintf(stderr,
+                "EC X or Y parameter exceeds expected size of %zu bytes\n",
+                exp_len);
+        goto cleanup;
+    }
+
+    x = BN_bin2bn(ecc_x, ecc_x_len, NULL);
+    y = BN_bin2bn(ecc_y, ecc_y_len, NULL);
+    group = EC_GROUP_new_by_curve_name(nid);
+    ec_key = EC_KEY_new();
+    pubkey = EVP_PKEY_new();
+    if (!x || !y || !group || !ec_key || !pubkey) {
+        fprintf(stderr, "Out of memory.\n");
+        goto cleanup;
+    }
+
+    CHECK_OSSL_RETURN1(!EC_KEY_set_group(ec_key, group),
+                       "Could not set EC group.\n");
+    point = EC_POINT_new(group);
+    CHECK_OSSL_NULLPTR1(point, "Could not create EC point.\n");
+    CHECK_OSSL_RETURN1(!EC_POINT_set_affine_coordinates(group, point,
+                                                            x, y, NULL),
+                       "Could not set EC point coordinates.\n");
+    CHECK_OSSL_RETURN1(!EC_KEY_set_public_key(ec_key, point),
+                       "Could not set EC public key.\n");
+    CHECK_OSSL_RETURN1(!EVP_PKEY_assign_EC_KEY(pubkey, ec_key),
+                       "Could not assign EC key.\n");
+    EC_POINT_free(point);
+    EC_GROUP_free(group);
+    BN_free(x);
+    BN_free(y);
+    return pubkey;
+
+cleanup:
+    EVP_PKEY_free(pubkey);
+    EC_KEY_free(ec_key);
+    EC_POINT_free(point);
+    EC_GROUP_free(group);
+    BN_free(x);
+    BN_free(y);
+    return NULL;
+}
+#endif
+
+#ifndef LIBRESSL_VERSION_NUMBER
 static EVP_PKEY *create_pubkey(unsigned char *public_bin, size_t public_len,
                                const char *keyalgo)
 {
@@ -455,6 +576,7 @@ cleanup:
 
     return pubkey;
 }
+#endif
 
 static int
 asn_init(void)
@@ -1033,6 +1155,7 @@ static int ui_get_pin(UI *ui, UI_STRING *uis)
     return 1;
 }
 
+#ifndef LIBRESSL_VERSION_NUMBER
 static EVP_PKEY *get_key_pkcs11(OSSL_PROVIDER *provider, const char *pkcs11uri)
 {
     OSSL_STORE_CTX *store = NULL;
@@ -1077,15 +1200,72 @@ cleanup:
 
     return sigkey;
 }
+#else
+static EVP_PKEY *
+get_key_pkcs11(const char *key_id)
+{
+    EVP_PKEY *sigkey = NULL;
+    ENGINE *engine = NULL;
+    UI_METHOD *ui_method = NULL;
+
+    if (getenv("SWTPM_PKCS11_PIN")) {
+        ui_method = UI_create_method("PIN reader");
+        CHECK_OSSL_NULLPTR1(ui_method, "Could not create the PIN reader.\n");
+
+        CHECK_OSSL_RETURN1(UI_method_set_reader(ui_method, ui_get_pin) != 0,
+                           "Could not set the PIN reader.\n");
+    }
+
+    ENGINE_load_builtin_engines();
+
+    engine = ENGINE_by_id("pkcs11");
+    if (!engine) {
+        fprintf(stderr, "Could not find pkcs11 engine.\n");
+        ERR_print_errors_fp(stderr);
+        goto cleanup;
+    }
+
+    if (!ENGINE_init(engine)) {
+        fprintf(stderr, "Could not initialize pkcs11 engine.\n");
+        ERR_print_errors_fp(stderr);
+        goto cleanup;
+    }
+
+    if (!ENGINE_set_default(engine, ENGINE_METHOD_ALL)) {
+        fprintf(stderr, "Could not set pkcs11 engine as default.\n");
+        ERR_print_errors_fp(stderr);
+        goto cleanup;
+    }
+
+    sigkey = ENGINE_load_private_key(engine, key_id, ui_method, NULL);
+    CHECK_OSSL_NULLPTR1(sigkey, "Could not get access to private key.\n");
+
+cleanup:
+    if (engine) {
+        ENGINE_finish(engine);
+        ENGINE_free(engine);
+    }
+    UI_destroy_method(ui_method);
+    return sigkey;
+}
+#endif
 
 static const EVP_MD *get_hashalg_for_signing(EVP_PKEY *signingkey)
 {
+#ifndef LIBRESSL_VERSION_NUMBER
     int bits = EVP_PKEY_get_bits(signingkey);
+#else
+    int bits = EVP_PKEY_bits(signingkey);
+#endif
     const EVP_MD *md;
 
     if (uses_hashless_signing(signingkey)) {
         md = NULL;
+#ifndef LIBRESSL_VERSION_NUMBER
     } else if (EVP_PKEY_is_a(signingkey, "RSA")) {
+#else
+    } else if (EVP_PKEY_base_id(signingkey) == EVP_PKEY_RSA) {
+#endif
         switch (bits) {
         case 2048:
             md = EVP_sha256();
@@ -1094,7 +1274,11 @@ static const EVP_MD *get_hashalg_for_signing(EVP_PKEY *signingkey)
             md = EVP_sha384();
             break;
         }
+#ifndef LIBRESSL_VERSION_NUMBER
     } else if (EVP_PKEY_is_a(signingkey, "EC")) {
+#else
+    } else if (EVP_PKEY_base_id(signingkey) == EVP_PKEY_EC) {
+#endif
         if (bits >= 512)
             md = EVP_sha512();
         else if (bits >= 384)
@@ -1152,7 +1336,10 @@ int main(int argc, char *argv[])
     X509_EXTENSION *ext = NULL;
     const X509_NAME *issuer_name = NULL;
     X509V3_CTX x509v3_ctx;
+#ifndef LIBRESSL_VERSION_NUMBER
     OSSL_PROVIDER *provider = NULL;
+#else
+#endif
     const EVP_MD *md;
     const char *pubkey_filename = NULL;
     const char *sigkey_filename = NULL;
@@ -1608,9 +1795,13 @@ int main(int argc, char *argv[])
 
             is_ecc = true;
         } else if (public_bin) {
+#ifndef LIBRESSL_VERSION_NUMBER
             if (strncmp(keyalgo, "ml-kem-", 7) == 0 ||
                 strncmp(keyalgo, "ml-dsa-", 7) == 0) {
                 pubkey = create_pubkey(public_bin, public_len, keyalgo);
+#else
+            if (0) {
+#endif
             } else {
                 fprintf(stderr, "Internal error: Unhandled keyalgo '%s'.\n",
                         keyalgo);
@@ -1633,11 +1824,16 @@ int main(int argc, char *argv[])
     }
 
     if (strstr(sigkey_filename, "pkcs11:") == sigkey_filename) {
+#ifndef LIBRESSL_VERSION_NUMBER
         provider = OSSL_PROVIDER_try_load(NULL, "pkcs11", 1);
         CHECK_OSSL_NULLPTR1(provider, "Could not load provider 'pkcs11'.\n");
 
         if (!(sigkey = get_key_pkcs11(provider, sigkey_filename)))
             goto cleanup;
+#else
+        if (!(sigkey = get_key_pkcs11(sigkey_filename)))
+            goto cleanup;
+#endif
     } else {
         if (!(fp = fopen(sigkey_filename, "r"))) {
             fprintf(stderr, "Could not open signing key file: %s\n",
@@ -1677,15 +1873,24 @@ int main(int argc, char *argv[])
     FCLOSE(fp);
 
     /* Build the certificate */
+#ifndef LIBRESSL_VERSION_NUMBER
     crt = X509_new_ex(NULL, NULL);
+#else
+    crt = X509_new();
+#endif
     CHECK_OSSL_NULLPTR1(crt, "Out of memory.\n");
 
     oct = ASN1_OCTET_STRING_new();
     CHECK_OSSL_NULLPTR1(oct, "Out of memory.\n");
 
     /* Version */
+#ifndef LIBRESSL_VERSION_NUMBER
     CHECK_OSSL_RETURN1(X509_set_version(crt, X509_VERSION_3) != 1,
                        "Could not set version on CRT.\n");
+#else
+    CHECK_OSSL_RETURN1(X509_set_version(crt, 2) != 1,
+                       "Could not set version on CRT.\n");
+#endif
 
     /* Serial Number */
     bn_serial = BN_bin2bn(ser_number, ser_number_len, NULL);
@@ -1702,8 +1907,13 @@ int main(int argc, char *argv[])
     CHECK_OSSL_NULLPTR1(issuer_name,
                         "Could not get subject name from signer cert.\n");
 
+#ifndef LIBRESSL_VERSION_NUMBER
     CHECK_OSSL_RETURN1(!X509_set_issuer_name(crt, issuer_name),
                        "Could not set issuer name on CRT.\n");
+#else
+    CHECK_OSSL_RETURN1(!X509_set_issuer_name(crt, (X509_NAME *)issuer_name),
+                       "Could not set issuer name on CRT.\n");
+#endif
 
     /* Validity */
     now = time(NULL);
@@ -2069,7 +2279,9 @@ cleanup:
     X509_EXTENSION_free(ext);
     X509_free(sigcert);
     X509_free(crt);
+#ifndef LIBRESSL_VERSION_NUMBER
     OSSL_PROVIDER_unload(provider);
+#endif
     if (fp)
         fclose(fp);
 

--- a/src/swtpm_localca/swtpm_localca.c
+++ b/src/swtpm_localca/swtpm_localca.c
@@ -22,6 +22,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <openssl/opensslv.h>
+
 #include <glib.h>
 
 #include <gmp.h>
@@ -131,6 +133,55 @@ static int create_localca_cert(const gchar *lockfile, const gchar *statedir,
         }
 
         /* create root CA key and self-signed cert */
+#ifdef LIBRESSL_VERSION_NUMBER
+        g_autofree gchar *rootca_cnf = g_strdup_printf("%s-ext.conf", cacert);
+        FILE *rootca_cnf_file = fopen(rootca_cnf, "w");
+        if (!rootca_cnf_file) {
+            logerr(gl_LOGFILE, "Could not create %s: %s\n", rootca_cnf, strerror(errno));
+            goto error;
+        }
+        fprintf(rootca_cnf_file, "[req]\n"
+                "distinguished_name=dn\n"
+                "x509_extensions=v3_ca\n"
+                "prompt=no\n"
+                "\n"
+                "[dn]\n"
+                "CN = swtpm-localca-rootca\n"
+                "\n"
+                "[v3_ca]\n"
+                "basicConstraints=critical,CA:TRUE\n"
+                "keyUsage=critical,keyCertSign\n"
+                "subjectKeyIdentifier=hash\n");
+        fclose(rootca_cnf_file);
+
+        cmd = concat_arrays(NULL,
+                            (const gchar *[]) {
+                            openssl,
+                            "req",
+                            "-x509",
+                            "-newkey", NEWKEY_ALGO,
+                            "-keyout", cakey,
+                            "-out", cacert,
+                            "-days", CERT_DAYS,
+                            CERT_HASH,
+                            "-config", rootca_cnf,
+                            swtpm_rootca_password == NULL ? "-nodes" : NULL,
+                            NULL
+                            }, FALSE);
+        if (swtpm_rootca_password != NULL) {
+            cmd = concat_arrays(cmd, (const char*[]){
+                                   "-passout", "env:SWTPM_ROOTCA_PASSWORD", NULL
+                                }, TRUE);
+            openssl_env = g_environ_setenv(openssl_env,
+                                           "SWTPM_ROOTCA_PASSWORD", swtpm_rootca_password,
+                                           TRUE);
+        }
+
+        if (run_openssl(cmd, (const char **)openssl_env, "Could not create local-CA: "))
+            goto error;
+
+        unlink(rootca_cnf);
+#else
         cmd = concat_arrays(NULL,
                             (const gchar *[]) {
                                 openssl,
@@ -157,6 +208,7 @@ static int create_localca_cert(const gchar *lockfile, const gchar *statedir,
         }
         if (run_openssl(cmd, (const char **)openssl_env, "Could not create root-CA: "))
             goto error;
+#endif
 
         if (chmod(cakey, S_IRUSR | S_IWUSR | S_IRGRP) != 0) {
             logerr(gl_LOGFILE, "Could not chmod %s: %s\n", cakey, strerror(errno));
@@ -165,6 +217,80 @@ static int create_localca_cert(const gchar *lockfile, const gchar *statedir,
 
         g_free(cmd);
         /* create intermediate CA's key and certificate */
+#ifdef LIBRESSL_VERSION_NUMBER
+        g_autofree gchar *csr = g_strdup_printf("%s-csr.pem", issuercert);
+        g_autofree gchar *ext = g_strdup_printf("%s-ext.conf", issuercert);
+
+        cmd = concat_arrays(NULL,
+                            (const gchar *[]) {
+                                openssl,
+                                "req",
+                                "-new",
+                                "-keyout", signkey,
+                                "-newkey", NEWKEY_ALGO,
+                                "-subj", "/CN=swtpm-localca",
+                                "-out", csr,
+                                signkey_password == NULL ? "-nodes" : NULL,
+                                NULL
+                            }, FALSE);
+        if (signkey_password != NULL) {
+            cmd = concat_arrays(cmd,
+                                (const gchar *[]) {
+                                    "-passout", "env:SWTPM_CA_PASSWORD",
+                                    NULL
+                                }, TRUE);
+            openssl_env = g_environ_setenv(openssl_env,
+                                           "SWTPM_CA_PASSWORD", signkey_password,
+                                           TRUE);
+        }
+
+        if (run_openssl(cmd, (const char **)openssl_env, "Could not create CSR: "))
+            goto error;
+
+        g_free(cmd);
+
+        FILE *ext_file = fopen(ext, "w");
+        if (!ext_file) {
+            logerr(gl_LOGFILE, "Could not create %s: %s\n", ext, strerror(errno));
+            goto error;
+        }
+        fprintf(ext_file, "[v3_ca]\n"
+                "basicConstraints=critical,CA:TRUE\n"
+                "keyUsage=critical,keyCertSign\n"
+                "subjectKeyIdentifier=hash\n"
+                "authorityKeyIdentifier=keyid,issuer\n");
+        fclose(ext_file);
+
+        cmd = concat_arrays(NULL,
+                            (const gchar *[]) {
+                                openssl,
+                                "x509",
+                                "-req",
+                                "-in", csr,
+                                "-out", issuercert,
+                                "-days", CERT_DAYS,
+                                CERT_HASH,
+                                "-CA", cacert,
+                                "-CAkey", cakey,
+                                "-set_serial", "1",
+                                "-extfile", ext,
+                                "-extensions", "v3_ca",
+                                NULL
+                            }, FALSE);
+        if (swtpm_rootca_password != NULL) {
+            cmd = concat_arrays(cmd,
+                                (const gchar *[]) {
+                                    "-passin", "env:SWTPM_ROOTCA_PASSWORD",
+                                    NULL
+                                }, TRUE);
+        }
+
+        if (run_openssl(cmd, (const char **)openssl_env, "Could not create local-CA: "))
+            goto error;
+
+        unlink(csr);
+        unlink(ext);
+#else
         cmd = concat_arrays(NULL,
                             (const gchar *[]) {
                                 openssl,
@@ -203,6 +329,7 @@ static int create_localca_cert(const gchar *lockfile, const gchar *statedir,
 
         if (run_openssl(cmd, (const char **)openssl_env, "Could not create local-CA: "))
             goto error;
+#endif
 
         if (chmod(signkey, S_IRUSR | S_IWUSR | S_IRGRP) != 0) {
             logerr(gl_LOGFILE, "Could not chmod %s: %s\n", signkey, strerror(errno));

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -408,6 +408,28 @@ static int read_certificate_file(const gchar *certsdir, const gchar *filename,
     return read_file(*certfile, filecontent, filecontent_len);
 }
 
+#ifdef LIBRESSL_VERSION_NUMBER
+/* leaks akid */
+const ASN1_OCTET_STRING *X509_get0_authority_key_id(X509 *);
+const ASN1_OCTET_STRING *X509_get0_authority_key_id(X509 *cert)
+{
+    AUTHORITY_KEYID *akid = NULL;
+
+    if (cert == NULL)
+        return NULL;
+
+    akid = (AUTHORITY_KEYID *)X509_get_ext_d2i(cert,
+                                               NID_authority_key_identifier,
+                                               NULL, NULL);
+    if (akid == NULL)
+        return NULL;
+
+    if (akid->keyid && akid->keyid->data && akid->keyid->length > 0)
+        return akid->keyid;
+    return NULL;
+}
+#endif
+
 static int tpm2_extract_certificate_data(const gchar *certdata, size_t certdata_len,
                                          struct ek_certificate_data *ecd)
 {

--- a/tests/_test_tpm2_swtpm_cert
+++ b/tests/_test_tpm2_swtpm_cert
@@ -44,6 +44,18 @@ function check_cert()
 
 	check_cert_size "${cert}" "${size}"
 	txt=$(openssl x509 -in "${cert}" -noout -text)
+	if openssl version 2>/dev/null | grep -qi LibreSSL; then
+		txt=$(printf '%s\n' "$txt" | sed \
+			-e 's/2\.23\.133\.8\.1/Endorsement Key Certificate/g' \
+			-e 's/2\.23\.133\.8\.2/Platform Attribute Certificate/g' \
+			-e 's/2\.23\.133\.2\.1/tcg-at-tpmManufacturer/g' \
+			-e 's/2\.23\.133\.2\.2/tcg-at-tpmModel/g' \
+			-e 's/2\.23\.133\.2\.3/tcg-at-tpmVersion/g' \
+			-e 's/2\.23\.133\.5\.1\.1/tcg-at-platformManufacturerStr/g' \
+			-e 's/2\.23\.133\.5\.1\.4/tcg-at-platformModel/g' \
+			-e 's/2\.23\.133\.5\.1\.5/tcg-at-platformVersion/g' \
+			-e 's/1\.3\.6\.1\.5\.5\.7\.8\.4/id-on-hardwareModuleName/g')
+	fi
 
 	while [ $# -ne 0 ]; do
 		if ! grep -q "$1" <<< "${txt}"; then
@@ -54,6 +66,16 @@ function check_cert()
 		fi
 		shift
 	done
+	if openssl version 2>/dev/null | grep -qi LibreSSL; then
+		if ! msg=$(openssl verify \
+			-CAfile "${PARAM_CACERT}" \
+			-untrusted "${PARAM_ISSUERCERT}" \
+			"${cert}" 2>&1); then
+			echo "Could not verify the certificate."
+			echo "${msg}"
+			exit 1
+		fi
+	else # no LibreSSL
 	if ! msg=$(openssl verify \
 		-partial_chain \
 		-CAfile "${PARAM_ISSUERCERT}" \
@@ -61,6 +83,7 @@ function check_cert()
 		echo "Could not verify the certificate."
 		echo "${msg}"
 		exit 1
+	fi
 	fi
 }
 
@@ -169,6 +192,7 @@ echo -n > "${cert}"
 echo "Test ${TC}: OK (ecc)"
 
 
+if ! openssl version 2>/dev/null | grep -qi LibreSSL; then
 if ! ${SWTPM_CERT} \
 	"${COMMON[@]}" \
 	--pubkey "${PARAM_MLKEM1024PUBKEY}";
@@ -188,8 +212,12 @@ check_cert "${cert}" "${PARAM_CERT_SIZES[$((TC++))]}" \
 # truncate result file
 echo -n > "${cert}"
 echo "Test ${TC}: OK (ML-KEM-1024 key)"
+else # LibreSSL
+echo "Test ${TC}: SKIP unsupported (ML-KEM-1024 key)"
+fi
 
 
+if ! openssl version 2>/dev/null | grep -qi LibreSSL; then
 if ! ${SWTPM_CERT} \
 	"${COMMON[@]}" \
 	--public 16d75180b96183fc9ff96aa6b8d93793a0a645dc97589b62245955be3061719525ac90c3efb17308859038776d7eb88c8b55a8d9ebbeb8873f2b798d9888aff3f22358808b1c3c489d690d29ea9f6e1c1c301815686a0d39d1479f0979cfb07f7127c37c83c2f26a9c8c203d68c41ae6a690ce56bc4276082cec00c32a5b6515a41121a853d76e64e2a928aac333a4618af260ef7763b9f425d1737926e180ec50cbb87b334b085a638568455c2d14b8501056514e062365117a6603b007a70d1567290297b3998a7bc0cab0b43625a2fa94e58b88755cb3c5779aaff877ff11c1b380555bb05eae277f98808ebf590f6bc33c26353e8a55abdf838e7cb5ada53545dc3164e668494ef45441016f11b94c964b379c653f28111286f25987c0283189ba3dc34430f3c026b72870667dfe85038dec103ae08c511cc8dc292fd9091ac624575d78994ff54f3b20b985b62d76c6512c240c65024fba29a486b9c096ac9173c44583f94a1e6c5e1586ab35c3c93d667e5edb22393705eb9782666c76423954b818b346012851aa015af6cb9865ca45aa14e966a7882704d28049c66601615855acb604ced42bf743c1c1a37ead7bbd2284bf512086d6a6cde9f22e39a5abe321393b477f07ec76a5529cc81996c99777df184f41842f1722801d936becda48159c21e85bc5f39b6f17e537a18956eca7238e0336b196bc5a36b1c6e531b88b29a1b23ad9d0bfb6643c65092730e81410154faf1a429950aa3cf7a435a24d1ca00930bb354c207a5809958a505936224fcfcbb4f622ca5115113781b53f1225dda59b39bba4b82ca180f535ac3b7554a62187566a3a3c81dfc9cf7fd91648b36c0e19237dd2a067d86d627c366cacb716acaa3fd9c22bd0a1dd6256d42b2a460acb1a95ccf0070f62367096765d06dcb2f7959f0c7280874362c0f75473998240a91ac70528aec4b49ea974bf975f405180bd1393093555f015ca1dc81c8b22999466a674d440ee47bffd5193fae2c67ba6360e86c4d3a38c52a448f773b91094c25d56731ce83bdf515e6a345999186136f57a4bdb2d6c49aa185c81330e8ff4bdbd9321bb74c5e0c6c217c7b78a02783594a09dd7aeb9293b1e31fc \
@@ -210,8 +238,12 @@ check_cert "${cert}" "${PARAM_CERT_SIZES[$((TC++))]}" \
 # truncate result file
 echo -n > "${cert}"
 echo "Test ${TC}: OK (ML-KEM-512 key)"
+else # LibreSSL
+echo "Test ${TC}: SKIP unsupported (ML-KEM-512 key)"
+fi
 
 
+if ! openssl version 2>/dev/null | grep -qi LibreSSL; then
 if ! ${SWTPM_CERT} \
 	"${COMMON[@]}" \
 	--pubkey "${PARAM_MLDSA87PUBKEY}";
@@ -231,6 +263,9 @@ check_cert "${cert}" "${PARAM_CERT_SIZES[$((TC++))]}" \
 # truncate result file
 echo -n > "${cert}"
 echo "Test ${TC}: OK (ML-DSA-87 key)"
+else # LibreSSL
+echo "Test ${TC}: SKIP unsupported (ML-DSA-87 key)"
+fi
 
 ###################### Platform Certificate #####################
 
@@ -312,6 +347,7 @@ echo -n > "${cert}"
 echo "Test ${TC}: OK (IAK)"
 
 
+if ! openssl version 2>/dev/null | grep -qi LibreSSL; then
 if ! ${SWTPM_CERT} \
 	"${COMMON[@]}" \
 	--type iak \
@@ -333,6 +369,9 @@ check_cert "${cert}" "${PARAM_CERT_SIZES[$((TC++))]}" \
 # truncate result file
 echo -n > "${cert}"
 echo "Test ${TC}: OK (ML-DSA-87 IAK)"
+else # LibreSSL
+echo "Test ${TC}: SKIP unsupported (ML-DSA-87 IAK)"
+fi
 
 ###################### IDevID Certificate #####################
 

--- a/tests/test_swtpm_cert
+++ b/tests/test_swtpm_cert
@@ -22,6 +22,43 @@ RSA3072ENCRYPTED_PRIVKEY=${TMPDIR}/rsa3072privkey.pem
 RSA3072ENCRYPTED_PUBKEY=${TMPDIR}/rsa3072pubkey.pem
 ISSUERCERT_RSA3072ENCRYPTED_PRIVKEY=${TMPDIR}/rsa3072privkeyissuercert.pem
 
+if openssl version | grep -qi "LibreSSL"; then
+if ! msg=$(openssl genrsa -out "${RSAPRIVKEY}" 2432 2>&1) ||
+   ! msg=$(openssl rsa -in "${RSAPRIVKEY}" -pubout -out "${RSAPUBKEY}" 2>&1) ||
+   ! msg=$(openssl req \
+        -new \
+        -x509 \
+        -nodes \
+        -newkey rsa:3072 \
+        -keyout "${CAKEY}" \
+        -sha256 \
+        -days 365 \
+        -out "${CACERT}" \
+        -subj "/CN=swtpm-localca-rootca" 2>&1) ||
+   ! msg=$(openssl genrsa -out "${RSA3072ENCRYPTED_PRIVKEY}" -aes256 -passout pass:password 3072 2>&1) ||
+   ! msg=$(openssl rsa -in "${RSA3072ENCRYPTED_PRIVKEY}" -pubout -passin pass:password -out "${RSA3072ENCRYPTED_PUBKEY}" 2>&1) ||
+   ! msg=$(openssl req \
+        -new \
+        -key "${RSA3072ENCRYPTED_PRIVKEY}" \
+        -passin pass:password \
+        -out "${ISSUERCERT_RSA3072ENCRYPTED_PRIVKEY}.csr" \
+        -subj "/CN=swtpm-localca" 2>&1) ||
+   ! msg=$(openssl x509 \
+        -req \
+        -in "${ISSUERCERT_RSA3072ENCRYPTED_PRIVKEY}.csr" \
+        -CA "${CACERT}" \
+        -CAkey "${CAKEY}" \
+        -CAcreateserial \
+        -passin pass:password \
+        -sha256 \
+        -days 1000 \
+        -out "${ISSUERCERT_RSA3072ENCRYPTED_PRIVKEY}" 2>&1);
+then
+	echo "Could not create the required keys"
+	echo "${msg}"
+	exit 1
+fi
+else # no LibreSSL
 if ! msg=$(openssl genrsa -out "${RSAPRIVKEY}" 2432 2>&1) ||
    ! msg=$(openssl rsa -in "${RSAPRIVKEY}" -pubout -out "${RSAPUBKEY}" 2>&1) ||
    ! msg=$(openssl req \
@@ -49,6 +86,7 @@ then
 	echo "Could not create the required keys"
 	echo "${msg}"
 	exit 1
+fi
 fi
 
 PARAM_RSAPUBKEY="${RSAPUBKEY}" \

--- a/tests/test_tpm2_swtpm_cert
+++ b/tests/test_tpm2_swtpm_cert
@@ -41,6 +41,71 @@ ISSUERCERT_MLDSA87=${TMPDIR}/mldsa87-issuercert.pem
 # ED448 key used for signing
 ISSUERCERT_ED448=${TMPDIR}/ed448-issuercert.pem
 
+if openssl version 2>/dev/null | grep -qi 'LibreSSL'; then
+    EC521CSR=${TMPDIR}/ec521-signing.csr
+    RSA3072CSR=${TMPDIR}/rsa3072-signing.csr
+    ISSUER_EXTFILE=${TMPDIR}/issuer-ext.cnf
+    cat > "${ISSUER_EXTFILE}" <<EOF
+[v3_ca]
+basicConstraints = critical,CA:TRUE
+keyUsage = critical,keyCertSign,cRLSign
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+EOF
+    if ! msg=$(openssl genrsa -out "${RSAPRIVKEY}" 2432 2>&1) ||
+       ! msg=$(openssl rsa -in "${RSAPRIVKEY}" -pubout -out "${RSAPUBKEY}" 2>&1) ||
+       ! msg=$(openssl ecparam -name prime256v1 -genkey -noout -out "${EC256PRIVKEY}" 2>&1) ||
+       ! msg=$(openssl ec -in "${EC256PRIVKEY}" -pubout -out "${EC256PUBKEY}" 2>&1) ||
+       ! msg=$(openssl req \
+            -x509 \
+            -new \
+            -nodes \
+            -keyout "${CAKEY}" \
+            -newkey rsa:3072 \
+            -sha256 \
+            -days 365 \
+            -out "${CACERT}" \
+            -subj "/CN=swtpm-localca-rootca" 2>&1) ||
+       ! msg=$(openssl ecparam -name secp521r1 -genkey -noout -out "${EC521PRIVKEY}" 2>&1) ||
+       ! msg=$(openssl ec -in "${EC521PRIVKEY}" -pubout -out "${EC521PUBKEY}" 2>&1) ||
+       ! msg=$(openssl genrsa -out "${RSA3072PRIVKEY}" 3072 2>&1) ||
+       ! msg=$(openssl rsa -in "${RSA3072PRIVKEY}" -pubout -out "${RSA3072PUBKEY}" 2>&1) ||
+       ! msg=$(openssl req \
+            -new \
+            -key "${EC521PRIVKEY}" \
+            -out "${EC521CSR}" \
+            -subj "/CN=swtpm-localca" 2>&1) ||
+       ! msg=$(openssl x509 \
+            -req \
+            -in "${EC521CSR}" \
+            -CA "${CACERT}" \
+            -CAkey "${CAKEY}" \
+            -CAcreateserial \
+            -days 1000 \
+            -extfile "${ISSUER_EXTFILE}" \
+            -extensions v3_ca \
+            -out "${ISSUERCERT_EC521}" 2>&1) ||
+       ! msg=$(openssl req \
+            -new \
+            -key "${RSA3072PRIVKEY}" \
+            -out "${RSA3072CSR}" \
+            -subj "/CN=swtpm-localca" 2>&1) ||
+       ! msg=$(openssl x509 \
+            -req \
+            -in "${RSA3072CSR}" \
+            -CA "${CACERT}" \
+            -CAkey "${CAKEY}" \
+            -CAcreateserial \
+            -days 1000 \
+            -extfile "${ISSUER_EXTFILE}" \
+            -extensions v3_ca \
+            -out "${ISSUERCERT_RSA3072}" 2>&1) \
+; then
+        echo "Could not create the required keys"
+        echo "${msg}"
+        exit 1
+    fi
+else
 if ! msg=$(openssl genrsa -out "${RSAPRIVKEY}" 2432 2>&1) ||
    ! msg=$(openssl rsa -in "${RSAPRIVKEY}" -pubout -out "${RSAPUBKEY}" 2>&1) ||
    ! msg=$(openssl ecparam -name prime256v1 -genkey -noout -out "${EC256PRIVKEY}" 2>&1) || \
@@ -102,6 +167,7 @@ if ! msg=$(openssl genrsa -out "${RSAPRIVKEY}" 2432 2>&1) ||
 	echo "${msg}"
 	exit 1
 fi
+fi
 
 echo "Testing with RSA certificate signing key"
 
@@ -111,6 +177,7 @@ PARAM_MLKEM1024PUBKEY="${MLKEM1024PUBKEY}" \
 PARAM_MLDSA87PUBKEY="${MLDSA87PUBKEY}" \
 PARAM_SIGNKEY="${RSA3072PRIVKEY}" \
 PARAM_ISSUERCERT="${ISSUERCERT_RSA3072}" \
+PARAM_CACERT="${CACERT}" \
 PARAM_CERT_SIZES="1046 841 1092 841 2340 1572 3364 1057 806 973 3245 973 1112" \
 	./_test_tpm2_swtpm_cert
 ret=$?
@@ -125,12 +192,17 @@ PARAM_MLKEM1024PUBKEY="${MLKEM1024PUBKEY}" \
 PARAM_MLDSA87PUBKEY="${MLDSA87PUBKEY}" \
 PARAM_SIGNKEY="${EC521PRIVKEY}" \
 PARAM_ISSUERCERT="${ISSUERCERT_EC521}" \
+PARAM_CACERT="${CACERT}" \
 PARAM_CERT_SIZES="792-794 587-589 838-840 587-589 2086-2088 1318-1320 3110-3112 804-805 552-554 719-721 2991-2993 720-721 858-860" \
 	./_test_tpm2_swtpm_cert
 ret=$?
 [ $ret -ne 0 ] && exit $ret
 
 
+if openssl version 2>/dev/null | grep -qi 'LibreSSL'; then
+printf "\nWarning: ml-dsa-87 and Ed448 are not yet supported with LibreSSL\n"
+	exit 0
+fi
 printf "\nTesting with ml-dsa-87 certificate signing key\n"
 
 PARAM_RSAPUBKEY="${RSAPUBKEY}" \
@@ -157,6 +229,5 @@ PARAM_CERT_SIZES="758 553 804 553 2052 1284 3076 769 518 685 2957 685 824" \
 	./_test_tpm2_swtpm_cert
 ret=$?
 [ $ret -ne 0 ] && exit $ret
-
 
 exit 0

--- a/tests/test_tpm2_swtpm_localca
+++ b/tests/test_tpm2_swtpm_localca
@@ -103,7 +103,7 @@ do
   for u in $usage; do
     echo "$u"
     if ! openssl x509 -inform der -in "${workdir}/ek.cert" -text -noout | \
-            grep "Key Usage" -A1 | \
+            grep -A1 "Key Usage" | \
             grep -q "$u"; then
       echo "Error: Could not find key usage $u in key created " \
            "with $params."
@@ -115,12 +115,29 @@ do
 
   IFS="$OIFS"
 
+  if openssl version | grep -qi "LibreSSL"; then
+    if ! openssl x509 \
+           -inform DER \
+           -in "${workdir}/ek.cert" \
+           -out "${workdir}/ek.cert.pem"; then
+      echo "Error: Could not convert DER certificate chain."
+      exit 1
+    fi
+    if ! openssl verify \
+           -CAfile "${workdir}/swtpm-localca-rootca-cert.pem" \
+           -untrusted "${ISSUERCERT}" \
+         "${workdir}/ek.cert.pem"; then
+      echo "Error: Could not verify certificate chain."
+      exit 1
+    fi
+  else # no LibreSSL
   if ! openssl verify \
          -CAfile "${workdir}/swtpm-localca-rootca-cert.pem" \
          -untrusted "${ISSUERCERT}" \
          "${workdir}/ek.cert"; then
     echo "Error: Could not verify certificate chain."
     exit 1
+  fi
   fi
 
   # Delete all keys to have CA re-created

--- a/tests/test_tpm2_swtpm_localca_pkcs11.test
+++ b/tests/test_tpm2_swtpm_localca_pkcs11.test
@@ -76,6 +76,51 @@ fi
 # And now create the intermediate CA with the pkcs11 URI key
 
 pubkey="${workdir}/swtpm-localca-interm-pubkey.pem"
+if openssl version | grep -qi "LibreSSL"; then
+	csr="${workdir}/swtpm-localca-interm-csr.pem"
+	ext="${workdir}/swtpm-localca-interm-ext.conf"
+	template="${workdir}/swtpm-localca-interm-csr-template.txt"
+
+	if ! msg=$(timeout 5 p11tool --export-pubkey "${pkcs11uri}" \
+		--outfile "${pubkey}" 2>&1"); then
+		echo "Could not get public key for pkcs11 uri key ($pkcs11uri}."
+		echo "${msg}"
+		exit 1
+	fi
+
+	cat > "${template}" << EOF
+cn = "swtpm-localca"
+signing_key = "${pkcs11uri}"
+EOF
+	msg=$(certtool --generate-request --template "${template}" \
+		--outfile "${csr}" 2>&1)
+	rc=$?
+	rm -f "${template}"
+	if [ "$rc" -ne 0 ]; then
+		echo "Could not generate request for pkcs11 uri key ($pkcs11uri}."
+		echo "${msg}"
+		exit 1
+	fi
+
+	cat > "${ext}" << EOF
+[v3_ca]
+keyUsage=critical,keyCertSign
+basicContsraints=critical,CA:TRUE
+EOF
+	if ! msg=$(openssl x509 \
+		-req -in "${csr}" -CA "${cacert}" -CAkey "${cakey}" \
+		-key "${pkcs11uri}" \
+		-CAcreateserial -CAserial "${CERTSERIAL}" \
+		-days 3650 \
+		-extfile "${ext}" \
+		-extensions "v3_ca" \
+		-out "${ISSUERCERT}" 2>&1); then
+		echo "Could not create intermediate CA"
+		echo "${msg}"
+		exit 1
+	fi
+	rm -f "${csr}" "${ext}" 
+else # not LibreSSL
 
 # Some versions of pkcs11 provider + OpenSSL may get stuck here (Ubuntu 26.04 host)
 msg=$(timeout 5 openssl pkey \
@@ -109,6 +154,7 @@ if ! msg=$(openssl req \
 fi
 
 echo -n 1 > "${CERTSERIAL}"
+fi # not LibreSSL
 
 # Now we can create the config files
 cat <<_EOF_ > "${workdir}/swtpm-localca.conf"

--- a/tests/test_tpm2_swtpm_setup_create_cert
+++ b/tests/test_tpm2_swtpm_setup_create_cert
@@ -143,7 +143,7 @@ for keysize in ${keysizes}; do
 		openssl x509 -inform der -in "${certfile}" -noout -text
 		exit 1
 	fi
-	if ! openssl x509 -inform der -in "${certfile}" -noout -text | grep "Key Usage" -A1 | \
+	if ! openssl x509 -inform der -in "${certfile}" -noout -text | grep -A1 "Key Usage" | \
 		grep -q "Digital Signature"; then
 		echo "Error: EK file '${certfile}' does not have key usage flag 'Digitial Signature' set."
 		openssl x509 -inform der -in "${certfile}" -noout -text
@@ -265,7 +265,7 @@ for pwdfile in "" "${PWDFILE}"; do
 		fi
 		# IAK and IDevID need serialNumber to match <company>:<ek cert akid>:<ek cert serial num>
 		if [[ ${certfile} =~ (iak|idevid) ]]; then
-			cert_vmid=$(openssl x509 -inform der --in "${certfile}" -noout -text \
+			cert_vmid=$(openssl x509 -inform der -in "${certfile}" -noout -text \
 				| sed -n 's/.*Subject:.*serialNumber[[:space:]]*=[[:space:]]*//p')
 			if [ "${cert_vmid}" != "${vmid}" ]; then
 				echo "Error: The subject serialNumber in the cert is wrong"
@@ -274,8 +274,8 @@ for pwdfile in "" "${PWDFILE}"; do
 				exit 1
 			fi
 			# The serial number in the SAN is not display 'nicely'...
-			serial=$(openssl x509 -inform der --in "${certfile}" -noout -text \
-			          | grep "Subject Alternative Name:" -A1 \
+			serial=$(openssl x509 -inform der -in "${certfile}" -noout -text \
+			          | grep -A1 "Subject Alternative Name:" \
 			          | tail -n1 \
 				  | sed -n "s/.*\(IBM[[:print:]]*\)/\1/p")
 			if [ -z "$serial" ] || \
@@ -285,8 +285,8 @@ for pwdfile in "" "${PWDFILE}"; do
 			then
 				echo "Error: serial Number does not seem to be properly formatted"
 				echo "  serial: ${serial}"
-				openssl x509 -inform der --in "${certfile}" -noout -text \
-				    | grep "Subject Alternative Name:" -A1
+				openssl x509 -inform der -in "${certfile}" -noout -text \
+				    | grep -A1 "Subject Alternative Name:"
 				exit 1
 			fi
 		fi


### PR DESCRIPTION
This is all the changes I needed to create a (working?) port on OpenBSD.
The recent PQC changes are not yet working with LibreSSL so I had to work around them.
I purposefully did not indent the `! LibreSSL` branches to not clutter the diffs.

If it makes sense to upstream parts of these changes or if these changes do not make sense at all, I appreciate any feedback.
For now, I just wanted to put these changes somewhere.

I haven't properly tested the binary itself because I have a little bit of a bootstrapping problem with TPMs and OpenBSD.
The test log is here:
https://gist.github.com/moritzbuhl/9ef2d0e89c15e4f73532ff90449f1003