### PR TITLE
swtpm: Properly check for truncation following snprintf call

### DIFF
--- a/src/swtpm/swtpm_nvstore.c
+++ b/src/swtpm/swtpm_nvstore.c
@@ -263,7 +263,7 @@ SWTPM_NVRAM_GetFilenameForName(char *filename,       /* output: filename */
     } else {
         n = snprintf(filename, bufsize, "tpm%s-%02lx.%s", suffix, (unsigned long)tpm_number, name);
     }
-    if ((size_t)n > bufsize) {
+    if ((size_t)n >= bufsize) {
         res = TPM_FAIL;
     }
 

--- a/src/swtpm/swtpm_nvstore_dir.c
+++ b/src/swtpm/swtpm_nvstore_dir.c
@@ -181,7 +181,7 @@ SWTPM_NVRAM_GetFilepathForName(char *filepath,       /* output: rooted file path
                                             tpm_number, name, is_tempfile);
     if (rc == 0) {
         n = snprintf(filepath, bufsize, "%s/%s", tpm_state_path, filename);
-        if ((size_t) n > bufsize)
+        if ((size_t) n >= bufsize)
             rc = TPM_FAIL;
     }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -169,6 +169,9 @@ EXTRA_DIST=$(TESTS) \
 	patches/0007-Disable-rev155-test-cases.patch \
 	patches/0008-Disable-x509-test-cases.patch \
 	patches/0009-Disable-getcapability-TPM_CAP_ACT.patch \
+	patches/0010-Adjust-test-cases-for-OpenSSL-3.patch \
+	patches/0011-Disable-ECC-encrypt-decrypt-tests.patch \
+	patches/0012-Disable-Nuvoton-commands.patch \
 	patches/libtpm.patch \
 	softhsm_setup \
 	test_clientfds.py \

--- a/tests/patches/0001-Deactivate-test-cases-accessing-rootcerts.txt.patch
+++ b/tests/patches/0001-Deactivate-test-cases-accessing-rootcerts.txt.patch
@@ -1,7 +1,7 @@
-From 498b847b8c0b70c7b92142305a9fddfec9d40ad5 Mon Sep 17 00:00:00 2001
+From 703166812b8090669a0dd6f349eca97dec513fe4 Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Fri, 26 Feb 2021 18:45:57 -0500
-Subject: [PATCH 1/6] Deactivate test cases accessing rootcerts.txt
+Subject: [PATCH 01/12] Deactivate test cases accessing rootcerts.txt
 
 rootcerts.txt contains files in a drive we don't have access to
 ---
@@ -10,11 +10,11 @@ rootcerts.txt contains files in a drive we don't have access to
  2 files changed, 15 insertions(+), 12 deletions(-)
 
 diff --git a/utils/regtests/testcredential.sh b/utils/regtests/testcredential.sh
-index cb9fec0..772a8ac 100755
+index 0392fa9..b70cdb2 100755
 --- a/utils/regtests/testcredential.sh
 +++ b/utils/regtests/testcredential.sh
-@@ -300,12 +300,15 @@ NVNAME=(
- 	${PREFIX}createek -high -pwde eee -pwdk kkk ${CALG[i]} -cp -noflush > run.out
+@@ -310,12 +310,15 @@ NVNAME=(
+ 	${PREFIX}createek -high -pwde eee -pwdk kkk ${CALG[i]} -cp -nopub > run.out
  	checkSuccess $?
  
 -	echo "Validate the ${CALG[i]} EK certificate against the root"
@@ -33,8 +33,8 @@ index cb9fec0..772a8ac 100755
  	checkSuccess $?
  
  	echo "Start a ${HALG[i]} policy session"
-@@ -402,9 +405,9 @@ NVNAME=(
- 	${PREFIX}createek -high -pwde eee -pwdk kkk ${CALG[i]} -cp -noflush > run.out
+@@ -424,9 +427,9 @@ NVNAME=(
+ 	${PREFIX}createek -high -pwde eee -pwdk kkk ${CALG[i]} -cp -nopub > run.out
  	checkSuccess $?
  
 -	echo "Validate the ${CALG[i]} EK certificate against the root"
@@ -46,8 +46,8 @@ index cb9fec0..772a8ac 100755
  
  	echo "Create a signing key under the ${CALG[i]} EK using the password"
  	${PREFIX}create -hp 80000001 -si -pwdp kkk > run.out
-@@ -540,9 +543,9 @@ NVNAME=(
- 	${PREFIX}createek ${ALG} -pwde eee -cp -noflush > run.out
+@@ -574,9 +577,9 @@ NVNAME=(
+ 	${PREFIX}createek ${ALG} -pwde eee -cp > run.out
  	checkSuccess $?
  
 -	echo "Validate the ${ALG} EK certificate against the root"
@@ -60,7 +60,7 @@ index cb9fec0..772a8ac 100755
  	echo "Start a policy session"
  	${PREFIX}startauthsession -se p > run.out
 diff --git a/utils/regtests/testunseal.sh b/utils/regtests/testunseal.sh
-index aae3d4e..1755740 100755
+index 5cde8e9..7f100dd 100755
 --- a/utils/regtests/testunseal.sh
 +++ b/utils/regtests/testunseal.sh
 @@ -724,8 +724,8 @@ echo ""
@@ -71,9 +71,9 @@ index aae3d4e..1755740 100755
 -elif [ ${CRYPTOLIBRARY} == "mbedtls" ]; then
 +#${PREFIX}createek -rsa 2048 -cp -noflush -root certificates/rootcerts.txt > run.out
 +#elif [ ${CRYPTOLIBRARY} == "mbedtls" ]; then
- ${PREFIX}createek -rsa 2048 -cp -noflush > run.out
+ ${PREFIX}createek -rsa 2048 -cp -noflush -nopub > run.out
  fi
  checkSuccess $?
 -- 
-2.36.0
+2.39.1
 

--- a/tests/patches/0002-Implement-powerup-for-swtpm.patch
+++ b/tests/patches/0002-Implement-powerup-for-swtpm.patch
@@ -1,7 +1,7 @@
-From f0f9aec53193b1c81f2de2cc9cc52a0c82afa523 Mon Sep 17 00:00:00 2001
+From 6dd4bd7247a6ab0f02c69f5f495cf299c5c8702f Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Sun, 28 Feb 2021 16:39:51 -0500
-Subject: [PATCH 2/9] Implement powerup for swtpm
+Subject: [PATCH 02/12] Implement powerup for swtpm
 
 ---
  utils/reg.sh                   | 12 ++++++++++++
@@ -13,7 +13,7 @@ Subject: [PATCH 2/9] Implement powerup for swtpm
  6 files changed, 21 insertions(+), 9 deletions(-)
 
 diff --git a/utils/reg.sh b/utils/reg.sh
-index 048863b..61f23d9 100755
+index 5f44760..24ea1df 100755
 --- a/utils/reg.sh
 +++ b/utils/reg.sh
 @@ -1,6 +1,12 @@
@@ -29,7 +29,7 @@ index 048863b..61f23d9 100755
  #################################################################################
  #										#
  #			TPM2 regression test					#
-@@ -244,6 +250,12 @@ initprimary()
+@@ -261,6 +267,12 @@ initprimary()
      checkSuccess $?
  }
  
@@ -43,10 +43,10 @@ index 048863b..61f23d9 100755
  export -f checkSuccess
  export -f checkWarning
 diff --git a/utils/regtests/inittpm.sh b/utils/regtests/inittpm.sh
-index eaefab4..2c87bb2 100755
+index 37d1584..99a4d41 100755
 --- a/utils/regtests/inittpm.sh
 +++ b/utils/regtests/inittpm.sh
-@@ -46,7 +46,7 @@ echo "Initialize TPM"
+@@ -45,7 +45,7 @@ echo "Initialize TPM"
  echo ""
  
  echo "Power cycle"
@@ -55,9 +55,9 @@ index eaefab4..2c87bb2 100755
  checkSuccess $?
  
  echo "Startup"
-@@ -62,7 +62,7 @@ ${PREFIX}pcrallocate +sha1 +sha256 +sha384 +sha512 > run.out
+@@ -65,7 +65,7 @@ ${PREFIX}pcrallocate +sha1 +sha256 +sha384 +sha512 -v > run.out
  checkSuccess $?
-     
+ 
  echo "Power cycle"
 -${PREFIX}powerup > run.out
 +powerup > run.out
@@ -65,10 +65,10 @@ index eaefab4..2c87bb2 100755
  
  echo "Startup"
 diff --git a/utils/regtests/testevent.sh b/utils/regtests/testevent.sh
-index 6336920..6d78ba5 100755
+index 7b2ee94..c201cb2 100755
 --- a/utils/regtests/testevent.sh
 +++ b/utils/regtests/testevent.sh
-@@ -66,7 +66,7 @@ do
+@@ -71,7 +71,7 @@ do
      do
  
  	echo "Power cycle to reset IMA PCR"
@@ -78,10 +78,10 @@ index 6336920..6d78ba5 100755
  
  	echo "Startup"
 diff --git a/utils/regtests/testnvpin.sh b/utils/regtests/testnvpin.sh
-index 89d14a7..c045af1 100755
+index 2d96aed..0f09bab 100755
 --- a/utils/regtests/testnvpin.sh
 +++ b/utils/regtests/testnvpin.sh
-@@ -240,7 +240,7 @@ ${PREFIX}nvwrite -ha 01000000 -hia p -id 0 1 > run.out
+@@ -248,7 +248,7 @@ ${PREFIX}nvwrite -ha 01000000 -hia p -id 0 1 > run.out
  checkFailure $?
  
  echo "Reboot"
@@ -90,7 +90,7 @@ index 89d14a7..c045af1 100755
  checkSuccess $?
  
  echo "Startup"
-@@ -448,7 +448,7 @@ ${PREFIX}nvwrite -ha 01000000 -hia p -id 0 1 > run.out
+@@ -456,7 +456,7 @@ ${PREFIX}nvwrite -ha 01000000 -hia p -id 0 1 > run.out
  checkFailure $?
  
  echo "Reboot"
@@ -100,7 +100,7 @@ index 89d14a7..c045af1 100755
  
  echo "Startup"
 diff --git a/utils/regtests/testpcr.sh b/utils/regtests/testpcr.sh
-index ef8fa2c..e2ac737 100755
+index f936d12..8d7bb98 100755
 --- a/utils/regtests/testpcr.sh
 +++ b/utils/regtests/testpcr.sh
 @@ -191,7 +191,7 @@ do
@@ -113,10 +113,10 @@ index ef8fa2c..e2ac737 100755
  
      echo "startup"
 diff --git a/utils/regtests/testshutdown.sh b/utils/regtests/testshutdown.sh
-index 566471b..7be9f1c 100755
+index dc45721..65c6f4d 100755
 --- a/utils/regtests/testshutdown.sh
 +++ b/utils/regtests/testshutdown.sh
-@@ -147,7 +147,7 @@ ${PREFIX}shutdown -s > run.out
+@@ -147,7 +147,7 @@ ${PREFIX}shutdown -s -v > run.out
  checkSuccess $?
  
  echo "Power cycle"
@@ -144,5 +144,5 @@ index 566471b..7be9f1c 100755
  
  echo "Startup clear"
 -- 
-2.26.2
+2.39.1
 

--- a/tests/patches/0003-Set-CRYPTOLIBRARY-to-openssl.patch
+++ b/tests/patches/0003-Set-CRYPTOLIBRARY-to-openssl.patch
@@ -1,17 +1,17 @@
-From b233462f3fe53d2209a1e2aad7f196979cea00e5 Mon Sep 17 00:00:00 2001
+From a3feeb63145506e3d77be99e1dd214247ebabe1a Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Sun, 28 Feb 2021 16:35:56 -0500
-Subject: [PATCH 3/9] Set CRYPTOLIBRARY to openssl
+Subject: [PATCH 03/12] Set CRYPTOLIBRARY to openssl
 
 ---
  utils/reg.sh | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/utils/reg.sh b/utils/reg.sh
-index 61f23d9..33e3299 100755
+index 24ea1df..c9d49b9 100755
 --- a/utils/reg.sh
 +++ b/utils/reg.sh
-@@ -264,7 +264,7 @@ export WARN
+@@ -281,7 +281,7 @@ export WARN
  export PREFIX
  export -f initprimary
  # hack because the mbedtls port is incomplete
@@ -21,5 +21,5 @@ index 61f23d9..33e3299 100755
  # example for running scripts with encrypted sessions, see TPM_SESSION_ENCKEY=getrandom below
  export TPM_SESSION_ENCKEY
 -- 
-2.26.2
+2.39.1
 

--- a/tests/patches/0004-Store-and-restore-volatile-state-at-every-step.patch
+++ b/tests/patches/0004-Store-and-restore-volatile-state-at-every-step.patch
@@ -1,17 +1,17 @@
-From 30fd9216f9b984cd1e55da4c793e948ba5bc5a22 Mon Sep 17 00:00:00 2001
+From fe645b76d6eee78c4e7bce3a422be10f42abb757 Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Sun, 28 Feb 2021 16:42:11 -0500
-Subject: [PATCH 4/9] Store and restore volatile state at every step
+Subject: [PATCH 04/12] Store and restore volatile state at every step
 
 ---
  utils/reg.sh | 14 +++++++++++++-
  1 file changed, 13 insertions(+), 1 deletion(-)
 
 diff --git a/utils/reg.sh b/utils/reg.sh
-index 33e3299..01f6940 100755
+index c9d49b9..0bba17a 100755
 --- a/utils/reg.sh
 +++ b/utils/reg.sh
-@@ -124,6 +124,16 @@ printUsage ()
+@@ -140,6 +140,16 @@ printUsage ()
      echo "-51 Events"
  }
  
@@ -28,7 +28,7 @@ index 33e3299..01f6940 100755
  checkSuccess()
  {
  if [ $1 -ne 0 ]; then
-@@ -133,7 +143,7 @@ if [ $1 -ne 0 ]; then
+@@ -149,7 +159,7 @@ if [ $1 -ne 0 ]; then
  else
      echo " INFO:"
  fi
@@ -37,7 +37,7 @@ index 33e3299..01f6940 100755
  }
  
  # FIXME should not increment past 254
-@@ -146,6 +156,7 @@ if [ $1 -ne 0 ]; then
+@@ -162,6 +172,7 @@ if [ $1 -ne 0 ]; then
  else
      echo " INFO:"
  fi
@@ -45,7 +45,7 @@ index 33e3299..01f6940 100755
  }
  
  checkFailure()
-@@ -157,6 +168,7 @@ if [ $1 -eq 0 ]; then
+@@ -173,6 +184,7 @@ if [ $1 -eq 0 ]; then
  else
      echo " INFO:"
  fi
@@ -54,5 +54,5 @@ index 33e3299..01f6940 100755
  
  cleanup()
 -- 
-2.29.2
+2.39.1
 

--- a/tests/patches/0005-Disable-tests-related-to-events.patch
+++ b/tests/patches/0005-Disable-tests-related-to-events.patch
@@ -1,14 +1,14 @@
-From 19ce952c3a7205585bed8cb063dc2b1f23434ba4 Mon Sep 17 00:00:00 2001
+From 0ada56485cca1b6f9e6c5fa9c79f07682fc86c46 Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Sun, 28 Feb 2021 16:33:02 -0500
-Subject: [PATCH 5/9] Disable tests related to 'events'
+Subject: [PATCH 05/12] Disable tests related to 'events'
 
 ---
  utils/regtests/testevent.sh | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/utils/regtests/testevent.sh b/utils/regtests/testevent.sh
-index 6d78ba5..9252161 100755
+index c201cb2..64eb624 100755
 --- a/utils/regtests/testevent.sh
 +++ b/utils/regtests/testevent.sh
 @@ -1,5 +1,6 @@
@@ -19,5 +19,5 @@ index 6d78ba5..9252161 100755
  #################################################################################
  #										#
 -- 
-2.26.2
+2.39.1
 

--- a/tests/patches/0006-Disable-testing-with-RSA-3072.patch
+++ b/tests/patches/0006-Disable-testing-with-RSA-3072.patch
@@ -1,7 +1,7 @@
-From ca400b52d26bf4f518964faf2b2353d25a057fce Mon Sep 17 00:00:00 2001
+From 9ef419cfb2f0b47a6d4fb989c18f401b06dad1fe Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Sun, 28 Feb 2021 16:35:02 -0500
-Subject: [PATCH 6/9] Disable testing with RSA 3072
+Subject: [PATCH 06/12] Disable testing with RSA 3072
 
 ---
  utils/reg.sh                       |  2 +-
@@ -16,10 +16,10 @@ Subject: [PATCH 6/9] Disable testing with RSA 3072
  9 files changed, 17 insertions(+), 16 deletions(-)
 
 diff --git a/utils/reg.sh b/utils/reg.sh
-index de7e181..9de1eaa 100755
+index 0bba17a..b3228d6 100755
 --- a/utils/reg.sh
 +++ b/utils/reg.sh
-@@ -186,7 +186,7 @@ cleanup()
+@@ -205,7 +205,7 @@ cleanup()
  	rm -f khrpub${HALG}.bin
      done
  
@@ -29,7 +29,7 @@ index de7e181..9de1eaa 100755
  	rm -f signrsa${BITS}priv.bin
  	rm -f signrsa${BITS}pub.bin
 diff --git a/utils/regtests/initkeys.sh b/utils/regtests/initkeys.sh
-index 80c6adb..469b5c9 100755
+index 569ec89..171662a 100755
 --- a/utils/regtests/initkeys.sh
 +++ b/utils/regtests/initkeys.sh
 @@ -64,7 +64,7 @@ BITS=(2048 3072)
@@ -39,10 +39,10 @@ index 80c6adb..469b5c9 100755
 -
 +    [ $i -eq 1 ] && continue # skip 3072 bits
      echo "Create an RSA ${BITS[i]} ${SHALG[i]} storage key under the primary key"
-     ${PREFIX}create -hp 80000000 -rsa ${BITS[i]} -halg ${SHALG[i]} -st -kt f -kt p -pol policies/policycccreate-auth.bin -opr storersa${BITS[i]}priv.bin -opu storersa${BITS[i]}pub.bin -tk storersa${BITS[i]}tk.bin -ch storersa${BITS[i]}ch.bin -pwdp sto -pwdk sto > run.out
+     ${PREFIX}create -hp 80000000 -rsa ${BITS[i]} -halg ${SHALG[i]} -st -kt f -kt p -pol policies/policycccreate-auth.bin -opr storersa${BITS[i]}priv.bin -opu storersa${BITS[i]}pub.bin -tk storersa${BITS[i]}tk.bin -ch storersa${BITS[i]}ch.bin -cd tmpcd.bin -pwdp sto -pwdk sto -v > run.out
      checkSuccess $?
 diff --git a/utils/regtests/testcreateloaded.sh b/utils/regtests/testcreateloaded.sh
-index d3e3eb8..76fb859 100755
+index f4c449e..959f313 100755
 --- a/utils/regtests/testcreateloaded.sh
 +++ b/utils/regtests/testcreateloaded.sh
 @@ -50,7 +50,7 @@ echo ""
@@ -55,11 +55,11 @@ index d3e3eb8..76fb859 100755
  
  	echo "CreateLoaded primary key, parent ${HIER} ${ALG}"
 diff --git a/utils/regtests/testcredential.sh b/utils/regtests/testcredential.sh
-index 16fd66a..a68960d 100755
+index b70cdb2..45a9595 100755
 --- a/utils/regtests/testcredential.sh
 +++ b/utils/regtests/testcredential.sh
-@@ -287,7 +287,7 @@ NVNAME=(
- # interate though high range RSA EK certficates
+@@ -289,7 +289,7 @@ NVNAME=(
+ # are limited.
      for ((i = 0 ; i < 2 ; i++))
      do
 -
@@ -81,7 +81,7 @@ index f51687f..59b1754 100755
  do
  
 diff --git a/utils/regtests/testrsa.sh b/utils/regtests/testrsa.sh
-index 4f76522..e835660 100755
+index 15577b6..44f6357 100755
 --- a/utils/regtests/testrsa.sh
 +++ b/utils/regtests/testrsa.sh
 @@ -55,7 +55,7 @@ echo ""
@@ -93,7 +93,7 @@ index 4f76522..e835660 100755
      do
  
  	echo "Generate the RSA $BITS encryption key with openssl"
-@@ -68,7 +68,7 @@ if   [ ${CRYPTOLIBRARY} == "openssl" ]; then
+@@ -73,7 +73,7 @@ if   [ ${CRYPTOLIBRARY} == "openssl" ]; then
  
  elif [ ${CRYPTOLIBRARY} == "mbedtls" ]; then
  
@@ -102,7 +102,7 @@ index 4f76522..e835660 100755
      do
  
  	echo "Generate the RSA $BITS encryption key with openssl"
-@@ -94,7 +94,7 @@ echo ""
+@@ -99,7 +99,7 @@ echo ""
  echo "RSA decryption key"
  echo ""
  
@@ -111,7 +111,7 @@ index 4f76522..e835660 100755
  do
  
      echo "Load the RSA $BITS decryption key under the primary key"
-@@ -124,7 +124,7 @@ echo ""
+@@ -129,7 +129,7 @@ echo ""
  echo "RSA decryption key to sign with OID"
  echo ""
  
@@ -120,25 +120,25 @@ index 4f76522..e835660 100755
  do
  
      echo "Load the RSA $BITS decryption key"
-@@ -166,7 +166,7 @@ echo "Start an HMAC auth session"
- ${PREFIX}startauthsession -se h > run.out
- checkSuccess $?
+@@ -173,7 +173,7 @@ if   [ ${CRYPTOLIBRARY} == "openssl" ]; then
+     ${PREFIX}startauthsession -se h > run.out
+     checkSuccess $?
  
--for BITS in 2048 3072
-+for BITS in 2048
- do
+-    for BITS in 2048 3072
++    for BITS in 2048
+     do
  
-     for SESS in "" "-se0 02000000 1"
-@@ -254,7 +254,7 @@ echo ""
- echo "Loadexternal DER encryption key"
- echo ""
+ 	for SESS in "" "-se0 02000000 1"
+@@ -260,7 +260,7 @@ if   [ ${CRYPTOLIBRARY} == "openssl" ]; then
+     echo "Loadexternal DER encryption key"
+     echo ""
  
--for BITS in 2048 3072
-+for BITS in 2048
- do
+-    for BITS in 2048 3072
++    for BITS in 2048
+     do
  
-     echo "Start an HMAC auth session"
-@@ -410,7 +410,7 @@ rm -f deepub.bin
+ 	echo "Start an HMAC auth session"
+@@ -418,7 +418,7 @@ rm -f deepub.bin
  rm -f tmpmsg.bin
  rm -f tmpdig.bin
  rm -f tmpsig.bin
@@ -148,7 +148,7 @@ index 4f76522..e835660 100755
      rm -f tmpkeypairrsa${BITS}.der
      rm -f tmpkeypairrsa${BITS}.pem
 diff --git a/utils/regtests/testsalt.sh b/utils/regtests/testsalt.sh
-index 1bdc1a7..57ec69e 100755
+index e0c3376..bf6f2a1 100755
 --- a/utils/regtests/testsalt.sh
 +++ b/utils/regtests/testsalt.sh
 @@ -57,6 +57,7 @@ fi
@@ -160,7 +160,7 @@ index 1bdc1a7..57ec69e 100755
      do
  
 diff --git a/utils/regtests/testsign.sh b/utils/regtests/testsign.sh
-index edfa014..bb76605 100755
+index 58eb426..4e4e64b 100755
 --- a/utils/regtests/testsign.sh
 +++ b/utils/regtests/testsign.sh
 @@ -44,7 +44,7 @@ echo ""
@@ -171,8 +171,8 @@ index edfa014..bb76605 100755
 +for BITS in 2048
  do
  
-     echo "Create an RSA $BITS key pair in PEM format using openssl"
-@@ -410,8 +410,8 @@ done
+     echo "Create an RSA $BITS key pair in DER format using openssl"
+@@ -434,8 +434,8 @@ checkSuccess $?
  
  rm -f tmpkeypairrsa2048.pem
  rm -f tmpkeypairrsa2048.der
@@ -184,7 +184,7 @@ index edfa014..bb76605 100755
  rm -f tmpkeypaireccnistp256.der
  rm -f tmpkeypaireccnistp384.pem
 diff --git a/utils/regtests/testx509.sh b/utils/regtests/testx509.sh
-index 813085f..f5737a8 100755
+index 5640985..17d0288 100755
 --- a/utils/regtests/testx509.sh
 +++ b/utils/regtests/testx509.sh
 @@ -59,7 +59,7 @@ SKEY=(rsa2048 rsa3072 eccnistp256 eccnistp384)
@@ -197,5 +197,5 @@ index 813085f..f5737a8 100755
      ${PREFIX}load -hp 80000000 -ipr sign${SKEY[i]}rpriv.bin -ipu sign${SKEY[i]}rpub.bin -pwdp sto > run.out
      checkSuccess $?
 -- 
-2.26.2
+2.39.1
 

--- a/tests/patches/0007-Disable-rev155-test-cases.patch
+++ b/tests/patches/0007-Disable-rev155-test-cases.patch
@@ -1,14 +1,14 @@
-From 7a6fe0d006ef5f2c6c960aa324b3e0ca4e0afcc9 Mon Sep 17 00:00:00 2001
+From 8c5314c6de0853d0b1e29d08ddbd998e4e4f3a60 Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Sun, 28 Feb 2021 16:36:53 -0500
-Subject: [PATCH 7/9] Disable rev155 test cases
+Subject: [PATCH 07/12] Disable rev155 test cases
 
 ---
  utils/regtests/testattest155.sh | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/utils/regtests/testattest155.sh b/utils/regtests/testattest155.sh
-index 0bf88aa..554a40e 100755
+index 824bab7..0187652 100755
 --- a/utils/regtests/testattest155.sh
 +++ b/utils/regtests/testattest155.sh
 @@ -1,5 +1,6 @@
@@ -19,5 +19,5 @@ index 0bf88aa..554a40e 100755
  #################################################################################
  #										#
 -- 
-2.26.2
+2.39.1
 

--- a/tests/patches/0008-Disable-x509-test-cases.patch
+++ b/tests/patches/0008-Disable-x509-test-cases.patch
@@ -1,14 +1,14 @@
-From 3dbd97928bd833f5b79e8a1f5147c7b23d4c989d Mon Sep 17 00:00:00 2001
+From 0f1f04cef51f4e72807980e21c17d06b3a9995a7 Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Sun, 28 Feb 2021 16:37:27 -0500
-Subject: [PATCH 8/9] Disable x509 test cases
+Subject: [PATCH 08/12] Disable x509 test cases
 
 ---
  utils/regtests/testx509.sh | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/utils/regtests/testx509.sh b/utils/regtests/testx509.sh
-index f5737a8..acd2c3c 100755
+index 17d0288..03650fe 100755
 --- a/utils/regtests/testx509.sh
 +++ b/utils/regtests/testx509.sh
 @@ -1,5 +1,6 @@
@@ -19,5 +19,5 @@ index f5737a8..acd2c3c 100755
  #################################################################################
  #										#
 -- 
-2.26.2
+2.39.1
 

--- a/tests/patches/0009-Disable-getcapability-TPM_CAP_ACT.patch
+++ b/tests/patches/0009-Disable-getcapability-TPM_CAP_ACT.patch
@@ -1,28 +1,28 @@
-From 0e64682da7e1da7b8ffdf1103b99546d31a599da Mon Sep 17 00:00:00 2001
+From c8c3ea92b9797d743f993bade0196150e26b4c28 Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.vnet.ibm.com>
 Date: Sun, 28 Feb 2021 16:38:10 -0500
-Subject: [PATCH 9/9] Disable getcapability TPM_CAP_ACT
+Subject: [PATCH 09/12] Disable getcapability TPM_CAP_ACT
 
 ---
  utils/regtests/testgetcap.sh | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/utils/regtests/testgetcap.sh b/utils/regtests/testgetcap.sh
-index 4e370cf..cd6607d 100755
+index f88697b..f5f9729 100755
 --- a/utils/regtests/testgetcap.sh
 +++ b/utils/regtests/testgetcap.sh
 @@ -120,8 +120,8 @@ echo "Get Capability TPM_CAP_AUTH_POLICIES"
- ${PREFIX}getcapability -cap 9 -pr 40000000 > run.out
+ ${PREFIX}getcapability -cap 9 -pr 40000000 -v > run.out
  checkSuccess $?
  
 -echo "Get Capability TPM_CAP_ACT"
--${PREFIX}getcapability -cap a -pr 40000110 > run.out
+-${PREFIX}getcapability -cap a -pr 40000110 -v > run.out
 -checkSuccess $?
 +#echo "Get Capability TPM_CAP_ACT"
-+#${PREFIX}getcapability -cap a -pr 40000110 > run.out
++#${PREFIX}getcapability -cap a -pr 40000110 -v > run.out
 +#checkSuccess $?
  
  
 -- 
-2.26.2
+2.39.1
 

--- a/tests/patches/0010-Adjust-test-cases-for-OpenSSL-3.patch
+++ b/tests/patches/0010-Adjust-test-cases-for-OpenSSL-3.patch
@@ -1,7 +1,7 @@
-From c351a11bfb60d9cf5caa3e267f5ce935655401f2 Mon Sep 17 00:00:00 2001
+From e50f9f4a05a6a255dd94808792ff33f3ccc9894d Mon Sep 17 00:00:00 2001
 From: Stefan Berger <stefanb@linux.ibm.com>
 Date: Tue, 3 May 2022 10:26:06 -0400
-Subject: [PATCH 6/6] Adjust test cases for OpenSSL 3
+Subject: [PATCH 10/12] Adjust test cases for OpenSSL 3
 
 1) Some openssl command lines need -traditional when converting a key
    from PEM to DER format.
@@ -17,56 +17,14 @@ ERROR: convertX509ToDer: Error in certificate serialization i2d_X509()
 certifyx509: failed, rc 000b007e
 TSS_RC_X509_ERROR - X509 parse error
 ---
- utils/regtests/testrsa.sh  |   2 +-
- utils/regtests/testsalt.sh |   2 +-
- utils/regtests/testsign.sh |   2 +-
  utils/regtests/testx509.sh | 109 +++++++++++++++++++------------------
- 4 files changed, 59 insertions(+), 56 deletions(-)
+ 1 file changed, 56 insertions(+), 53 deletions(-)
 
-diff --git a/utils/regtests/testrsa.sh b/utils/regtests/testrsa.sh
-index 4f76522..c78566c 100755
---- a/utils/regtests/testrsa.sh
-+++ b/utils/regtests/testrsa.sh
-@@ -62,7 +62,7 @@ if   [ ${CRYPTOLIBRARY} == "openssl" ]; then
- 	openssl genrsa -out tmpkeypairrsa${BITS}.pem -aes256 -passout pass:rrrr ${BITS} > run.out 2>&1
- 
- 	echo "Convert key pair to plaintext DER format"
--	openssl rsa -inform pem -outform der -in tmpkeypairrsa${BITS}.pem -out tmpkeypairrsa${BITS}.der -passin pass:rrrr > run.out 2>&1
-+	openssl rsa -traditional -inform pem -outform der -in tmpkeypairrsa${BITS}.pem -out tmpkeypairrsa${BITS}.der -passin pass:rrrr > run.out 2>&1
- 
-     done
- 
-diff --git a/utils/regtests/testsalt.sh b/utils/regtests/testsalt.sh
-index 1bdc1a7..34fe97b 100755
---- a/utils/regtests/testsalt.sh
-+++ b/utils/regtests/testsalt.sh
-@@ -98,7 +98,7 @@ openssl ecparam -name prime256v1 -genkey -noout -out tmpkeypairecc.pem > run.out
- 
- echo "Convert key pair to plaintext DER format"
- 
--openssl rsa -inform pem -outform der -in tmpkeypairrsa.pem -out tmpkeypairrsa.der -passin pass:rrrr > run.out 2>&1
-+openssl rsa -traditional -inform pem -outform der -in tmpkeypairrsa.pem -out tmpkeypairrsa.der -passin pass:rrrr > run.out 2>&1
- openssl ec -inform pem -outform der -in tmpkeypairecc.pem -out tmpkeypairecc.der -passin pass:rrrr > run.out 2>&1
- 
- for HALG in ${ITERATE_ALGS}
-diff --git a/utils/regtests/testsign.sh b/utils/regtests/testsign.sh
-index edfa014..1730e85 100755
---- a/utils/regtests/testsign.sh
-+++ b/utils/regtests/testsign.sh
-@@ -51,7 +51,7 @@ do
-     openssl genrsa -out tmpkeypairrsa${BITS}.pem -aes256 -passout pass:rrrr 2048 > run.out 2>&1
- 
-     echo "Convert RSA $BITS key pair to plaintext DER format"
--    openssl rsa -inform pem -outform der -in tmpkeypairrsa${BITS}.pem -out tmpkeypairrsa${BITS}.der -passin pass:rrrr > run.out 2>&1
-+    openssl rsa -traditional -inform pem -outform der -in tmpkeypairrsa${BITS}.pem -out tmpkeypairrsa${BITS}.der -passin pass:rrrr > run.out 2>&1
- 
-     echo "Load the RSA $BITS signing key under the primary key"
-     ${PREFIX}load -hp 80000000 -ipr signrsa${BITS}priv.bin -ipu signrsa${BITS}pub.bin -pwdp sto > run.out
 diff --git a/utils/regtests/testx509.sh b/utils/regtests/testx509.sh
-index 813085f..06e7cce 100755
+index 03650fe..54b0b56 100755
 --- a/utils/regtests/testx509.sh
 +++ b/utils/regtests/testx509.sh
-@@ -68,9 +68,9 @@ do
+@@ -69,9 +69,9 @@ do
      ${PREFIX}load -hp 80000000 -ipr sign${SKEY[i]}priv.bin -ipu sign${SKEY[i]}pub.bin -pwdp sto > run.out
      checkSuccess $?
  
@@ -78,17 +36,17 @@ index 813085f..06e7cce 100755
 +    #checkSuccess $?
  
  
-     # dumpasn1 -a -l -d     tmpx509i.bin > tmpx509i1.dump
-@@ -87,14 +87,14 @@ do
+     # dumpasn1 -a -l -d     tmppart1.bin > tmppart1.dump
+@@ -86,14 +86,14 @@ do
      openssl x509 -inform der -in tmpx5091.bin -out tmpx5091.pem > run.out 2>&1
      echo " INFO:"
  
 -    echo "Verify ${SALG[i]} self signed issuer root" 
--    openssl verify -CAfile tmpx5091.pem tmpx5091.pem > run.out 2>&1
+-    openssl verify -check_ss_sig -CAfile tmpx5091.pem tmpx5091.pem > run.out 2>&1
 -    grep -q OK run.out
 -    checkSuccess $?
 +    #echo "Verify ${SALG[i]} self signed issuer root"
-+    #openssl verify -CAfile tmpx5091.pem tmpx5091.pem > run.out 2>&1
++    #openssl verify -check_ss_sig -CAfile tmpx5091.pem tmpx5091.pem > run.out 2>&1
 +    #grep -q OK run.out
 +    #checkSuccess $?
  
@@ -99,24 +57,24 @@ index 813085f..06e7cce 100755
 +    #${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -iob 00040472 > run.out
 +    #checkSuccess $?
  
-     # dumpasn1 -a -l -d     tmpx509i.bin > tmpx509i2.dump
-     # dumpasn1 -a -l -d -hh tmpx509i.bin > tmpx509i2.dumphh
-@@ -110,10 +110,10 @@ do
+     # dumpasn1 -a -l -d     tmppart2.bin > tmppart2.dump
+     # dumpasn1 -a -l -d -hh tmppart2.bin > tmppart2.dumphhe 
+@@ -107,10 +107,10 @@ do
      openssl x509 -inform der -in tmpx5092.bin -out tmpx5092.pem > run.out 2>&1
      echo " INFO:"
  
 -    echo "Verify ${SALG[i]} subject against issuer" 
--    openssl verify -CAfile tmpx5091.pem tmpx5092.pem > run.out 2>&1
+-    openssl verify -check_ss_sig -CAfile tmpx5091.pem tmpx5092.pem > run.out 2>&1
 -    grep -q OK run.out
 -    checkSuccess $?
 +    #echo "Verify ${SALG[i]} subject against issuer"
-+    #openssl verify -CAfile tmpx5091.pem tmpx5092.pem > run.out 2>&1
++    #openssl verify -check_ss_sig -CAfile tmpx5091.pem tmpx5092.pem > run.out 2>&1
 +    #grep -q OK run.out
 +    #checkSuccess $?
  
      echo "Signing Key Certify ${SALG[i]} with bad OID"
      ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -iob ffffffff > run.out
-@@ -156,13 +156,13 @@ do
+@@ -153,13 +153,13 @@ do
      ${PREFIX}load -hp 80000000 -ipr sign${SKEY[i]}priv.bin -ipu sign${SKEY[i]}pub.bin -pwdp sto > run.out
      checkSuccess $?
  
@@ -136,7 +94,7 @@ index 813085f..06e7cce 100755
  
      echo "Signing Key Certify ${SALG[i]} keyEncipherment"
      ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,keyEncipherment > run.out
-@@ -176,13 +176,13 @@ do
+@@ -173,13 +173,13 @@ do
      ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,keyAgreement > run.out
      checkFailure $?
  
@@ -156,7 +114,7 @@ index 813085f..06e7cce 100755
  
      echo "Signing Key Certify ${SALG[i]} encipherOnly"
      ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,encipherOnly > run.out
-@@ -217,9 +217,9 @@ do
+@@ -214,9 +214,9 @@ do
      ${PREFIX}load -hp 80000000 -ipr sign${SKEY[i]}nfpriv.bin -ipu sign${SKEY[i]}nfpub.bin -pwdp sto > run.out
      checkSuccess $?
  
@@ -169,7 +127,7 @@ index 813085f..06e7cce 100755
  
      echo "Signing Key Certify ${SALG[i]} nonRepudiation"
      ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,nonRepudiation > run.out
-@@ -237,13 +237,13 @@ do
+@@ -234,13 +234,13 @@ do
      ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,keyAgreement > run.out
      checkFailure $?
  
@@ -189,7 +147,7 @@ index 813085f..06e7cce 100755
  
      echo "Signing Key Certify ${SALG[i]} encipherOnly"
      ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sig -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,encipherOnly > run.out
-@@ -282,21 +282,21 @@ do
+@@ -279,21 +279,21 @@ do
      ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sto -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,digitalSignature > run.out
      checkFailure $?
  
@@ -223,7 +181,7 @@ index 813085f..06e7cce 100755
  
      echo "Signing Key Certify ${SALG[i]} keyCertSign"
      ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sto -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,keyCertSign > run.out
-@@ -306,13 +306,13 @@ do
+@@ -303,13 +303,13 @@ do
      ${PREFIX}certifyx509 -hk 80000001 -ho 80000002 -halg ${HALG[i]} -pwdk sig -pwdo sto -opc tmppart2.bin -os tmpsig2.bin -oa tmpadd2.bin -otbs tmptbs2.bin -ocert tmpx5092.bin ${SALG[i]} -ku critical,cRLSign > run.out
      checkFailure $?
  
@@ -243,7 +201,7 @@ index 813085f..06e7cce 100755
  
      echo "Flush the root CA issuer signing key"
      ${PREFIX}flushcontext -ha 80000001 > run.out
-@@ -340,5 +340,8 @@ rm -r tmptbs2.bin
+@@ -336,5 +336,8 @@ rm -r tmptbs2.bin
  rm -r tmpsig2.bin
  rm -r tmpx5092.bin
  
@@ -253,5 +211,5 @@ index 813085f..06e7cce 100755
  # openssl only
  fi
 -- 
-2.36.0
+2.39.1
 

--- a/tests/patches/0011-Disable-ECC-encrypt-decrypt-tests.patch
+++ b/tests/patches/0011-Disable-ECC-encrypt-decrypt-tests.patch
@@ -1,0 +1,47 @@
+From b5787bd7b31da92a1315596b05ccc73e810ebb15 Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.ibm.com>
+Date: Wed, 10 May 2023 16:10:02 -0400
+Subject: [PATCH 11/12] Disable ECC encrypt/decrypt tests
+
+---
+ utils/regtests/testecc.sh  | 2 +-
+ utils/regtests/testhelp.sh | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/utils/regtests/testecc.sh b/utils/regtests/testecc.sh
+index f787597..1b78214 100755
+--- a/utils/regtests/testecc.sh
++++ b/utils/regtests/testecc.sh
+@@ -48,7 +48,7 @@ echo "Start an HMAC auth session"
+ ${PREFIX}startauthsession -se h > run.out
+ checkSuccess $?
+ 
+-for CURVE in ${CURVE_ALGS}
++for CURVE in
+ do
+ 
+     echo "create an ECC ${CURVE} decryption key"
+diff --git a/utils/regtests/testhelp.sh b/utils/regtests/testhelp.sh
+index 520d422..40dff0f 100755
+--- a/utils/regtests/testhelp.sh
++++ b/utils/regtests/testhelp.sh
+@@ -6967,14 +6967,14 @@ echo ""
+ echo "policycommandcode"
+ echo ""
+ 
+-for CC in 11f 120 121 122 124 125 126 127 128 129 12a 12b 12c 12d 12e 130 131 132 133 134 135 136 137 138 139 13a 13b 13c 13d 13e 13f 140 142 143 144 145 146 147 148 149 14a 14b 14c 14d 14e 14f 150 151 152 153 154 155 156 157 158 159 15b 15c 15d 15e 160 161 162 163 164 165 167 168 169 16a 16b 16c 16d 16e 16f 170 171 172 173 174 176 177 178 17a 17b 17c 17d 17e 17f 180 181 182 183 184 185 186 187 188 189 18a 18b 18c 18d 18e 18f 190 191 192 193 197 199 19A
++for CC in 11f 120 121 122 124 125 126 127 128 129 12a 12b 12c 12d 12e 130 131 132 133 134 135 136 137 138 139 13a 13b 13c 13d 13e 13f 140 142 143 144 145 146 147 148 149 14a 14b 14c 14d 14e 14f 150 151 152 153 154 155 156 157 158 159 15b 15c 15d 15e 160 161 162 163 164 165 167 168 169 16a 16b 16d 16e 16f 170 171 172 173 174 176 177 178 17a 17b 17c 17d 17e 17f 180 181 182 183 184 185 186 187 188 189 18a 18b 18c 18d 18e 18f 191 192 193 197
+ do
+ 
+     echo "startauthsession"
+     ${PREFIX}startauthsession -se p > run.out
+     checkSuccess $?
+ 
+-    echo "policycommandcode"
++    echo "policycommandcode ${CC}"
+     ${PREFIX}policycommandcode -ha 03000000 -v -cc ${CC} > run.out
+     checkSuccess $?
+ 
+-- 
+2.39.1
+

--- a/tests/patches/0012-Disable-Nuvoton-commands.patch
+++ b/tests/patches/0012-Disable-Nuvoton-commands.patch
@@ -1,0 +1,25 @@
+From d7ea9b0e0e4be46e367c9116617b33ce399a3601 Mon Sep 17 00:00:00 2001
+From: Stefan Berger <stefanb@linux.ibm.com>
+Date: Wed, 10 May 2023 18:17:23 -0400
+Subject: [PATCH 12/12] Disable Nuvoton commands
+
+---
+ utils/regtests/testntc.sh | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/utils/regtests/testntc.sh b/utils/regtests/testntc.sh
+index 065af7f..f7bb67e 100755
+--- a/utils/regtests/testntc.sh
++++ b/utils/regtests/testntc.sh
+@@ -44,6 +44,8 @@ echo ""
+ echo "Nuvoton Commands"
+ echo ""
+ 
++exit 0
++
+ # help
+ 
+ echo "Preconfig Help"
+-- 
+2.39.1
+

--- a/tests/test_tpm2_ibmtss2
+++ b/tests/test_tpm2_ibmtss2
@@ -51,8 +51,7 @@ git clone https://git.code.sf.net/p/ibmtpm20tss/tss ibmtpm20tss-tss
 
 pushd ibmtpm20tss-tss &>/dev/null
 
-git checkout tags/v1.6.0
-if [ $? -ne 0 ]; then
+if ! git checkout tags/v2.0.1; then
 	echo "'Git checkout' failed."
 	exit 1
 fi
@@ -62,7 +61,13 @@ fi
 git config --local user.name test
 git config --local user.email test@test.test
 
-# A v1.6.0 bug work-around:
+# ECC encrypt/decrypt is not supported in any version of libtpms
+git am < "${PATCHESDIR}/0011-Disable-ECC-encrypt-decrypt-tests.patch"
+
+# Nuvoton commands are not supported
+git am < "${PATCHESDIR}/0012-Disable-Nuvoton-commands.patch"
+
+# A v2.0.1 bug work-around:
 # We cannot run the EK certificate tests since rootcerts.txt points to
 # files we do not have
 git am < ${PATCHESDIR}/0001-Deactivate-test-cases-accessing-rootcerts.txt.patch


### PR DESCRIPTION
Use '>=' on the returned value from snprintf when comparing it against the buffer size passed into snprintf to determine whether truncation of the output occurred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of generated filenames and file paths.
  * Prevented truncated output by ensuring space remains for the terminating character.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->