### PR TITLE
cuse_tpm: validate --tpmstate backend-uri before assuming dir:// prefix

### DIFF
--- a/src/swtpm/cuse_tpm.c
+++ b/src/swtpm/cuse_tpm.c
@@ -544,9 +544,18 @@ static int tpm_start(uint32_t flags, TPMLIB_TPMVersion l_tpmversion,
 {
     DIR *dir;
     const char *uri = tpmstate_get_backend_uri();
-    const char *tpmdir = uri + strlen("dir://");
+    const char *tpmdir;
 
     *res = TPM_FAIL;
+
+    /* uri is untrusted; must have the "dir://" prefix before advancing past it */
+    if (uri == NULL || strncmp(uri, "dir://", strlen("dir://")) != 0) {
+        logprintf(STDERR_FILENO,
+                  "Error: swtpm_cuse only supports the dir:// backend URI, "
+                  "got: %s\n", uri ? uri : "(null)");
+        return -1;
+    }
+    tpmdir = uri + strlen("dir://");
 
     dir = opendir(tpmdir);
     if (dir) {


### PR DESCRIPTION
## Summary

Fixes #1175. `tpm_start()` in `src/swtpm/cuse_tpm.c` unconditionally computed `uri + strlen("dir://")` from the command-line-provided `--tpmstate backend-uri=...` value, with no check that `uri` actually starts with `"dir://"` or is even long enough:

```c
const char *uri = tpmstate_get_backend_uri();
const char *tpmdir = uri + strlen("dir://");   /* no prefix/length check */
...
dir = opendir(tpmdir);                          /* OOB read */
```

A URI shorter than 6 bytes (e.g. `x`) produces a pointer past the end of the string's allocation, which is then passed to `opendir()` (and can reach `mkdir()`), reading out of bounds while scanning for a NUL terminator.

## Fix

`swtpm_cuse` only supports the `dir://` backend, so require the prefix (and a non-NULL `uri`) before advancing past it, failing startup with a clear error otherwise — matching how the socket frontend (`swtpm_nvstore.c`'s `SWTPM_NVRAM_Init`) already validates `backend_uri` against known prefixes before dispatching to a backend.

## Verification

Compiles clean — both `swtpm` and `swtpm_cuse` (which share this translation unit) rebuild without warnings under the project's strict flags.

I wasn't able to exercise this live end-to-end in my environment — `swtpm_cuse` requires the CUSE kernel module, which isn't available there — so this is a code-level fix verified by inspection and compilation rather than a live-triggered PoC, unlike the other fixes in this campaign. Happy to iterate if testing surfaces anything.

---
> Found by an independent audit (credit: Leyao, ICT CAS). Fixed with assistance from Claude Code (claude.ai/code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation for TPM state backend URIs.
  - Invalid or missing directory-based URIs are now rejected with an error instead of potentially causing unsafe memory access.
  - TPM startup now fails safely when the configured backend URI is missing or uses an unsupported format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->