### PR TITLE
swtpm: Fix the buffer for the AES IV

### DIFF
--- a/src/swtpm/swtpm_aes.c
+++ b/src/swtpm/swtpm_aes.c
@@ -86,7 +86,7 @@ TPM_RESULT SWTPM_SymmetricKeyData_Encrypt(unsigned char **encrypt_data,   /* out
     TPM_RESULT          rc = 0;
     uint32_t            pad_length;
     unsigned char       *decrypt_data_pad;
-    unsigned char       ivec[SWTPM_AES256_BLOCK_SIZE];       /* initial chaining vector */
+    unsigned char       ivec[SWTPM_AES_BLOCK_SIZE];       /* initial chaining vector */
     TPM_SYMMETRIC_KEY_DATA *tpm_symmetric_key_data =
 	(TPM_SYMMETRIC_KEY_DATA *)tpm_symmetric_key_token;
     size_t userKeyLength = tpm_symmetric_key_token->userKeyLength;
@@ -96,16 +96,16 @@ TPM_RESULT SWTPM_SymmetricKeyData_Encrypt(unsigned char **encrypt_data,   /* out
     decrypt_data_pad = NULL;    /* freed @1 */
 
     if (rc == 0) {
-        if (u_ivec != NULL && u_ivec_length != userKeyLength) {
+        if (u_ivec != NULL && u_ivec_length < sizeof(ivec)) {
             logprintf(STDERR_FILENO,
                       "SWTPM_SymmetricKeyData_Encrypt: IV is %u bytes, "
                       "but expected %zu bytes\n", u_ivec_length,
-                      tpm_symmetric_key_token->userKeyLength);
+                      sizeof(ivec));
             rc = TPM_ENCRYPT_ERROR;
         } else {
             if (u_ivec) {
                 /* copy user-provided IV */
-                memcpy(ivec, u_ivec, u_ivec_length);
+                memcpy(ivec, u_ivec, sizeof(ivec));
             } else {
                 memset(ivec, 0, sizeof(ivec));
             }
@@ -197,7 +197,7 @@ TPM_RESULT SWTPM_SymmetricKeyData_Decrypt(unsigned char **decrypt_data,   /* out
     uint32_t		pad_length;
     uint32_t		i;
     unsigned char       *pad_data;
-    unsigned char       ivec[SWTPM_AES256_BLOCK_SIZE];       /* initial chaining vector */
+    unsigned char       ivec[SWTPM_AES_BLOCK_SIZE];       /* initial chaining vector */
     TPM_SYMMETRIC_KEY_DATA *tpm_symmetric_key_data =
 	(TPM_SYMMETRIC_KEY_DATA *)tpm_symmetric_key_token;
     size_t userKeyLength = tpm_symmetric_key_token->userKeyLength;
@@ -213,15 +213,15 @@ TPM_RESULT SWTPM_SymmetricKeyData_Decrypt(unsigned char **decrypt_data,   /* out
         }
     }
     if (rc == 0) {
-        if (u_ivec != NULL && u_ivec_length != userKeyLength) {
+        if (u_ivec != NULL && u_ivec_length < sizeof(ivec)) {
             logprintf(STDERR_FILENO,
                       "SWTPM_SymmetricKeyData_Decrypt: IV is %u bytes, "
-                      "but expected %zu bytes\n", u_ivec_length, userKeyLength);
+                      "but expected %zu bytes\n", u_ivec_length, sizeof(ivec));
             rc = TPM_DECRYPT_ERROR;
         } else {
             if (u_ivec) {
                 /* copy user-provided IV */
-                memcpy(ivec, u_ivec, u_ivec_length);
+                memcpy(ivec, u_ivec, sizeof(ivec));
             } else {
                 memset(ivec, 0, sizeof(ivec));
             }

--- a/src/swtpm/swtpm_aes.h
+++ b/src/swtpm/swtpm_aes.h
@@ -41,11 +41,13 @@
 
 #include <libtpms/tpm_types.h>
 
-#define SWTPM_AES128_BLOCK_SIZE 16
-#define SWTPM_AES256_BLOCK_SIZE 32
+#define SWTPM_AES_BLOCK_SIZE  16 /* also IV size */
+
+#define SWTPM_AES128_KEY_SIZE 16
+#define SWTPM_AES256_KEY_SIZE 32
 
 typedef struct tdTPM_SYMMETRIC_KEY_DATA {
-    unsigned char userKey[SWTPM_AES256_BLOCK_SIZE];
+    unsigned char userKey[SWTPM_AES256_KEY_SIZE];
     size_t userKeyLength;
 } TPM_SYMMETRIC_KEY_DATA;
 

--- a/src/swtpm/swtpm_nvstore.c
+++ b/src/swtpm/swtpm_nvstore.c
@@ -288,7 +288,7 @@ SWTPM_NVRAM_GetFilenameForName(char *filename,       /* output: filename */
 /* Load 'data' of 'length' from the 'name'.
 
    'data' must be freed after use.
-   
+
    Returns
         0 on success.
         TPM_RETRY and NULL,0 on non-existent file (non-fatal, first time start up)
@@ -401,7 +401,7 @@ SWTPM_NVRAM_StoreData_Intern(const unsigned char *data,
                           td[0].tlv.length);
             }
             flags |= BLOB_FLAG_ENCRYPTED;
-            if (SWTPM_NVRAM_FileKey_Size() == SWTPM_AES256_BLOCK_SIZE)
+            if (SWTPM_NVRAM_FileKey_Size() == SWTPM_AES256_KEY_SIZE)
                 flags |= BLOB_FLAG_ENCRYPTED_256BIT_KEY;
         } else {
             td_len = 1;
@@ -487,8 +487,8 @@ SWTPM_NVRAM_KeyParamCheck(uint32_t keylen,
 {
     TPM_RESULT rc = 0;
 
-    if (keylen != SWTPM_AES128_BLOCK_SIZE &&
-        keylen != SWTPM_AES256_BLOCK_SIZE) {
+    if (keylen != SWTPM_AES128_KEY_SIZE &&
+        keylen != SWTPM_AES256_KEY_SIZE) {
         rc = TPM_BAD_KEY_PROPERTY;
     }
     switch (encmode) {
@@ -931,7 +931,7 @@ SWTPM_NVRAM_DecryptData(const encryptionkey *key,
         break;
         case 2:
             keylen = (hdrflags & flag_256bitkey)
-                      ? SWTPM_AES256_BLOCK_SIZE : SWTPM_AES128_BLOCK_SIZE;
+                      ? SWTPM_AES256_KEY_SIZE : SWTPM_AES128_KEY_SIZE;
             if (keylen != key->symkey.userKeyLength) {
                 logprintf(STDERR_FILENO,
                           "Wrong decryption key. Need %zu bit key.\n",
@@ -1193,7 +1193,7 @@ TPM_RESULT SWTPM_NVRAM_GetStateBlob(unsigned char **data,
             goto err_exit;
 
         *is_encrypted = TRUE;
-        if (SWTPM_NVRAM_FileKey_Size() == SWTPM_AES256_BLOCK_SIZE)
+        if (SWTPM_NVRAM_FileKey_Size() == SWTPM_AES256_KEY_SIZE)
             flags |= BLOB_FLAG_ENCRYPTED_256BIT_KEY;
     } else {
         *is_encrypted = FALSE;
@@ -1213,7 +1213,7 @@ TPM_RESULT SWTPM_NVRAM_GetStateBlob(unsigned char **data,
     if (SWTPM_NVRAM_Has_MigrationKey()) {
         /* we have to encrypt it now with the migration key */
         flags |= BLOB_FLAG_MIGRATION_ENCRYPTED;
-        if (SWTPM_NVRAM_MigrationKey_Size() == SWTPM_AES256_BLOCK_SIZE)
+        if (SWTPM_NVRAM_MigrationKey_Size() == SWTPM_AES256_KEY_SIZE)
              flags |= BLOB_FLAG_MIGRATION_256BIT_KEY;
 
         td_len = 3;


### PR DESCRIPTION
Rename the SWTPM_AES128/256_BLOCK_SIZE #defines to SWTPM_AES128/256_KEY_SIZE and introduce a SWTPM_AES_BLOCK_SIZE #define that is to be used for the IV buffer, which is always 16 bytes for AES. Ensure that the IV size passed to the encryption and decryption function is at least of the BLOCK_SIZE -- due to a mistake 32 bytes may be passed when a 256bit key is used even though only 16 bytes will be used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AES encryption and decryption reliability by consistently handling initialization vectors at the correct block size.
  * Strengthened validation of user-provided initialization vectors.
  * Corrected AES key-length handling for 128-bit and 256-bit keys.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->