### PR TITLE
swtpm: Fix length check in SWTPM_NVRAM_CheckHeader()

### DIFF
--- a/src/swtpm/swtpm_nvstore.c
+++ b/src/swtpm/swtpm_nvstore.c
@@ -1100,7 +1100,7 @@ SWTPM_NVRAM_CheckHeader(unsigned char *data, uint32_t length,
     blobheader *bh = (blobheader *)data;
     uint16_t hdrsize;
 
-    if (length < sizeof(bh)) {
+    if (length < sizeof(*bh)) {
         if (!quiet)
             logprintf(STDERR_FILENO,
                       "not enough bytes for header: %u\n", length);


### PR DESCRIPTION
The length of an incoming blob was compared against sizeof(bh), which is the size of the blobheader pointer rather than the size of the structure. blobheader is packed and 10 bytes wide, so on 64-bit builds a blob of 8 bytes passed the check and the subsequent read of bh->totlen, which occupies offsets 6-9, accessed 2 bytes beyond the buffer. On 32-bit builds the check admitted 4 bytes and the overread was 6.

A blob of this length can be supplied via CMD_SET_STATEBLOB, where ctrlchannel_receive_state() allocates exactly the length the client declares.

Fixes: CVE-2026-75900