### PR TITLE
Cleanups in swtpm_cert

### DIFF
--- a/src/swtpm_cert/ek-cert.c
+++ b/src/swtpm_cert/ek-cert.c
@@ -1721,7 +1721,7 @@ int main(int argc, char *argv[])
         ASN1_TIME_set_string(asn1_time, "99991231235959Z");
     } else {
         CHECK_OSSL_NULLPTR(X509_time_adj_ex(asn1_time, days, 0, &now),
-                           "Days '%lu' may be too far in the future.\n",
+                           "Days '%ld' may be too far in the future.\n",
                            days);
     }
     CHECK_OSSL_RETURN1(X509_set1_notAfter(crt, asn1_time) != 1,

--- a/src/swtpm_cert/ek-cert.c
+++ b/src/swtpm_cert/ek-cert.c
@@ -1375,7 +1375,7 @@ int main(int argc, char *argv[])
                         optarg);
                 goto cleanup;
             }
-            if (days > INT_MAX) {
+            if (days > INT_MAX || days < -1 /* -1 is for no-expiration */) {
                 fprintf(stderr, "Days value of '%s' is outside valid range.\n",
                         optarg);
                 goto cleanup;

--- a/src/swtpm_cert/ek-cert.c
+++ b/src/swtpm_cert/ek-cert.c
@@ -1818,7 +1818,7 @@ int main(int argc, char *argv[])
     case CERT_TYPE_IDEVID:
         err = create_iak_info(&datum, tpm_serial_num);
         if (err) {
-            fprintf(stderr, "Could not create IAK info");
+            fprintf(stderr, "Could not create IAK info.\n");
             goto cleanup;
         }
         critical = 0;

--- a/src/swtpm_cert/ek-cert.c
+++ b/src/swtpm_cert/ek-cert.c
@@ -257,9 +257,9 @@ static void usage(const char *prg)
         , prg);
 }
 
-static char hex_to_str(char digit)
+static int hex_to_val(char digit)
 {
-    char value = -1;
+    int value = -1;
 
     if (digit >= '0' && digit <= '9') {
         value = digit - '0';
@@ -277,7 +277,7 @@ static unsigned char *hex_str_to_bin(const char *hexstr, int *modulus_len)
     int len;
     unsigned char *result;
     int i = 0, j = 0;
-    char val1, val2;
+    int val1, val2;
 
     len = strlen(hexstr);
     if (len > MAX_HEX_STRING_SIZE) {
@@ -300,14 +300,14 @@ static unsigned char *hex_str_to_bin(const char *hexstr, int *modulus_len)
     j = 0;
 
     while (i < len) {
-        val1 = hex_to_str(hexstr[i]);
+        val1 = hex_to_val(hexstr[i]);
         if (val1 < 0) {
             fprintf(stderr, "Illegal hex character '%c'.\n", hexstr[i]);
             free(result);
             return NULL;
         }
         i++;
-        val2 = hex_to_str(hexstr[i]);
+        val2 = hex_to_val(hexstr[i]);
         if (val2 < 0) {
             fprintf(stderr, "Illegal hex character '%c'.\n", hexstr[i]);
             free(result);

--- a/src/swtpm_cert/ek-cert.c
+++ b/src/swtpm_cert/ek-cert.c
@@ -1017,7 +1017,12 @@ readfd:
 
 static int password_cb(char *buf, int buflen, int rwflag, void *userdata)
 {
-    size_t to_copy = strlen(userdata);
+    size_t to_copy;
+
+    if (!userdata)
+        return 0;
+
+    to_copy = strlen(userdata);
     if (buflen < 0 || to_copy > (size_t)buflen)
         return 0;
 

--- a/src/swtpm_cert/ek-cert.c
+++ b/src/swtpm_cert/ek-cert.c
@@ -1176,7 +1176,7 @@ int main(int argc, char *argv[])
     long days = 365;
     char *sigkeypass = NULL;
     unsigned char ser_number[20];
-    size_t ser_number_len;
+    size_t ser_number_len = 0;
     long int exponent = 0x10001;
     bool write_pem = false;
     enum cert_type_t certtype = CERT_TYPE_EK;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate handling when no password information is provided.
  * Ensured serial-number output is initialized consistently.
  * Rejected negative certificate validity periods.
  * Improved hexadecimal value parsing and invalid-character handling.
  * Corrected formatting of an IAK information error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->