### PR TITLE
tests: check for TPM 2.0 in test_tpm2_ctrlchannel3

### DIFF
--- a/tests/test_tpm2_ctrlchannel3
+++ b/tests/test_tpm2_ctrlchannel3
@@ -26,7 +26,7 @@ function cleanup()
 }
 
 source "${TESTDIR}/common"
-skip_test_no_tpm12 "${SWTPM_EXE}"
+skip_test_no_tpm20 "${SWTPM_EXE}"
 
 
 if ! [[ "$(uname -s)" =~ Linux ]]; then


### PR DESCRIPTION
The test runs swtpm with --tpm2 but checks for TPM 1.2 support, causing it to be skipped by TPM 2-only builds. Check for TPM 2.0 instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the test environment check so TPM 2.0-specific tests are skipped when the required TPM 2.0 emulator is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->