### PR TITLE
Fix a couple of potential issues related to integer overflows and malloc(0)

### DIFF
--- a/src/swtpm/ctrlchannel.c
+++ b/src/swtpm/ctrlchannel.c
@@ -428,7 +428,11 @@ static ssize_t ctrlchannel_recv_cmd(int fd,
                      offsetof(struct ptm_hdata, u.req.data);
             if (recvd >= needed) {
                 phd = (struct ptm_hdata *)&input->body;
-                needed += be32toh(phd->u.req.length);
+                if (__builtin_add_overflow(needed, be32toh(phd->u.req.length),
+                                           &needed)) {
+                    errno = EOVERFLOW;
+                    return -1;
+                }
             }
             break;
         case CMD_HASH_END:
@@ -450,7 +454,11 @@ static ssize_t ctrlchannel_recv_cmd(int fd,
                      offsetof(struct ptm_setstate, u.req.data);
             if (recvd >= needed) {
                 pss = (struct ptm_setstate_priv *)&input->body;
-                needed += be32toh(pss->u.req.length);
+                if (__builtin_add_overflow(needed, be32toh(pss->u.req.length),
+                                           &needed)) {
+                    errno = EOVERFLOW;
+                    return -1;
+                }
             }
             break;
         case CMD_STOP:

--- a/src/swtpm/swtpm_nvstore.c
+++ b/src/swtpm/swtpm_nvstore.c
@@ -984,7 +984,10 @@ SWTPM_NVRAM_GetPlainData(unsigned char **plain, uint32_t *plain_length,
 
     switch (hdrversion) {
     case 1:
-        *plain = malloc(length);
+        *plain = NULL;
+        /* length == 0 is treated as error - should not be passed */
+        if (length > 0)
+            *plain = malloc(length);
         if (*plain) {
             memcpy(*plain, data, length);
             *plain_length = length;

--- a/src/swtpm/swtpm_nvstore.c
+++ b/src/swtpm/swtpm_nvstore.c
@@ -1076,15 +1076,22 @@ SWTPM_NVRAM_PrependHeader(unsigned char **data, uint32_t *length,
                           uint16_t flags)
 {
     unsigned char *out = NULL;
-    uint32_t out_len = sizeof(blobheader) + *length;
+    uint32_t out_len;
     blobheader bh = {
         .version = BLOB_HEADER_VERSION,
         .min_version = 1,
         .hdrsize = htons(sizeof(bh)),
         .flags = htons(flags),
-        .totlen = htonl(out_len),
     };
     TPM_RESULT res;
+
+    if (__builtin_add_overflow(sizeof(blobheader), *length, &out_len)) {
+        logprintf(STDERR_FILENO, "SWTPM_NVRAM_PrependHeader: length is too big: 0x%x\n",
+                  out_len);
+        res = TPM_FAIL;
+        goto error;
+    }
+    bh.totlen = htonl(out_len);
 
     out = malloc(out_len);
     if (!out) {

--- a/src/swtpm/swtpm_nvstore_linear_file.c
+++ b/src/swtpm/swtpm_nvstore_linear_file.c
@@ -1,6 +1,7 @@
 #include "config.h"
 
 #define _GNU_SOURCE
+#include <inttypes.h>
 #include <limits.h>
 #include <unistd.h>
 #include <string.h>
@@ -24,6 +25,7 @@
 #include "swtpm_utils.h"
 #include "logging.h"
 #include "tpmstate.h"
+#include "utils.h"
 
 /*
     Provides a linear backend based on memory-mapping a filesystem path.
@@ -48,6 +50,7 @@ static struct {
 static TPM_RESULT
 SWTPM_NVRAM_LinearFile_Mmap(void)
 {
+    uint32_t pagesize;
     TPM_RESULT rc = 0;
     struct stat st;
 
@@ -57,6 +60,14 @@ SWTPM_NVRAM_LinearFile_Mmap(void)
         logprintf(STDERR_FILENO,
                   "SWTPM_NVRAM_LinearFile_Mmap: Could not stat file: %s\n",
                   strerror(errno));
+        rc = TPM_FAIL;
+        goto fail;
+    }
+
+    if ((uint64_t)st.st_size > UINT32_MAX) {
+        logprintf(STDERR_FILENO,
+                  "SWTPM_NVRAM_LinearFile_Mmap: Unsupported file size: %" PRIuMAX "\n",
+                  (uintmax_t)st.st_size);
         rc = TPM_FAIL;
         goto fail;
     }
@@ -95,10 +106,24 @@ SWTPM_NVRAM_LinearFile_Mmap(void)
         if (ioctl(mmap_state.fd, BLKGETSIZE64, &bd_size)) {
             logprintf(STDERR_FILENO,
                       "SWTPM_NVRAM_LinearFile_Mmap: Could not get block device "
-                      "size): %s\n",
+                      "size: %s\n",
                       strerror(errno));
             rc = TPM_FAIL;
             goto fail;
+        }
+
+        if (bd_size > UINT32_MAX) {
+            pagesize = get_pagesize();
+
+            if (!pagesize) {
+                rc = TPM_FAIL;
+                goto fail;
+            }
+            logprintf(STDERR_FILENO,
+                      "SWTPM_NVRAM_LinearFile_Mmap: Restricting usage of block device "
+                      "to 0x%x bytes out of possible 0x%" PRIxMAX "\n",
+                      UINT32_MAX & ~(pagesize - 1), (uintmax_t)bd_size);
+            bd_size = UINT32_MAX & ~(pagesize - 1);
         }
 
         mmap_state.size = bd_size;
@@ -222,7 +247,6 @@ SWTPM_NVRAM_LinearFile_Flush(const char* uri SWTPM_ATTR_UNUSED,
     uint8_t *msync_offset;
     uint32_t msync_count;
     uint32_t pagesize;
-    long n;
 
     if (!mmap_state.mapped) {
         logprintf(STDERR_FILENO, "%s: Nothing mapped\n", __func__);
@@ -230,17 +254,10 @@ SWTPM_NVRAM_LinearFile_Flush(const char* uri SWTPM_ATTR_UNUSED,
     }
 
     /* msync parameters must be page-aligned */
-    n = sysconf(_SC_PAGESIZE);
-    if (n < 0) {
-        logprintf(STDERR_FILENO, "%s: sysconf failed: %s\n",
-                  __func__, strerror(errno));
+    pagesize = get_pagesize();
+    if (!pagesize)
         return TPM_FAIL;
-    } else if (n == 0 || (unsigned long)n > UINT32_MAX) {
-        logprintf(STDERR_FILENO, "%s: sysconf returned bad value for _SC_PAGESIZE: %ld\n",
-                  __func__, n);
-        return TPM_FAIL;
-    }
-    pagesize = (uint32_t)n;
+
     msync_offset = mmap_state.ptr + (offset & ~(pagesize - 1));
 #if defined(__CYGWIN__)
     /* Cygwin uses Win API FlushViewOfFile, which we call with len = 0 */

--- a/src/swtpm/utils.c
+++ b/src/swtpm/utils.c
@@ -941,3 +941,19 @@ gchar **strv_extend(gchar **array, const gchar *const*append)
 
     return array;
 }
+
+uint32_t get_pagesize(void)
+{
+    long n = sysconf(_SC_PAGESIZE);
+
+    if (n < 0) {
+        logprintf(STDERR_FILENO, "%s: sysconf failed: %s\n",
+                  __func__, strerror(errno));
+        return 0;
+    } else if (n == 0 || (unsigned long)n > UINT32_MAX) {
+        logprintf(STDERR_FILENO, "%s: sysconf returned bad value for _SC_PAGESIZE: %ld\n",
+                  __func__, n);
+        return 0;
+    }
+    return (uint32_t)n;
+}

--- a/src/swtpm/utils.h
+++ b/src/swtpm/utils.h
@@ -102,4 +102,6 @@ size_t strv_dedup(gchar **array, gencmpstr_t strtrafo, gboolean freethem);
 
 gchar **strv_extend(gchar **array, const gchar *const*append);
 
+uint32_t get_pagesize(void);
+
 #endif /* _SWTPM_UTILS_H_ */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented oversized command and storage data lengths from causing integer overflows.
  - Added safeguards for regular files and block devices exceeding supported size limits.
  - Prevented unsupported file sizes from being mapped beyond the maximum supported limit.
  - Improved error reporting when block-device size detection fails.
  - Improved handling of zero-length unencrypted storage data without unnecessary memory allocation.
  - Improved page-size validation and handling during storage operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->