### PR TITLE
Fix some issues in swtpm_setup

### DIFF
--- a/man/man8/swtpm_setup.pod
+++ b/man/man8/swtpm_setup.pod
@@ -165,7 +165,7 @@ Create an EK certificate; this implies --createek.
 
 =item B<--create-platform-cert>
 
-Create a platform certificate; this implies --create-ek-cert.
+Create a platform certificate; this implies --createek.
 
 =item B<--lock-nvram>
 

--- a/src/swtpm_setup/profile.c
+++ b/src/swtpm_setup/profile.c
@@ -67,7 +67,7 @@ int get_profile_names(const gchar *swtpm_capabilities_json, gchar ***profile_nam
     *profile_names = g_malloc0((num + 1) * sizeof(char *));
     for (i = 0; i < num; i++) {
         if (!json_reader_read_element(jr, i)) {
-            logerr(gl_LOGFILE, "Could not parse JSON list: %s\n", error->message);
+            logerr(gl_LOGFILE, "Could not parse JSON list\n");
             goto error_str_array_free;
         }
         (*profile_names)[i] = g_strdup(json_reader_get_string_value(jr));

--- a/src/swtpm_setup/profile.c
+++ b/src/swtpm_setup/profile.c
@@ -86,6 +86,7 @@ error_unref_jp:
 
 error_str_array_free:
     g_strfreev(*profile_names);
+    *profile_names = NULL;
 
     goto error_unref_jr;
 }

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -2531,7 +2531,7 @@ static int swtpm_tpm12_run_swtpm_bios(struct swtpm *self)
     return 0;
 }
 
