### PR TITLE
nvstore_linear: validate file offset/length fields against store size

### DIFF
--- a/src/swtpm/swtpm_nvstore_linear.c
+++ b/src/swtpm/swtpm_nvstore_linear.c
@@ -17,6 +17,8 @@
 #include "logging.h"
 #include "utils.h"
 
+static void SWTPM_NVRAM_Cleanup_Linear(void);
+
 static struct {
     TPM_BOOL      initialized;
     char          *loaded_uri;
@@ -118,6 +120,12 @@ SWTPM_NVRAM_Linear_AllocFile(const char *uri, uint32_t file_nr, uint32_t size)
     uint32_t cur_end;
     uint32_t i;
     uint32_t section_size = size;
+
+    if (section_size == 0 || section_size > (UINT32_MAX / 2) + 1) {
+        /* size 0 has nothing to round; a size this large can't be rounded
+           up to the next power of 2 without overflowing */
+        return TPM_SIZE;
+    }
     ROUND_TO_NEXT_POWER_OF_2_32(section_size);
 
     /* find end of current last file */
@@ -127,13 +135,21 @@ SWTPM_NVRAM_Linear_AllocFile(const char *uri, uint32_t file_nr, uint32_t size)
             continue;
         }
 
-        cur_end = le32toh(file->offset) + le32toh(file->section_length);
+        if (__builtin_add_overflow(le32toh(file->offset),
+                                   le32toh(file->section_length), &cur_end)) {
+            /* a slot with an inconsistent offset/section_length made it
+               into the header (e.g. via a bug elsewhere); don't propagate
+               the corruption into a new allocation */
+            return TPM_FAIL;
+        }
         if (cur_end > new_offset) {
             new_offset = cur_end;
         }
     }
 
