### PR TITLE
swtpm: Properly check for truncation following snprintf call

### DIFF
--- a/src/swtpm/swtpm_nvstore.c
+++ b/src/swtpm/swtpm_nvstore.c
@@ -275,7 +275,7 @@ SWTPM_NVRAM_GetFilenameForName(char *filename,       /* output: filename */
     } else {
         n = snprintf(filename, bufsize, "tpm%s-%02lx.%s", suffix, (unsigned long)tpm_number, name);
     }
-    if ((size_t)n > bufsize) {
+    if ((size_t)n >= bufsize) {
         res = TPM_FAIL;
     }
 

--- a/src/swtpm/swtpm_nvstore_dir.c
+++ b/src/swtpm/swtpm_nvstore_dir.c
@@ -182,7 +182,7 @@ SWTPM_NVRAM_GetFilepathForName(char *filepath,       /* output: rooted file path
                                             tpm_number, name, is_tempfile);
     if (rc == 0) {
         n = snprintf(filepath, bufsize, "%s/%s", tpm_state_path, filename);
-        if ((size_t) n > bufsize)
+        if ((size_t) n >= bufsize)
             rc = TPM_FAIL;
     }
 
@@ -299,7 +299,7 @@ SWTPM_NVRAM_CreateBackupFilename(const char *filepath,
     int        irc;
 
     irc = snprintf(bakfile, bakfile_len, "%s.%s", filepath, suffix);
-    if ((size_t)irc > bakfile_len) {
+    if ((size_t)irc >= bakfile_len) {
         logprintf(STDERR_FILENO,
                   "SWTPM_NVRAM_StoreData: Name of backup file is too long\n");
         rc = TPM_FAIL;


### PR DESCRIPTION
Use '>=' on the returned value from snprintf when comparing it against the buffer size passed into snprintf to determine whether truncation of the output occurred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filename and backup-path handling when generated values exactly fill the available buffer.
  * Prevented truncated, non-null-terminated paths from being accepted, improving reliability and safety during storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->