### PR TITLE
swtpm: Free buffer to avoid memory leak in failure case

### DIFF
--- a/src/swtpm/utils.c
+++ b/src/swtpm/utils.c
@@ -513,7 +513,7 @@ ssize_t file_read(const char *filename, void **buffer,
 
     ret = read_eintr(fd, *buffer, buflen);
     if (ret < 0 || (size_t)ret != buflen)
-        goto err_close;
+        goto err_free;
 
     /* make sure file is always writable */
     if (!do_chmod && (statbuf.st_mode & 0200) == 0) {
@@ -524,7 +524,7 @@ ssize_t file_read(const char *filename, void **buffer,
     }
 
     if (do_chmod && fchmod(fd, mode) < 0)
-        goto err_close;
+        goto err_free;
 
     ret = buflen;
 
@@ -533,6 +533,12 @@ err_close:
         ret = -1;
 
     return ret;
+
+err_free:
+    free(*buffer);
+    *buffer = NULL;
+
+    goto err_close;
 }
 
 /*


### PR DESCRIPTION
Free the allocated buffer in case of an error to avoid a memory leak.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup after file read or permission-setting failures.
  * Prevented retained memory from remaining accessible when these operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->