### PR TITLE
swtpm: Properly check for truncation following snprintf call

### DIFF
--- a/src/swtpm/swtpm_nvstore.c
+++ b/src/swtpm/swtpm_nvstore.c
@@ -263,7 +263,7 @@ SWTPM_NVRAM_GetFilenameForName(char *filename,       /* output: filename */
     } else {
         n = snprintf(filename, bufsize, "tpm%s-%02lx.%s", suffix, (unsigned long)tpm_number, name);
     }
-    if ((size_t)n > bufsize) {
+    if ((size_t)n >= bufsize) {
         res = TPM_FAIL;
     }
 

--- a/src/swtpm/swtpm_nvstore_dir.c
+++ b/src/swtpm/swtpm_nvstore_dir.c
@@ -181,7 +181,7 @@ SWTPM_NVRAM_GetFilepathForName(char *filepath,       /* output: rooted file path
                                             tpm_number, name, is_tempfile);
     if (rc == 0) {
         n = snprintf(filepath, bufsize, "%s/%s", tpm_state_path, filename);
-        if ((size_t) n > bufsize)
+        if ((size_t) n >= bufsize)
             rc = TPM_FAIL;
     }
 


### PR DESCRIPTION
Use '>=' on the returned value from snprintf when comparing it against the buffer size passed into snprintf to determine whether truncation of the output occurred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filename and filepath validation to prevent buffer overflows.
  * Ensured generated paths remain properly terminated for safer file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->