### PR TITLE
swtpm: Close mmap file descriptor in case of fchmod error

### DIFF
--- a/src/swtpm/swtpm_nvstore_linear_file.c
+++ b/src/swtpm/swtpm_nvstore_linear_file.c
@@ -21,6 +21,7 @@
 #include "swtpm.h"
 #include "swtpm_debug.h"
 #include "swtpm_nvstore_linear.h"
+#include "swtpm_utils.h"
 #include "logging.h"
 #include "tpmstate.h"
 
@@ -179,6 +180,7 @@ SWTPM_NVRAM_LinearFile_DoOpenURI(const char *uri)
         logprintf(STDERR_FILENO,
                   "SWTPM_NVRAM_LinearFile_Open: Could not change mode bits: %s\n",
                   strerror(errno));
+        SWTPM_CLOSE(mmap_state.fd);
         return TPM_FAIL;
     }
     return 0;


### PR DESCRIPTION
To avoid leaking an mmap file descriptor in case fchmod fails, close the file descriptor to avoid leaking it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when opening a URI fails during permission updates, helping prevent file-descriptor leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->