### PR TITLE
Add O_NOFOLLOW to some open() calls

### DIFF
--- a/src/swtpm/common.c
+++ b/src/swtpm/common.c
@@ -1446,7 +1446,7 @@ error:
  * Parse the 'seccomp' options.
  *
  * @options: the flags options to parse
- * @seccomp_action: the action to take when 
+ * @seccomp_action: the action to take when
  *
  * Returns 0 on success, -1 on failure.
  */
@@ -1663,7 +1663,7 @@ static int parse_pcap_options(const char *options, struct pcap_state *ps)
     checksums = option_get_int(ovs, "checksums", false);
 
     if (filename) {
-        flags = O_CREAT|O_WRONLY|O_NONBLOCK;
+        flags = O_CREAT|O_WRONLY|O_NONBLOCK|O_NOFOLLOW;
 
         if (truncate)
             flags |= O_TRUNC;

--- a/src/swtpm/swtpm_nvstore_linear_file.c
+++ b/src/swtpm/swtpm_nvstore_linear_file.c
@@ -166,7 +166,7 @@ SWTPM_NVRAM_LinearFile_DoOpenURI(const char *uri)
     if (mmap_state.fd >= 0)
         return TPM_SUCCESS;
 
-    mmap_state.fd = open(path, O_RDWR|O_CREAT,
+    mmap_state.fd = open(path, O_RDWR|O_CREAT|O_NOFOLLOW,
                          tpmstate_get_mode(&mode_is_default));
     if (mmap_state.fd < 0) {
         logprintf(STDERR_FILENO,


### PR DESCRIPTION
This PR adds O_NOFOLLOW to the open on pcap files and open on the linear file backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-handling security by preventing symbolic links from being followed when creating or opening capture and NVRAM storage files.
  * Strengthened protection against unintended access to files outside the configured paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->