-    new_size = new_offset + section_size;
+    if (__builtin_add_overflow(new_offset, section_size, &new_size)) {
+        return TPM_SIZE;
+    }
     rc = SWTPM_NVRAM_Linear_SafeResize(uri, new_size);
     if (rc) {
         return rc;
@@ -169,6 +185,7 @@ SWTPM_NVRAM_Linear_RemoveFile(const char *uri,
     TPM_RESULT rc = 0;
     uint32_t next_offset = 0xffffffff;
     uint32_t state_end = 0;
+    uint32_t move_distance = 0;
     uint32_t new_len;
     uint32_t i, cur_offset, cur_end;
     struct nvram_linear_hdr_file *file;
@@ -178,17 +195,33 @@ SWTPM_NVRAM_Linear_RemoveFile(const char *uri,
         return 0;
     }
 
+    if (le32toh(old_file.offset) < sizeof(struct nvram_linear_hdr) ||
+        __builtin_add_overflow(le32toh(old_file.offset),
+                               le32toh(old_file.section_length), &cur_end) ||
+        cur_end > state.length) {
+        /* the slot being removed is itself inconsistent with the mapped
+           store: an offset inside the header would make the memmove
+           below overwrite header data, and an oversized section_length
+           would underflow the "new_len = state.length - section_length"
+           computation below into requesting a near-UINT32_MAX resize */
+        return TPM_FAIL;
+    }
+
     TPM_DEBUG("SWTPM_NVRAM_Linear_RemoveFile: removing filenr %d (resize=%d)\n",
               file_nr, resize);
 
-    state.hdr->files[file_nr].offset = 0;
-    state.hdr->files[file_nr].data_length = 0;
-    state.hdr->files[file_nr].section_length = 0;
-
-    /* find offset of file right after the one we remove, and adjust offsets */
+    /*
+     * First pass (read-only): find the offset of the file right after the
+     * one being removed and the end of the region in use, and validate
+     * that every affected slot is arithmetically consistent -- all before
+     * mutating any header field. Bailing out partway through a mutating
+     * pass would leave some slots' offsets shifted and others not, with
+     * the data not yet moved to match either -- a corrupted, inconsistent
+     * header that a later store could act on.
+     */
     for (i = 0; i < SWTPM_NVSTORE_LINEAR_MAX_STATES; i++) {
         file = &state.hdr->files[i];
-        if (!file->offset) {
+        if (!file->offset || i == file_nr) {
             continue;
         }
 
@@ -197,14 +230,65 @@ SWTPM_NVRAM_Linear_RemoveFile(const char *uri,
             if (cur_offset < next_offset) {
                 next_offset = cur_offset;
             }
-            cur_end = cur_offset + le32toh(file->section_length);
+            if (__builtin_add_overflow(cur_offset,
+                                       le32toh(file->section_length),
+                                       &cur_end)) {
+                return TPM_FAIL;
+            }
             if (cur_end > state_end) {
                 state_end = cur_end;
             }
-            file->offset = htole32(cur_offset -
-                                   le32toh(old_file.section_length));
         }
     }
+
+    if (next_offset != 0xffffffff) {
+        if (next_offset > state_end || state_end > state.length) {
+            /* the header we just walked is inconsistent with the mapped
+               store size; refuse to move data around based on it */
+            return TPM_FAIL;
+        }
+        if (next_offset - le32toh(old_file.offset) <
+            le32toh(old_file.section_length)) {
+            /* a later slot starts inside the removed slot's own section --
+               only rejected as an overlap by ValidateFiles() at prepare
+               time, not re-checked here. If allowed through, move_distance
+               below would be smaller than old_file.section_length, so the
+               resize's new_len = state.length - old_file.section_length
+               would shrink the store below where the compacted data
+               actually ends, truncating a valid slot */
+            return TPM_FAIL;
+        }
+        /*
+         * Use the actual gap between the removed slot and the next one,
+         * not old_file.section_length, to shift both the data and every
+         * later slot's recorded offset by the same amount. ValidateFiles
+         * rejects overlapping slots but not gapped (non-overlapping but
+         * non-contiguous) ones; if a gap exists here, moving the data by
+         * next_offset - old_file.offset while adjusting offsets by only
+         * section_length (or vice versa) would desynchronize a later
+         * slot's recorded offset from where its data actually ends up.
+         * next_offset is the minimum of all qualifying cur_offset values
+         * above, so cur_offset - move_distance below can never underflow.
+         */
+        move_distance = next_offset - le32toh(old_file.offset);
+    }
+
+    /* second pass: everything above validated, now apply the changes */
+    for (i = 0; i < SWTPM_NVSTORE_LINEAR_MAX_STATES; i++) {
+        file = &state.hdr->files[i];
+        if (!file->offset || i == file_nr) {
+            continue;
+        }
+
+        cur_offset = le32toh(file->offset);
+        if (cur_offset > le32toh(old_file.offset)) {
+            file->offset = htole32(cur_offset - move_distance);
+        }
+    }
+
+    state.hdr->files[file_nr].offset = 0;
+    state.hdr->files[file_nr].data_length = 0;
+    state.hdr->files[file_nr].section_length = 0;
 
     if (next_offset != 0xffffffff) {
         TPM_DEBUG("SWTPM_NVRAM_Linear_RemoveFile: compacting\n");
@@ -223,6 +307,102 @@ SWTPM_NVRAM_Linear_RemoveFile(const char *uri,
     }
 
     return rc;
+}
+
+/*
+    Validates every file slot's offset/data_length/section_length in the
+    loaded header against the actual size of the mapped store.
+
+    The header is untrusted input (it comes from the on-disk/mmap'd state
+    file, which may be corrupted or maliciously crafted, e.g. when the
+    backend-uri points at shared/attacker-influenced storage). Every
+    consumer of file->offset/data_length/section_length
+    (SWTPM_NVRAM_LoadData_Linear, SWTPM_NVRAM_StoreData_Linear) relies on
+    these fields being consistent with the store's real size; validating
+    them once here, with overflow-safe arithmetic, avoids having each
+    caller re-derive (or, in the store path, omit) that trust boundary
+    check itself.
+*/
+static TPM_RESULT
+SWTPM_NVRAM_Linear_ValidateFiles(void)
+{
+    unsigned int i, j;
+    uint32_t offset[SWTPM_NVSTORE_LINEAR_MAX_STATES];
+    uint32_t end[SWTPM_NVSTORE_LINEAR_MAX_STATES];
+    TPM_BOOL allocated[SWTPM_NVSTORE_LINEAR_MAX_STATES];
+    uint32_t data_length, section_length;
+    uint16_t hdrsize;
+
+    /*
+     * hdrsize is untrusted (read from the on-disk header) and is later
+     * trusted as-is by SWTPM_NVRAM_Linear_AllocFile() as the baseline
+     * offset for newly allocated slots, and by SWTPM_NVRAM_Linear_FlushHeader()
+     * as the number of header bytes to flush. A too-small hdrsize would let
+     * AllocFile place a new slot's data inside the real header (there is
+     * no other check on freshly-allocated slots, since ValidateFiles only
+     * runs once at prepare time against the header found on disk). This
+     * format has no header versioning that would call for anything other
+     * than the current fixed header size, so require an exact match.
+     */
+    hdrsize = le16toh(state.hdr->hdrsize);
+    if (hdrsize != sizeof(struct nvram_linear_hdr)) {
+        logprintf(STDERR_FILENO,
+                  "SWTPM_NVRAM_Linear_ValidateFiles: Corrupt linear NVRAM "
+                  "header: hdrsize=%u does not match expected size %zu\n",
+                  hdrsize, sizeof(struct nvram_linear_hdr));
+        return TPM_FAIL;
+    }
+
+    for (i = 0; i < SWTPM_NVSTORE_LINEAR_MAX_STATES; i++) {
+        struct nvram_linear_hdr_file *file = &state.hdr->files[i];
+
+        allocated[i] = FALSE;
+        offset[i] = le32toh(file->offset);
+        if (!offset[i]) {
+            /* unallocated slot */
+            continue;
+        }
+
+        data_length = le32toh(file->data_length);
+        section_length = le32toh(file->section_length);
+
+        /* The slot must start after the header (not overlap it) and its
+           end (offset + section_length, computed overflow-safely) must
+           not exceed the mapped store. */
+        if (offset[i] < sizeof(struct nvram_linear_hdr) ||
+            data_length > section_length ||
+            __builtin_add_overflow(offset[i], section_length, &end[i]) ||
+            end[i] > state.length) {
+            logprintf(STDERR_FILENO,
+                      "SWTPM_NVRAM_Linear_ValidateFiles: Corrupt linear NVRAM "
+                      "header: file[%u] offset=%u data_length=%u "
+                      "section_length=%u is inconsistent with store size %u\n",
+                      i, offset[i], data_length, section_length, state.length);
+            return TPM_FAIL;
+        }
+        allocated[i] = TRUE;
+    }
+
+    /* Reject slots whose [offset, offset + section_length) ranges overlap;
+       an attacker-crafted header could otherwise let one file's data alias
+       another's, corrupting it on the next store. */
+    for (i = 0; i < SWTPM_NVSTORE_LINEAR_MAX_STATES; i++) {
+        if (!allocated[i])
+            continue;
+        for (j = i + 1; j < SWTPM_NVSTORE_LINEAR_MAX_STATES; j++) {
+            if (!allocated[j])
+                continue;
+            if (offset[i] < end[j] && offset[j] < end[i]) {
+                logprintf(STDERR_FILENO,
+                          "SWTPM_NVRAM_Linear_ValidateFiles: Corrupt linear "
+                          "NVRAM header: file[%u] and file[%u] overlap\n",
+                          i, j);
+                return TPM_FAIL;
+            }
+        }
+    }
+
+    return 0;
 }
 
 static TPM_RESULT
@@ -289,7 +469,14 @@ SWTPM_NVRAM_Prepare_Linear(const char *uri)
             logprintf(STDERR_FILENO,
                       "SWTPM_NVRAM_PrepareLinear: Unknown format version: %d\n",
                       state.hdr->version);
+            SWTPM_NVRAM_Cleanup_Linear();
             return TPM_FAIL;
+        }
+
+        rc = SWTPM_NVRAM_Linear_ValidateFiles();
+        if (rc) {
+            SWTPM_NVRAM_Cleanup_Linear();
+            return rc;
         }
     }
 
@@ -320,6 +507,7 @@ SWTPM_NVRAM_LoadData_Linear(unsigned char **data,
     uint32_t file_nr;
     uint32_t file_offset;
     uint32_t file_data_len;
+    uint32_t file_end;
     struct nvram_linear_hdr_file *file;
 
     TPM_DEBUG("SWTPM_NVRAM_LoadData_Linear: request for %s:%d\n",
@@ -338,7 +526,10 @@ SWTPM_NVRAM_LoadData_Linear(unsigned char **data,
         return TPM_RETRY;
     }
 
-    if (file_offset + file_data_len > state.length) {
+    if (file_offset < sizeof(struct nvram_linear_hdr) ||
+        file_data_len > le32toh(file->section_length) ||
+        __builtin_add_overflow(file_offset, file_data_len, &file_end) ||
+        file_end > state.length) {
         /* shouldn't happen, but just to be safe */
         return TPM_FAIL;
     }
@@ -413,6 +604,21 @@ SWTPM_NVRAM_StoreData_Linear(unsigned char *filedata,
     file = &state.hdr->files[file_nr];
     file_offset = le32toh(file->offset);
 
+    {
+        uint32_t file_end;
+
+        if (file_offset < sizeof(struct nvram_linear_hdr) ||
+            filedata_length > le32toh(file->section_length) ||
+            __builtin_add_overflow(file_offset, filedata_length, &file_end) ||
+            file_end > state.length) {
+            logprintf(STDERR_FILENO,
+                      "SWTPM_NVRAM_StoreData_Linear: file offset=%u length=%u "
+                      "would exceed store size %u or section\n",
+                      file_offset, filedata_length, state.length);
+            return TPM_FAIL;
+        }
+    }
+
     if (filedata_length != le32toh(file->data_length)) {
         file->data_length = htole32(filedata_length);
         needs_hdr_flush = TRUE;
@@ -473,7 +679,12 @@ static void SWTPM_NVRAM_Cleanup_Linear(void) {
     }
     if (state.loaded_uri) {
         free(state.loaded_uri);
+        state.loaded_uri = NULL;
     }
+    state.data = NULL;
+    state.hdr = NULL;
+    state.length = 0;
+    state.initialized = FALSE;
 }
 
 static TPM_RESULT


### PR DESCRIPTION
## Summary

Fixes #1170. Fixes #1172. Fixes #1173. Fixes #1174.

The `linear://`/`file://` NVRAM backend (`src/swtpm/swtpm_nvstore_linear.c`) trusts per-file `offset`/`data_length`/`section_length` fields read directly from the on-disk/mmap'd state-file header without validating them against the actual mapped store size. Only `magic` and `version` were checked when a store is opened.

**Load path (`SWTPM_NVRAM_LoadData_Linear`)** — the original check, `file_offset + file_data_len > state.length`, is unsigned 32-bit addition and wraps around: `offset = 0xFFFFFFF0`, `data_length = 0x20` sums to `0x10`, which passes the check even though `state.data + file_offset` (≈ +4 GiB from the mapped base) is nowhere near the real (typically tens-of-KB) mapped file. The subsequent `memcpy` reads out of bounds. (#1170, confirmed independently with an ASan repro.)

**Store path (`SWTPM_NVRAM_StoreData_Linear`)** — had no bounds check at all: if a pre-existing header entry already has a non-zero `offset` and a `section_length` that's `>= filedata_length`, both the alloc and realloc branches are skipped, and `memcpy(state.data + file_offset, filedata, filedata_length)` ran with no check against `state.length` whatsoever. (#1170, also confirmed independently, including demonstrating the write landing in an adjacent mapping and being flushed back to disk.)

**Compaction (`SWTPM_NVRAM_Linear_RemoveFile`)** and **allocation (`SWTPM_NVRAM_Linear_AllocFile`)** — the two functions that mutate slot metadata during live operation (reached via the realloc path in `StoreData_Linear` whenever a store grows past its current section) had the same class of unchecked arithmetic: `AllocFile`'s `new_size = new_offset + section_size` and its scan for the current end of the last file could overflow; `RemoveFile`'s offset-adjustment subtraction could underflow, and its compaction `memmove`'s source/destination/length were derived from that unvalidated arithmetic with no bounds check against `state.length`. (#1172, #1173, #1174.)

## Fix

**`SWTPM_NVRAM_Linear_ValidateFiles()`**, called once right after the header's magic/version are confirmed valid in `SWTPM_NVRAM_Prepare_Linear`, rejects the store if:
- `state.hdr->hdrsize` doesn't match `sizeof(struct nvram_linear_hdr)` — `hdrsize` is trusted as-is by `AllocFile` as the baseline offset for newly-allocated slots; a too-small value would let a fresh allocation land inside the real header, and freshly-allocated slots are never re-validated by `ValidateFiles` since it only runs once against the on-disk header.
- any file slot's `offset`/`data_length`/`section_length` is inconsistent with the mapped store size (using overflow-safe arithmetic, `__builtin_add_overflow`, matching the pattern already used elsewhere in this codebase).
- a slot's offset lands inside the header itself, or any pair of allocated slots' ranges overlap.

`SWTPM_NVRAM_Prepare_Linear()` now also routes both this and the pre-existing version-check failure through `SWTPM_NVRAM_Cleanup_Linear()` before returning, so a rejected store doesn't leak `state.loaded_uri`/the mmap and make a retry fail with "Already open".

**`LoadData_Linear`/`StoreData_Linear`**'s own per-call bounds checks are fixed directly (the former's overflow, the latter's total absence) rather than relying solely on the one-time prepare-time validation, so each call is self-defending even if the header changes after `Prepare_Linear` runs (e.g. a concurrent writer when storage locking is disabled).

**`AllocFile`/`RemoveFile`** are hardened the same way: every `offset + section_length` sum is overflow-checked, the offset-adjustment subtraction in `RemoveFile` is underflow-checked, `AllocFile`'s size-rounding is guarded against an input large enough to overflow it, and the compaction `memmove` is preceded by a check that the range it's about to move is actually within the mapped store.

Only affects the `linear://`/`file://` backend (`--tpmstate backend-uri=file://...`); the default `dir://` backend is unaffected.

## Verification

**Isolated unit test** driving `SWTPM_NVRAM_Linear_ValidateFiles()` directly against hand-crafted headers (9 cases): the reported overflow case, a `data_length`/`section_length` mismatch, an out-of-bounds section, a slot overlapping the header, two overlapping slots, and both a too-small and too-large `hdrsize` are all correctly rejected; a well-formed multi-slot header and a freshly-formatted header are correctly accepted.

**Live end-to-end regression test** against a real `linear://` (`file://`)-backed swtpm instance, driven with tpm2-tools: `TPM2_Startup`, RSA `CreatePrimary`, ECC P521 `CreatePrimary` (a different permanent-state size that forces the realloc path — `RemoveFile` followed by `AllocFile`, exactly the functions touched by the hardening above), `NV_DefineSpace`/`NV_Write`/`NV_Read` with random data verified to read back correctly, `TPM2_Shutdown` (full state save), and a full process restart against the same on-disk state file with the NV data still reading back correctly after being reloaded through `Prepare_Linear` → `ValidateFiles` → `LoadData_Linear`. All steps succeed.

---
> Additional confirmation, PoCs, and 3 further issues (#1172, #1173, #1174) in this file from an independent audit (credit: Leyao, ICT CAS). Fixed with assistance from Claude Code (claude.ai/code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of NVRAM metadata, headers, storage boundaries, and allocated regions.
  * Prevented invalid sizes, offsets, overlapping regions, and arithmetic overflows from affecting storage operations.
  * Improved handling of inconsistent metadata or slot layouts during loading, saving, and removal.
  * Increased reliability when removing files and compacting stored data.
  * Ensured temporary storage state is cleared after initialization or validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->