-static int swptm_tpm12_create_endorsement_keypair(struct swtpm *self,
+static int swtpm_tpm12_create_endorsement_keypair(struct swtpm *self,
                                                   gchar **pubek, size_t *pubek_len)
 {
     unsigned char req[] = {
@@ -2949,7 +2949,7 @@ static int swtpm_tpm12_nv_lock(struct swtpm *self)
 
 static const struct swtpm12_ops swtpm_tpm12_ops = {
     .run_swtpm_bios = swtpm_tpm12_run_swtpm_bios,
-    .create_endorsement_key_pair = swptm_tpm12_create_endorsement_keypair,
+    .create_endorsement_key_pair = swtpm_tpm12_create_endorsement_keypair,
     .take_ownership = swtpm_tpm12_take_ownership,
     .write_ek_cert_nvram = swtpm_tpm12_write_ek_cert_nvram,
     .write_platform_cert_nvram = swtpm_tpm12_write_platform_cert_nvram,

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -2897,7 +2897,7 @@ static int swtpm_tpm12_nv_write_value(struct swtpm *self, uint32_t nvindex,
 
     ((struct tpm_req_header *)req)->size = htobe32(req_len);
 
-    return transfer(self, req, req_len, "TPM_NV_DefineSpace", FALSE,
+    return transfer(self, req, req_len, "TPM_NV_WriteValue", FALSE,
                     NULL, NULL, TPM_DURATION_SHORT);
 }
 

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -2220,7 +2220,7 @@ static int swtpm_tpm2_nv_writelock(struct swtpm *self, uint32_t nvindex)
 {
     struct tpm_req_header hdr = TPM_REQ_HEADER_INITIALIZER(TPM2_ST_SESSIONS, 0, TPM2_CC_NV_WRITELOCK);
     struct tpm2_authblock authblock = TPM2_AUTHBLOCK_INITIALIZER(TPM2_RS_PW);
-    g_autofree unsigned char *req;
+    g_autofree unsigned char *req = NULL;
     ssize_t req_len;
 
     req_len = memconcat(&req,

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -650,7 +650,7 @@ static const struct ek_params {
             .keysize = 48,
         },
         .ek_handle = TPM2_EK_ECC_SECP384R1_HANDLE,
-        .keytype = "rsa384r1",
+        .keytype = "secp384r1",
         .nvindex_ekcert = TPM2_NV_INDEX_ECC_SECP384R1_HI_EKCERT,
         .nvindex_template = TPM2_NV_INDEX_ECC_SECP384R1_HI_EKTEMPLATE,
     }, {

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -2397,6 +2397,13 @@ static int swtpm_tpm2_get_capability(struct swtpm *self, uint32_t cap, uint32_t 
     if (ret != 0)
         return 1;
 
+    if (tpmresp_len < 27) {
+        logerr(self->logfile,
+               "Response from TPM2_GetCapability is too short! %zu < 27\n",
+               tpmresp_len);
+        return 1;
+    }
+
     memcpy(&val, &tpmresp[23], sizeof(val));
     *res = be32toh(val);
 

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -363,7 +363,7 @@ static int do_cmd_get_info(struct swtpm *self, uint64_t swtpm_info_flags,
     if (tpmresp_len < 8 + sizeof(length))
         goto err_too_short;
     memcpy(&length, &tpmresp[8], sizeof(length));
-    length = htobe32(length);
+    length = be32toh(length);
 
     if (tpmresp_len < 12 + length)
         goto err_too_short;

--- a/src/swtpm_setup/swtpm.c
+++ b/src/swtpm_setup/swtpm.c
@@ -1920,6 +1920,9 @@ static int swtpm_tpm2_create_spk(struct swtpm *self, enum keyalgo keyalgo,
     if (ret == 0)
         logit(self->logfile,
               "Successfully created storage primary key with handle 0x%x.\n", TPM2_SPK_HANDLE);
+    else
+        logerr(self->logfile,
+               "Could not make storage primary key permanent.\n");
 
     ret = swtpm_tpm2_flushcontext(self, curr_handle);
     if (ret != 0) {

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -1799,6 +1799,7 @@ int main(int argc, char *argv[])
     const struct passwd *curr_user;
     struct group *curr_grp;
     char *endptr;
+    unsigned long long tmp_fd;
     gboolean swtpm_has_tpm12 = FALSE;
     gboolean swtpm_has_tpm2 = FALSE;
     int fds_to_pass[2] = { -1, -1 };
@@ -1925,23 +1926,27 @@ int main(int argc, char *argv[])
             g_free(keyfile);
             keyfile = g_strdup(optarg);
             break;
-        case 'X': /* --pwdfile-fd' */
-            keyfile_fd = strtoull(optarg, &endptr, 10);
-            if (*endptr != '\0' && keyfile_fd >= INT_MAX) {
+        case 'X': /* --keyfile-fd */
+            errno = 0;
+            tmp_fd = strtoull(optarg, &endptr, 10);
+            if (*endptr != '\0' || endptr == optarg || errno || tmp_fd >= INT_MAX) {
                 fprintf(stderr, "Invalid file descriptor '%s'\n", optarg);
                 goto error;
             }
+            keyfile_fd = tmp_fd;
             break;
         case 'k': /* --pwdfile */
             g_free(pwdfile);
             pwdfile = g_strdup(optarg);
             break;
-        case 'K': /* --pwdfile-fd' */
-            pwdfile_fd = strtoull(optarg, &endptr, 10);
-            if (*endptr != '\0' || pwdfile_fd >= INT_MAX) {
+        case 'K': /* --pwdfile-fd */
+            errno = 0;
+            tmp_fd = strtoull(optarg, &endptr, 10);
+            if (*endptr != '\0' || endptr == optarg || errno || tmp_fd >= INT_MAX) {
                 fprintf(stderr, "Invalid file descriptor '%s'\n", optarg);
                 goto error;
             }
+            pwdfile_fd = tmp_fd;
             break;
         case 'p': /* --cipher */
             g_free(cipher);
@@ -2014,11 +2019,13 @@ int main(int argc, char *argv[])
             json_profile_file = g_strdup(optarg);
             break;
         case 'G': /* --profile-file-fd */
-            json_profile_fd = strtoull(optarg, &endptr, 10);
-            if (*endptr != '\0' || json_profile_fd >= INT_MAX) {
+            errno = 0;
+            tmp_fd = strtoull(optarg, &endptr, 10);
+            if (*endptr != '\0' || endptr == optarg || errno || tmp_fd >= INT_MAX) {
                 fprintf(stderr, "Invalid file descriptor '%s'\n", optarg);
                 goto error;
             }
+            json_profile_fd = tmp_fd;
             break;
         case 'j': /* --profile-remove-disabled */
             if (strcmp(optarg, "fips-host") != 0 &&

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -1974,7 +1974,7 @@ int main(int argc, char *argv[])
             break;
         case 'A': /* --rsa-keysize */
             g_free(rsa_keysize_str);
-            rsa_keysize_str = strdup(optarg);
+            rsa_keysize_str = g_strdup(optarg);
             flags |= SETUP_RSA_KEYSIZE_BY_USER_F;
             break;
         case '3': /* --write-ek-cert-files */

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -759,7 +759,7 @@ static int get_default_profile_fd(gchar *const *config_file_lines)
 
     fd = open(profile_file, O_RDONLY);
     if (fd < 0) {
-        logerr(gl_LOGFILE, "Could not read default profile '%s': %s",
+        logerr(gl_LOGFILE, "Could not read default profile '%s': %s\n",
                profile_file, strerror(errno));
         return -2;
     }
@@ -2346,7 +2346,7 @@ int main(int argc, char *argv[])
 
         if ((iakkeyalgo != KEYALGO_NONE || idevidkeyalgo != KEYALGO_NONE) &&
             (flags & SETUP_CREATE_EK_F)== 0 ) {
-            fprintf(stderr, "When creaing IAK and/or IDevID keys, then an EK certificate must be created as well.\n");
+            fprintf(stderr, "When creating IAK and/or IDevID keys, then an EK certificate must be created as well.\n");
             goto error;
         }
     }

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -2200,7 +2200,7 @@ int main(int argc, char *argv[])
     if ((json_profile != NULL) +
         (json_profile_name != NULL) +
         (json_profile_file != NULL) +
-        (json_profile_fd > 0) > 1) {
+        (json_profile_fd >= 0) > 1) {
         logerr(gl_LOGFILE, "Only one of --profile, --profile-name, --profile-file, and --profile-file-fd may be given.\n");
         goto error;
     }
@@ -2209,7 +2209,7 @@ int main(int argc, char *argv[])
          (json_profile ||
           json_profile_name ||
           json_profile_file ||
-          json_profile_fd > 0)) {
+          json_profile_fd >= 0)) {
             logerr(gl_LOGFILE, "Reconfiguration does not accept a (new) profile.\n");
             goto error;
     }

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -1634,7 +1634,7 @@ static int change_process_owner(const char *user)
     }
 
     if (setuid(uid) != 0) {
-        logerr(gl_LOGFILE, "Error: setuid(%lld) failed: %s\n", uid, strerror(errno));
+        logerr(gl_LOGFILE, "Error: setuid(%llu) failed: %s\n", uid, strerror(errno));
         goto error;
     }
 

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -1983,8 +1983,8 @@ int main(int argc, char *argv[])
             user_certsdir = g_strdup(optarg);
             flags |= SETUP_WRITE_EK_CERT_FILES_F;
             break;
-        case 'u':
-            if (optarg == NULL && optind < argc && argv[optind][0] != '0')
+        case 'u': /* --create-config-files */
+            if (optarg == NULL && optind < argc && argv[optind][0] != '-')
                 optarg = argv[optind++];
             ret = handle_create_config_files(optarg);
             goto out;

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -2352,7 +2352,7 @@ int main(int argc, char *argv[])
             goto error;
 
         if ((iakkeyalgo != KEYALGO_NONE || idevidkeyalgo != KEYALGO_NONE) &&
-            (flags & SETUP_CREATE_EK_F)== 0 ) {
+            (flags & SETUP_EK_CERT_F) == 0 ) {
             fprintf(stderr, "When creating IAK and/or IDevID keys, then an EK certificate must be created as well.\n");
             goto error;
         }

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -202,7 +202,8 @@ static int tpm_get_specs_and_attributes(struct swtpm *swtpm, gchar ***params)
     if (ret) {
         g_strfreev(*params);
         *params = NULL;
-        g_object_unref(jr);
+        if (jr)
+            g_object_unref(jr);
     }
 error:
     g_object_unref(jp);

--- a/src/swtpm_setup/swtpm_setup.c
+++ b/src/swtpm_setup/swtpm_setup.c
@@ -1234,7 +1234,7 @@ static void usage(const char *prgname, const char *default_config_file)
         "--create-ek-cert : Create an EK certificate; this implies --createek\n"
         "\n"
         "--create-platform-cert\n"
-        "                 : Create a platform certificate; this implies --create-ek-cert\n"
+        "                 : Create a platform certificate; this implies --createek\n"
         "\n"
         "--create-spk     : Create storage primary key; this requires --tpm2; deprecated\n"
         "\n"

--- a/src/swtpm_setup/swtpm_setup_utils.c
+++ b/src/swtpm_setup/swtpm_setup_utils.c
@@ -185,7 +185,7 @@ int create_config_files(gboolean overwrite, gboolean root_flag,
         if (!g_file_set_contents(configfiles[i], filedata[i], -1, &error)) {
             fprintf(stderr,
                     "Could not write to %s: %s\n",
-                    configfiles[i], strerror(errno));
+                    configfiles[i], error->message);
             delete_files = TRUE;
             goto error;
         }


### PR DESCRIPTION
This PR fixes some issues in swtpm_setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed information response decoding across different system architectures.
  - Corrected TPM 1.2 NV write operations and NV write-lock handling.
  - Corrected the reported type for P384 ECC endorsement keys.
  - Added validation for TPM capability responses.
  - Strengthened validation for file descriptors and optional configuration-file arguments.
  - Improved cleanup during JSON profile processing.
  - Corrected diagnostics for privilege changes, configuration write failures, JSON parsing, and storage key persistence.
  - Improved RSA key-size option memory handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->